### PR TITLE
docs: Add project-specific CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,414 @@
+# AI Casino
+
+Multi-agent stock trading system using technical analysis, sentiment analysis, and news analysis to generate trading decisions. Built with LangGraph for agent orchestration and LiteLLM for flexible LLM provider switching.
+
+**Tech Stack:** Python 3.12, LangGraph, LiteLLM, pandas-ta, transformers (FinBERT), yfinance
+
+**Purpose:** Agentic AI system combining multiple analysis methods (technical indicators, sentiment, news) to make informed trading decisions (BUY/SELL/HOLD) with confidence scoring and risk assessment.
+
+**Status:** MVP complete (44% - 11/25 features), functional paper trading foundation pending
+
+---
+
+## Project Structure
+
+### Directory Layout
+
+```
+src/
+├── agents/          # Trading agents (specialized analysts + final trader)
+│   ├── technical.py   # Technical analysis (RSI/MACD via pandas-ta)
+│   ├── sentiment.py   # Sentiment analysis (FinBERT on news)
+│   ├── news.py        # News analysis (LLM-powered interpretation)
+│   └── trader.py      # Final decision maker (synthesizes all inputs)
+├── data/            # Data fetchers for market and news data
+│   ├── market.py      # Alpha Vantage + yfinance
+│   └── news.py        # Marketaux API
+├── models/          # ML models and LLM wrappers
+│   ├── llm.py         # LiteLLM client (Ollama/Claude/GPT abstraction)
+│   └── sentiment.py   # FinBERT wrapper for sentiment analysis
+├── strategies/      # Trading strategies
+│   └── momentum.py    # RSI + MACD momentum strategy
+├── workflows/       # Agent orchestration (LangGraph-style)
+│   └── trading.py     # Sequential workflow: data → analysis → decision
+└── main.py          # CLI entry point
+
+tests/               # Full mirror of src structure
+├── conftest.py      # Shared fixtures (sample_ohlcv_data, mock_llm_client)
+├── test_agents/     # Agent tests
+├── test_data/       # Data fetcher tests
+├── test_models/     # Model tests
+├── test_strategies/ # Strategy tests
+└── test_workflows/  # Workflow tests
+```
+
+### Key Modules
+
+- **agents/** - Specialized agents for analysis (TechnicalAnalyst, SentimentAnalyst, NewsAnalyst, TraderAgent)
+- **workflows/trading.py** - Sequential pipeline: fetch data → technical → sentiment → news → final decision
+- **models/llm.py** - LiteLLM abstraction for provider switching (Ollama dev → Claude/GPT prod)
+- **strategies/momentum.py** - RSI + MACD momentum strategy using pandas-ta
+
+---
+
+## Development Workflow
+
+### Before Coding
+
+1. ASK clarifying questions (95% confident)
+2. Research existing patterns (agents/, workflows/)
+3. Create plan, get approval
+4. Work incrementally
+
+### Pre-Commit (MANDATORY)
+
+```bash
+mise check  # Must pass: format, lint, test
+```
+
+Never skip/disable on failure - fix properly, re-run until clean.
+
+### Git
+
+**Commits:** Conventional format (feat:, fix:, chore:, docs:, test:, refactor:) with `-s -S` flags
+**Branches:** `feat/description`, `fix/description`, `chore/description`
+**Hooks:** Strict ruff - adjust to pass, never work around
+
+---
+
+## Python Conventions
+
+### Code Style
+
+**Formatter/Linter:** ruff (45+ rule categories)
+**Line length:** 110 | **Quotes:** Double | **Docstrings:** Google style | **Type hints:** Mandatory
+
+**Linter errors:** Fix properly (research if needed), NEVER skip/disable (`# noqa`, `# type: ignore`). If stuck after research, ASK.
+
+### Import Organization
+
+**Order:** stdlib → third-party (alphabetical) → local (relative)
+
+```python
+"""Module docstring - Google style."""
+
+# Standard library
+import os
+from datetime import datetime
+from enum import Enum
+
+# Third-party
+import pandas as pd
+from loguru import logger
+from pydantic import BaseModel
+
+# Local
+from src.models.llm import LLMClient
+from src.strategies.momentum import Signal
+```
+
+### Type Hints
+
+**Required on all functions:**
+
+```python
+def __init__(self, llm_client: LLMClient, strategy: MomentumStrategy) -> None:
+def fetch_daily(self, symbol: str, period_days: int = 90) -> MarketData:
+def analyze(self, symbol: str, articles: list[NewsArticle]) -> SentimentAnalysis:
+```
+
+**Use Python 3.10+ syntax:** `list[str]`, `dict[str, int]`, `int | None` (not `Optional[int]`)
+
+### Docstrings (Google Style)
+
+```python
+def analyze(self, symbol: str, market_data: pd.DataFrame) -> TechnicalAnalysis:
+    """Perform technical analysis on market data.
+
+    Args:
+        symbol: Stock ticker symbol
+        market_data: OHLCV dataframe with required columns
+
+    Returns:
+        TechnicalAnalysis with signal, indicators, and interpretation
+    """
+```
+
+Class docstrings: 1-line sufficient
+
+### Error Handling & Logging
+
+**Pattern:** Try-except with logger.error + re-raise (no bare excepts)
+
+```python
+try:
+    response = completion(model=self._model_id, messages=messages, temperature=temperature)
+    return response.choices[0].message.content
+except Exception as e:
+    logger.error(f"LLM completion failed: {e}")
+    raise
+```
+
+**Logging (loguru):** `logger.info/warning/error/debug()` - set level via `LOG_LEVEL` env var
+
+### Pydantic Models & Enums
+
+```python
+class TechnicalAnalysis(BaseModel):
+    """Technical analysis result."""
+    signal: Signal
+    rsi: float
+    macd_hist: float
+    interpretation: str
+    confidence: float
+
+    class Config:
+        arbitrary_types_allowed = True  # When using DataFrame, etc.
+
+class Signal(str, Enum):
+    """Trading signal - str enum for JSON serialization."""
+    BUY = "BUY"
+    SELL = "SELL"
+    HOLD = "HOLD"
+```
+
+**All classes implement `__repr__`:** `return f"TechnicalAnalyst(strategy={self.strategy})"`
+
+### Testing (pytest)
+
+**Fixtures:** `sample_ohlcv_data`, `sample_news_articles`, `mock_llm_client`, `mock_finbert`
+**Markers:** `@pytest.mark.unit`, `@pytest.mark.integration`, `@pytest.mark.slow`
+
+```python
+def test_technical_analyst_analyze(mock_llm_client, sample_ohlcv_data):
+    analyst = TechnicalAnalyst(mock_llm_client, MomentumStrategy())
+    result = analyst.analyze("AAPL", sample_ohlcv_data)
+
+    assert isinstance(result, TechnicalAnalysis)
+    assert 0.0 <= result.confidence <= 1.0
+    mock_llm_client.complete.assert_called_once()
+```
+
+**Rules:** Mock all external APIs, test ranges/types, no real API integration tests
+
+---
+
+## Simplicity Principles
+
+### Anti-Patterns
+
+❌ **NEVER:** TODOs, placeholders, incomplete error handling, obvious comments, over-engineering, premature abstractions, >100 line changes, print() (except main.py), bare excepts, commented code, backwards-compat hacks, provider-specific LLM (unless justified), globals, singletons
+
+✅ **ALWAYS:** Simplest solution, reuse existing patterns, minimal changes, complete implementations
+
+**Before implementing:** Can this be simpler? Abstractions needed NOW? Similar code exists? Minimal change?
+**If unsure:** ASK for approval.
+
+---
+
+## Architecture Patterns
+
+### Dependency Injection (MANDATORY)
+
+**All classes accept dependencies via `__init__` - no singletons, no globals:**
+
+```python
+class TechnicalAnalyst:
+    def __init__(self, llm_client: LLMClient, strategy: MomentumStrategy) -> None:
+        self.llm = llm_client
+        self.strategy = strategy
+        logger.info("Initialized TechnicalAnalyst")
+```
+
+### LLM Abstraction (LiteLLM)
+
+**Always use LiteLLM - case-by-case for provider-specific features:**
+
+```python
+class LLMClient:
+    def __init__(self, provider: str | None = None, model: str | None = None) -> None:
+        self.provider = provider or os.getenv("LLM_PROVIDER", "ollama")
+        self.model = model or os.getenv("LLM_MODEL", "qwen3:14b")
+        self._model_id = f"{self.provider}/{self.model}"  # ollama/qwen3:14b
+
+    def complete(self, prompt: str, system: str | None = None, temperature: float = 0.7) -> str:
+        messages = [{"role": "system", "content": system}] if system else []
+        messages.append({"role": "user", "content": prompt})
+        return completion(model=self._model_id, messages=messages, temperature=temperature).choices[0].message.content
+```
+
+**Providers:** Dev: Ollama qwen3:14b, Prod: Claude sonnet-4, Alt: OpenAI gpt-4o
+
+### Agent Pattern
+
+**All agents return Pydantic models with confidence scores:**
+
+```python
+def analyze(self, symbol: str, market_data: pd.DataFrame) -> TechnicalAnalysis:
+    logger.info(f"Analyzing {symbol} technicals")
+    signal, indicators = self.strategy.generate_signal(market_data)
+
+    prompt = f"Analyze indicators for {symbol}: RSI {indicators.rsi}, MACD {indicators.macd_hist}"
+    response = self.llm.complete(prompt, system="You are a technical analyst.", temperature=0.3)
+
+    return TechnicalAnalysis(
+        signal=signal, rsi=indicators.rsi, macd_hist=indicators.macd_hist,
+        interpretation=response, confidence=self._calculate_confidence(signal, indicators)
+    )
+```
+
+### Workflow Pattern (Sequential Pipeline)
+
+```python
+def analyze(self, symbol: str, period_days: int = 90) -> TradingWorkflowResult:
+    """Pipeline: fetch → technical → sentiment → news → decision"""
+    state = self._fetch_data(symbol, period_days)
+    state = self._run_technical_analysis(state)
+    state = self._run_sentiment_analysis(state)
+    state = self._run_news_analysis(state)
+    state = self._make_decision(state)
+    return TradingWorkflowResult(symbol=symbol, technical=state["technical_analysis"], ...)
+```
+
+---
+
+## Domain-Specific Rules
+
+### Trading Signals
+
+**Always use Signal enum - never strings:**
+
+```python
+class Signal(str, Enum):
+    BUY = "BUY"
+    SELL = "SELL"
+    HOLD = "HOLD"
+
+# Good
+signal = Signal.BUY
+
+# Bad
+signal = "BUY"
+```
+
+### Confidence and Risk
+
+**Confidence:** 0.0-1.0 float
+**Risk:** LOW (≥0.75), MEDIUM (0.5-0.75), HIGH (<0.5)
+
+```python
+def _calculate_risk_level(self, confidence: float) -> str:
+    return "LOW" if confidence >= 0.75 else "MEDIUM" if confidence >= 0.5 else "HIGH"
+```
+
+### LLM Temperature
+
+- Technical analysis: `0.3` (deterministic)
+- Trading decisions: `0.5` (balanced)
+- General: `0.7` (default)
+
+### Data Fetching
+
+Prefer Alpha Vantage, fallback to yfinance, raise on empty data:
+
+```python
+def fetch_daily(self, symbol: str, period_days: int = 90) -> MarketData:
+    try:
+        data = self._fetch_alpha_vantage(symbol, period_days)
+    except Exception as e:
+        logger.warning(f"Alpha Vantage failed: {e}, falling back to yfinance")
+        data = self._fetch_yfinance(symbol, period_days)
+    if data.empty:
+        raise ValueError(f"No market data available for {symbol}")
+    return MarketData(symbol=symbol, data=data, last_updated=datetime.now())
+```
+
+### Technical Indicators (pandas-ta)
+
+```python
+def calculate_indicators(self, df: pd.DataFrame) -> IndicatorData:
+    df.ta.rsi(length=14, append=True)  # RSI
+    df.ta.macd(fast=12, slow=26, signal=9, append=True)  # MACD
+    return IndicatorData(rsi=df["RSI_14"].iloc[-1], macd_hist=df["MACDh_12_26_9"].iloc[-1])
+```
+
+---
+
+## Common Commands
+
+### Development
+
+```bash
+# Install dependencies (using uv package manager)
+uv sync --frozen --all-extras
+
+# Run analysis (CLI entry point)
+python -m src.main AAPL
+python -m src.main TSLA --period 180
+
+# Quality checks (run before every commit)
+mise check              # All checks: format + lint + test
+
+# Individual checks
+mise format             # Format code with ruff
+mise format:check       # Check formatting (CI mode)
+mise lint               # Run ruff linter
+mise test               # Run pytest
+mise test:cov           # Run with coverage report
+
+# Ollama management (for local LLM dev)
+mise ollama:start       # Start Ollama server in background
+mise ollama:stop        # Stop Ollama server
+mise ollama:status      # Check if Ollama running
+
+# Activate virtual environment (if needed)
+source .venv/bin/activate
+```
+
+### Configuration (.env)
+
+Required: `ALPHA_VANTAGE_API_KEY`
+Optional: `MARKETAUX_API_KEY`, `ALPACA_API_KEY`, `ALPACA_SECRET_KEY`
+LLM: `LLM_PROVIDER` (ollama|anthropic|openai), `LLM_MODEL`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`
+Logging: `LOG_LEVEL` (DEBUG|INFO|WARNING|ERROR)
+
+---
+
+## Project-Specific Context
+
+### Domain Knowledge
+
+**Agents:** Technical (RSI/MACD), Sentiment (FinBERT), News (LLM), Trader (synthesizer)
+
+**Indicators:**
+- RSI: 0-100, oversold <30, overbought >70
+- MACD: Histogram >0 bullish, <0 bearish
+
+**Workflow:** fetch data → technical → sentiment → news → decision
+
+**State:** TypedDict with symbol, market_data, news_articles, *_analysis fields
+
+### Gotchas
+
+- Alpha Vantage: 5 req/min free tier (cache in data/cache/)
+- FinBERT: 440MB download first run
+- Ollama: Must run locally for dev (`mise ollama:start`)
+- Empty news: Handle with warning, not error
+- MACD: Needs ~35 data points minimum
+
+### Integration Points
+
+- **Alpha Vantage:** Market data (ALPHA_VANTAGE_API_KEY required, 5 req/min free)
+- **Marketaux:** News (MARKETAUX_API_KEY optional, 100 req/day)
+- **Ollama:** Local LLM (http://localhost:11434, qwen3:14b recommended, `mise ollama:start`)
+- **LiteLLM:** Unified API (Ollama/Anthropic/OpenAI via env vars)
+
+---
+
+## Additional Resources
+
+- **Implementation Plan:** ./implem-plan.md (25 features, MVP roadmap)
+- **Research:** ./agentic-stock-trading-system-research.md (architecture deep dive)
+- **Dependencies:** pyproject.toml (pinned versions via renovate)
+- **Linting Config:** ruff.toml (45+ rule categories, complexity limits)
+- **CI Workflows:** .github/workflows/ci.yml (lint, test, yamllint, actionlint)

--- a/CLAUDE.md.template
+++ b/CLAUDE.md.template
@@ -1,0 +1,435 @@
+# [Project Name]
+
+<!--
+CLAUDE.md Template
+This file is automatically read by Claude Code at the start of every conversation.
+Keep it under 500 lines for optimal performance.
+Version control this file and share with your team.
+-->
+
+## Overview
+
+<!-- Brief 2-3 sentence description of the project -->
+[Brief project description - what it does, who it's for]
+
+**Tech Stack:** [Primary language(s), frameworks, key technologies]
+
+**Purpose:** [Primary goal or problem this project solves]
+
+---
+
+## Project Structure
+
+<!-- Document directory layout and key modules -->
+
+### Directory Layout
+
+```
+/cmd/              # [If Go: Main applications, one per executable]
+/src/              # [Or equivalent source directory]
+/internal/         # [Private/internal packages]
+/pkg/              # [Public libraries]
+/api/              # [API definitions, specs]
+/scripts/          # [Build, deploy, utility scripts]
+/tests/            # [Test files]
+/docs/             # [Documentation]
+/[other dirs]      # [Project-specific directories]
+```
+
+### Key Modules
+
+- **[Module Name]** - [Brief description, location]
+- **[Module Name]** - [Brief description, location]
+- **[Module Name]** - [Brief description, location]
+
+<!-- For large codebases, reference subdirectory CLAUDE.md files -->
+<!-- See ./backend/CLAUDE.md for backend-specific patterns -->
+<!-- See ./infra/CLAUDE.md for infrastructure patterns -->
+
+---
+
+## Development Workflow
+
+### Before Coding
+
+<!-- Instructions to prevent Claude from jumping straight to code -->
+
+1. **ASK clarifying questions** until 95% confident about requirements
+2. **Research existing patterns** in codebase
+3. **Create plan** and get approval before implementing
+4. **Work incrementally** - one focused task at a time
+
+### Recommended Workflow
+
+**Explore → Plan → Code → Commit**
+
+- Use **Plan Mode** (Shift+Tab twice) for complex tasks
+- Search codebase for similar implementations before proposing new patterns
+- Propose plan with alternatives when multiple approaches exist
+- **Do NOT code until plan is confirmed**
+
+---
+
+## [Language] Conventions
+
+<!-- Replace [Language] with your primary language: Go, TypeScript, Python, etc. -->
+
+### Code Style
+
+- **Formatter:** [e.g., gofmt, prettier, black]
+- **Linter:** [e.g., golangci-lint, ESLint, pylint]
+- **Naming conventions:** [camelCase, snake_case, PascalCase]
+- **Indentation:** [spaces/tabs, size]
+- **Line length:** [max characters]
+
+### Linter Errors
+
+**ALWAYS:**
+- Attempt to fix linter errors properly
+- Research solutions online if unclear how to fix
+- Fix root cause, not symptoms
+
+**NEVER:**
+- Use skip/disable directives (e.g., `// eslint-disable`, `# noqa`, `//nolint`)
+- Ignore linter warnings
+- Work around linter errors
+
+**If stuck:**
+- Try fixing the error
+- Research online for proper solution
+- If still unclear after research, ASK what to do (don't skip/disable)
+
+### [Language-Specific Patterns]
+
+<!-- For Go -->
+<!--
+- Error handling: Return errors as last value
+- Check explicitly: `if err != nil`
+- Wrap with context: `fmt.Errorf("operation: %w", err)`
+- Use errors.Is/errors.As for inspection
+- Early returns for errors (happy path last)
+- NO panic except exceptional cases
+-->
+
+<!-- For TypeScript/JavaScript -->
+<!--
+- Prefer const over let, never var
+- Use async/await over .then()
+- Functional components over class components (React)
+- Type everything (TypeScript)
+- Avoid any type
+-->
+
+<!-- For Python -->
+<!--
+- Type hints required for functions
+- Use f-strings for formatting
+- Comprehensions over loops where readable
+- Context managers for resources
+- Specific exceptions, not bare except
+-->
+
+### Error Handling
+
+<!-- Document your error handling patterns -->
+
+[How to handle errors in this project - patterns, wrappers, logging]
+
+**Example:**
+```[language]
+[Code example of proper error handling in your project]
+```
+
+### Testing
+
+- **Framework:** [Jest, pytest, go test, etc.]
+- **Style:** [Unit, integration, e2e patterns]
+- **Coverage threshold:** [e.g., 80%]
+- **Approach:** [TDD, test after, etc.]
+
+**Test Pattern:**
+```[language]
+[Example test following your project's pattern]
+```
+
+---
+
+## Simplicity Principles
+
+<!-- CRITICAL: Document anti-patterns to prevent over-engineering -->
+
+### Anti-Patterns to AVOID
+
+<!-- Be specific about what NOT to do -->
+
+❌ **NEVER:**
+- Over-engineer simple features
+- Add unnecessary abstractions
+- Create helpers/utilities for one-time operations
+- Design for hypothetical future requirements
+- Build complex multi-layer architectures for simple tasks
+- Generate long code blocks or entire files at once
+- Use placeholder comments like `// ... rest of code ...`
+- [Add project-specific anti-patterns here]
+
+### Enforcement Rules
+
+✅ **ALWAYS:**
+- Choose the simplest practical solution
+- Three similar lines > premature abstraction
+- Only introduce complexity if clearly justified
+- Make minimal, surgical changes
+- Examine codebase for similar patterns FIRST
+- Fit seamlessly with established architecture
+- Reuse existing components/utilities/logic
+- Consistency > perfection
+
+### Complexity Check
+
+**Before implementing, ask:**
+1. Can this be simpler?
+2. Am I adding abstractions needed NOW (not future)?
+3. Does similar code exist I can reuse?
+4. Is this the minimal change to achieve the goal?
+
+**If unsure:** STOP and ask for approval before proceeding.
+
+### Pattern Drift Threats
+
+<!-- Document areas where Claude tends to over-complicate in YOUR codebase -->
+
+[Specific areas/patterns where over-engineering commonly occurs]
+
+**Example:**
+- API handlers: Claude tends to add middleware layers unnecessarily. Keep simple: validate → call service → return response.
+- [Add your specific patterns here]
+
+---
+
+## Code Generation Rules
+
+<!-- Prevent long, untested code blocks -->
+
+### ALWAYS
+
+- Show **complete code** (no placeholders)
+- **Incremental changes** - small focused steps (20-50 lines)
+- **Surgical, minimal** changes only
+- **Test-driven development** when appropriate
+- **Follow existing patterns** found in codebase
+- **Ask questions** before assuming requirements
+
+### NEVER
+
+- Generate entire long files at once
+- Generate >100 lines in single response
+- Make big changes in single step
+- Modify code unrelated to the task
+- Assume requirements without asking
+- Add features beyond what's requested
+- Use placeholders like `// ... rest of code ...`
+
+### Incremental Development Process
+
+**Break changes into steps:**
+1. Define interfaces/types
+2. Implement core logic (minimal)
+3. Add error handling
+4. Add tests
+5. Iterate
+
+**Each step:** Review, approve, then proceed to next.
+
+---
+
+## Common Commands
+
+<!-- Document frequently used commands - saves time and ensures consistency -->
+
+### Development
+
+```bash
+# Build
+[your build command]
+
+# Run locally
+[your run/start command]
+
+# Test
+[your test command]
+
+# Lint
+[your lint command]
+
+# Format
+[your format command]
+```
+
+### Git Conventions
+
+- **Branch naming:** [e.g., feat/description, fix/description]
+- **Commit message format:** [e.g., type: description, conventional commits]
+- **PR process:** [workflow, requirements]
+- **Commit signing:** [e.g., -s -S flags required]
+
+**Example commit:**
+```
+[type]: [summary in 50 chars or less]
+
+[Detailed description wrapped at 72 chars]
+
+[Reference to issue if applicable]
+```
+
+### [Domain-Specific Commands]
+
+<!-- For infrastructure projects -->
+<!--
+```bash
+# Kubernetes
+kubectl get pods -n [namespace]
+kubectl apply -f [manifest]
+
+# Terraform
+terraform plan
+terraform apply
+
+# Docker
+docker build -t [image:tag] .
+docker-compose up
+```
+-->
+
+---
+
+## [Domain-Specific Patterns]
+
+<!-- For Infrastructure/DevOps Projects -->
+<!--
+## Infrastructure Patterns
+
+### Kubernetes
+- Namespace conventions: [specify]
+- Deployment strategy: [blue-green/canary/rolling]
+- Always include: health checks, rollback mechanisms, monitoring
+- Resource limits: [specify defaults]
+- RBAC: least-privilege by default
+
+### Networking
+- [Security group/firewall conventions]
+- [Load balancer patterns]
+- [Network policy requirements]
+
+### Terraform/IaC
+- [Module organization]
+- Least-privilege by default
+- Document every permission with justification
+- [State management patterns]
+-->
+
+<!-- For Web Applications -->
+<!--
+## Application Patterns
+
+### API Design
+- [RESTful conventions, GraphQL patterns]
+- [Authentication/authorization approach]
+- [Rate limiting, caching strategies]
+
+### Data Management
+- [Database patterns, ORM usage]
+- [Migration strategy]
+- [Data validation approach]
+
+### Frontend
+- [Component structure]
+- [State management]
+- [Routing patterns]
+-->
+
+---
+
+## Project-Specific Context
+
+<!-- Domain knowledge Claude needs to generate appropriate code -->
+
+### Domain Knowledge
+
+[Key concepts, terminology, business logic specific to your domain]
+
+**Example:**
+- [Concept]: [Explanation]
+- [Pattern]: [How it's used in this project]
+
+### Known Issues & Gotchas
+
+<!-- Warn Claude about common pitfalls -->
+
+- [Issue description and how to handle]
+- [Gotcha and workaround]
+- [Complex area requiring extra care]
+
+### Integration Points
+
+<!-- External services, APIs, dependencies -->
+
+- **[Service Name]:** [Purpose, how it's used]
+- **[API Name]:** [Authentication, endpoints, patterns]
+- **[Dependency]:** [Why it's used, limitations]
+
+---
+
+## Additional Resources
+
+<!-- Links to key documentation -->
+
+- **Architecture docs:** [link or path]
+- **API specifications:** [link or path]
+- **Design docs:** [link or path]
+- **Runbooks:** [link or path]
+- **Team wiki:** [link]
+
+---
+
+## Notes for Maintaining This File
+
+<!-- Guidelines for keeping CLAUDE.md useful -->
+
+**Do:**
+- Update when architecture changes
+- Add patterns as they emerge
+- Keep under 500 lines
+- Review monthly with team
+- Update based on PR review feedback
+
+**Don't:**
+- Add generic programming advice
+- Include outdated patterns
+- Let it grow beyond 1000 lines
+- Forget to update when conventions change
+
+---
+
+<!--
+TEMPLATE USAGE NOTES:
+
+1. **Remove all HTML comments** (like this one) before using
+2. **Replace all [placeholders]** with your project specifics
+3. **Delete sections** that don't apply to your project
+4. **Add sections** for project-specific needs
+5. **Keep it under 500 lines** for best performance
+6. **Version control** and share with team
+
+For large codebases (300k+ LoC):
+- Create subdirectory CLAUDE.md files for major modules
+- Keep root CLAUDE.md high-level
+- Reference subdirectory files where appropriate
+
+To generate CLAUDE.md for your project:
+- New project: Use the "generate-claude-md-new.md" prompt
+- Existing project: Use the "generate-claude-md-existing.md" prompt
+
+For more information:
+- See findings/claude-md-best-practices.md for complete research
+- Run `/init` in Claude Code to auto-generate a baseline
+-->

--- a/claude-md-best-practices.md
+++ b/claude-md-best-practices.md
@@ -1,0 +1,562 @@
+# CLAUDE.md Best Practices - Research Findings
+
+**Date:** Nov 29, 2025 | **Scope:** Claude Code, Copilot, Cursor, Windsurf, Aider
+
+## TL;DR
+
+CLAUDE.md = persistent project context for Claude Code. Anthropic: **"single most impactful optimization"**
+
+**Core Principles:**
+
+1. Version control project CLAUDE.md (automatic team consistency)
+2. <500 lines (token efficiency)
+3. Hierarchical: Global → Project → Subdirectory
+4. Explicit anti-patterns (what NOT to do)
+5. Incremental development rules (prevent over-engineering)
+6. Data-driven loop: PR reviews → Update CLAUDE.md
+
+## 1. Fundamentals
+
+**Structure:**
+
+```text
+~/.claude/CLAUDE.md          # Global (personal)
+./CLAUDE.md                  # Project (VERSION CONTROLLED)
+./backend/CLAUDE.md          # Module-specific
+```
+
+**Resolution:** Home → Project → Subdirectory (most specific wins)
+
+**Size:** <500 lines optimal | 10k+ words degrades | Large codebases: split by module
+(47k → 9k words)
+
+---
+
+## 2. Content Structure
+
+**Template:**
+
+```markdown
+# Project Name
+
+## Overview
+- 2-3 sentence description, tech stack, purpose
+
+## Project Structure
+- Directory layout, key modules, important files
+
+## Development Workflow
+- Requirements gathering (Plan Mode), incremental dev, testing
+
+## [Language] Conventions
+- Code style, error handling, testing patterns
+
+## Simplicity Principles
+- Anti-patterns to AVOID, enforcement rules, pattern consistency
+
+## Code Generation Rules
+- ALWAYS: incremental, complete code
+- NEVER: long files, placeholders, over-engineering
+
+## Common Commands
+- Build, test, lint, git, deployment
+
+## Project-Specific Context
+- Domain knowledge, known issues, integration points
+```
+
+**DO Include:** Commands typed repeatedly | Architectural context (10+ min to explain) | Actual workflows |
+Specific anti-patterns | Pattern examples with file refs | Domain terminology
+
+**DON'T Include:** Generic advice | Obvious info | Outdated patterns | Sensitive data | Duplicated info |
+Theoretical practices not followed
+
+---
+
+## 3. Language-Specific Patterns
+
+### Go
+
+```markdown
+## Go Structure
+- `/cmd/` - Main apps (one per executable, small main.go)
+- `/internal/` - Private packages (90% of code, compiler enforced)
+- `/pkg/` - Public libs (only if truly public)
+- `/api/` - API definitions (OpenAPI, protobuf)
+
+## Go Conventions
+- Errors: return last value, check `if err != nil`, wrap with `fmt.Errorf("op: %w", err)`
+- Use errors.Is/errors.As, early returns, NO panic (except exceptional)
+- Table-driven tests preferred
+```
+
+**Other:** TypeScript/JS (structure, ESLint, testing) | Python (packages, type hints, pytest) | Rust (Cargo, errors, ownership)
+
+---
+
+## 4. Infrastructure & DevOps
+
+```markdown
+## Kubernetes
+- Namespace conventions, deployment strategy (blue-green/canary/rolling)
+- ALWAYS: health checks, rollback, monitoring
+- Resource limits, RBAC: least-privilege
+
+## Terraform/IaC
+- Module organization, least-privilege default
+- Document every permission with justification
+```
+
+**Impact:** Hours saved on IAM docs | Comprehensive infra generation | Consistent security | Faster onboarding
+
+---
+
+## 5. Large Codebase Strategies
+
+**Problem:** 300k+ LoC overwhelms single CLAUDE.md
+
+**Solutions:**
+
+1. **Hierarchical files** - Root: overview/principles | Modules: specific patterns | Features: context-specific
+2. **MCP semantic search** - claude-context server, vector DB, load only relevant code
+3. **Scoped sessions** - One goal per session, explicit naming, reset when goal changes
+
+**Session Management:**
+
+```markdown
+## Starting: State goal, set boundaries, explore, plan before code
+## During: Focus on goal, no scope creep, test frequently, commit incrementally
+## End: When goal achieved OR changes, clear context
+```
+
+---
+
+## 6. Preventing Over-Engineering
+
+**Simplicity Principles:**
+
+```markdown
+## Anti-Patterns AVOID
+- Over-engineering, unnecessary abstractions, one-time helpers
+- Hypothetical future design, multi-layer for simple tasks
+- Long code blocks, placeholders like `// ... rest ...`
+
+## Enforce
+- Simplest solution ALWAYS, 3 similar lines > premature abstraction
+- Minimal surgical changes, examine codebase FIRST
+- Reuse existing, consistency > perfection
+
+## Complexity Check
+1. Can this be simpler?
+2. Abstractions needed NOW (not future)?
+3. Similar code exists to reuse?
+4. Minimal change to achieve goal?
+
+If unsure: STOP, ask approval
+```
+
+**Pattern Drift Prevention:** Document "drift threat vectors" - areas Claude over-complicates in YOUR codebase
+
+```markdown
+## Pattern Drift Threats
+### API Handlers
+- Claude adds middleware unnecessarily
+- Keep simple: validate → service → response
+- No caching/retry unless explicitly needed
+```
+
+---
+
+## 7. Development Workflow
+
+### Problem
+
+Claude jumps to coding without: clarifying questions, understanding patterns, planning, approval
+
+### Solution: Plan Mode (Shift+Tab twice)
+
+**Workflow:** Explore → Plan → Approve → Code → Commit
+
+**CLAUDE.md Instructions:**
+
+```markdown
+## Before Coding
+1. ASK clarifying questions until 95% confident
+2. Research existing patterns
+3. Create plan, get approval
+4. Work incrementally
+
+## Plan Mode (Shift+Tab twice) for:
+- Architecture decisions, multi-file changes
+- New patterns/abstractions, security-critical code
+```
+
+**Breakthrough Prompt:** "Before [task], ask clarifying questions until 95% confident, then create plan and wait for approval"
+
+---
+
+## 8. Incremental Development
+
+**Problem:** Claude generates 100+ line files with placeholders, untested logic, mixed concerns
+
+**Solution:**
+
+```markdown
+## Code Generation Rules
+
+### NEVER
+- Generate entire long files, placeholders `// ... rest ...`
+- Big tasks in single step, >100 lines per response
+
+### ALWAYS
+- Incremental changes (20-50 lines), surgical minimal changes
+- Complete code (no placeholders), test after each step
+
+### Incremental Steps
+1. Define interfaces/types
+2. Implement core (minimal)
+3. Add error handling
+4. Add tests
+5. Iterate
+
+### TDD
+- Write tests FIRST (input/output pairs)
+- Run after each change, green before next step
+```
+
+**Session Hygiene:** Reset when goal changes | <500 lines CLAUDE.md | Subdirectory files for specific areas |
+One objective per session
+
+---
+
+## 9. PR Review Automation
+
+**Built-in:** `/security-review` (OWASP top 10, remediation suggestions)
+
+**GitHub Actions:**
+
+```yaml
+# .github/workflows/claude-security-review.yml
+name: Claude Security Review
+on: [pull_request]
+jobs:
+  security-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-security-review@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+**Custom Slash Command** (`.claude/commands/pr-review.md`):
+
+```markdown
+Review PR for: Code quality (conventions, error handling, no over-engineering) | Testing (exist, pass,
+coverage) | Security (validation, auth, no sensitive data) | Completeness (no placeholders)
+
+Commands: `gh pr view`, `git diff main...HEAD`
+
+Output: ✅ Good | ⚠️ Concerns | 🔧 Improvements
+```
+
+**Team Pattern:** Dev uses `/pr-review` → Addresses → Creates PR → GHA security review → Team review →
+Capture patterns in CLAUDE.md
+
+**Improvement Loop:** PR reviews → identify patterns → update CLAUDE.md → better code
+
+---
+
+## 10. Team Consistency
+
+**Version Control:**
+
+```markdown
+✅ Commit: ./CLAUDE.md, ./.claude/commands/*.md, ./.mcp.json
+❌ Ignore: ~/.claude/CLAUDE.md, .env, CLAUDE.local.md
+```
+
+**Onboarding Impact:**
+
+| Before | After |
+| ------ | ----- |
+| 2-4 weeks ramp-up | Immediate context on clone |
+| Repeated explanations | Consistent AI code |
+| Inconsistent AI style | Auto-enforced patterns |
+| Manual enforcement | Self-documenting |
+
+**Daily Workflow:** Start with goal → Claude reads CLAUDE.md → Plan Mode for complex → Questions before code →
+Review/approve → `/pr-review` → Reset when goal changes
+
+**Pattern Discovery:** Note manual additions → Monthly review → Create slash command if used 3+ times
+
+**Cross-Tool:** Maintain CLAUDE.md + AGENTS.md for compatibility (Cursor, Windsurf, etc.)
+
+---
+
+## 11. Advanced Features
+
+### Custom Slash Commands (`.claude/commands/`)
+
+**Example `/commit`:**
+
+```markdown
+1. Review: `git status`, `git diff`
+2. Check style: `git log -10 --oneline`
+3. Format: <type>: <summary> (50 chars) | Types: feat/fix/docs/refactor/test/chore
+4. Sign: `git commit -s -S -m "message"`
+```
+
+### MCP Integration (`.mcp.json`)
+
+```json
+{
+  "mcpServers": {
+    "kubernetes": {"command": "mcp-server-kubernetes", "args": ["--context", "prod"]},
+    "terraform": {"command": "mcp-server-terraform", "args": ["--workspace", "prod"]},
+    "brave-search": {"command": "mcp-server-brave-search", "env": {"BRAVE_API_KEY": "${BRAVE_API_KEY}"}}
+  }
+}
+```
+
+**Scopes:** Local (personal) | Project (`.mcp.json` committed) | User (`~/.config/claude/mcp.json`)
+**Debug:** `claude-code --mcp-debug`
+
+### Hooks
+
+```bash
+# Post-edit hook: auto-format
+gofmt -w $FILE              # Go
+prettier --write $FILE      # JS/TS
+black $FILE                 # Python
+```
+
+### Ultrathink Mode
+
+**What:** Max thinking budget (31,999 tokens)
+**How:** Add "ultrathink" keyword to prompt
+**When:** Complex architecture, multi-service, security-critical, performance optimization, large refactoring
+**Best:** Opus + ultrathink + Plan Mode
+
+---
+
+## 12. Other AI Tools Comparison
+
+| Tool | Config | Key Features |
+| ------ | -------- | ------------ |
+| **GitHub Copilot** | `.github/copilot-instructions.md` | Short statements, one per line, markdown links, enable via setting |
+| **Cursor** | `.cursor/*.mdc` (new), `.cursorrules` (legacy) | <500 lines, composable rules, cursor.directory/awesome-cursorrules |
+| **Windsurf** | `global_rules.md`, workspace rules | "Constitutional framework", activation modes, rulebook slash commands |
+| **Aider** | `.env`, YAML | Env vars for keys, git-centric, `/add`+`/drop` commands |
+
+**Patterns from Cursor (100+ top rules):** Functional/declarative | Early returns | Modular/reusable | No placeholders
+
+**Windsurf Principles:** Simplicity First (SF) | Readability Priority (RP) | Dependency Minimalism (DM)
+
+**Convergence:** All tools agree: <500 lines | Version control | Explicit anti-patterns | Incremental dev |
+Project-specific context | Simplicity > complexity
+
+---
+
+## 13. Real-World Examples
+
+### Java/Gradle (IntelliJ Plugin)
+
+```markdown
+# AI IntelliJ Plugin
+Tech: Java 17, Gradle, IntelliJ Platform SDK
+
+## Structure
+- `/src/main/java` - Implementation | `/src/main/resources` - UI/i18n | `/src/test/java` - Tests
+
+## Commands
+./gradlew runIde/test/buildPlugin/publishPlugin
+
+## Patterns
+- UI: Swing thread | Actions: extend AnAction | Services: @Service | Extensions: plugin.xml
+- i18n: `AIBundle.message("key")`, no hardcoded English
+```
+
+### Python/DevOps (AWS MCP)
+
+```markdown
+# AWS MCP Server
+Tech: Python 3.10+, boto3, AWS SDK
+
+## Style
+Type hints required | Async/await for AWS | Specific exceptions (not bare except) | Google docstrings
+
+## Security
+Least-privilege IAM | Never hardcode credentials | Env vars/instance profiles | Log all API calls
+
+## Error Handling
+try: await ec2.describe_instances()
+except ClientError as e:
+    if e.response['Error']['Code'] == 'UnauthorizedOperation':
+        logger.error(f"Insufficient perms: {e}")
+        raise PermissionError("Need ec2:DescribeInstances")
+    raise
+```
+
+### TypeScript/Next.js
+
+```markdown
+Tech: Next.js 14, TypeScript, Tailwind, shadcn/ui, TanStack Query
+
+## Structure
+/app (pages/layouts) | /components | /lib | /hooks | /types
+
+## Commands
+npm run dev/build/lint/test
+
+## Conventions
+Server Components default | 'use client' only when needed | TypeScript strict | Prettier
+
+## Patterns
+export function Component({ prop }: Props) { return <div>{prop}</div> }
+import { Button } from "@/components/ui/button"
+const { data } = useQuery({ queryKey: ['key'], queryFn: fetchData })
+```
+
+**Community Resources:** [claude-md-examples](https://github.com/ArthurClune/claude-md-examples) |
+[awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code) |
+[awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) |
+[ai-prompts](https://github.com/instructa/ai-prompts)
+
+---
+
+## 14. Metrics & Impact
+
+**Token Efficiency:** Loaded once vs. repeated | Hierarchical: only relevant context | <500 lines optimal
+
+**Team Impact:**
+
+| Metric | Improvement |
+| ------ | ----------- |
+| Onboarding | Weeks → Days |
+| Code consistency | Manual → Automatic |
+| PR review cycles | -30-50% |
+| Context re-explanation | -70% |
+| PR review speed | +40% |
+| Code style alignment | 60% → 85% |
+| Time saved | 3-5 hrs/week per engineer |
+
+---
+
+## 15. Getting Started (30 Min)
+
+1. **`/init`** - Auto-generates baseline, analyzes codebase
+2. **Refine** - Remove generic, add project-specific, document top 10 commands
+3. **Anti-patterns** - What Claude did wrong, patterns to follow, what to avoid
+4. **Commit** - `git add CLAUDE.md && git commit -m "Add CLAUDE.md" && git push`
+5. **Test** - New session, verify references CLAUDE.md, ask to summarize structure
+
+**Incremental:** Week 1: structure+commands | Week 2: anti-patterns+simplicity | Week 3: 2-3 slash commands |
+Week 4: MCP+refine | Ongoing: update from PR reviews
+
+---
+
+## 16. Common Pitfalls
+
+| Pitfall | Problem | Solution |
+| ------- | ------- | -------- |
+| **Too Generic** | Copy-paste generic advice | Only project-specific patterns |
+| **Too Verbose** | 5000-line CLAUDE.md | <500 lines, split by module |
+| **Outdated** | Doesn't match current arch | Update during PRs, monthly audits |
+| **No Anti-Patterns** | Only what TO do | Explicitly document what NOT to do |
+| **Not Version Controlled** | Each engineer different context | Commit project CLAUDE.md |
+| **Ignoring Feedback** | Never improves | Data-driven loop from PRs |
+
+---
+
+## 17. Future Directions
+
+**Emerging:** Skills integration (reusable agents) | MCP ecosystem growth | Multi-agent orchestration | Context engineering
+
+**Research Gaps:** Optimal size by codebase | Quantitative productivity metrics | Multi-repo best practices |
+Cross-tool standardization
+
+---
+
+## Complete Source List
+
+### Official
+
+- [Claude Code Best Practices](https://www.anthropic.com/engineering/claude-code-best-practices) |
+  [Using CLAUDE.MD](https://www.claude.com/blog/using-claude-md-files) |
+  [Slash Commands](https://docs.claude.com/en/docs/claude-code/slash-commands) |
+  [MCP](https://docs.claude.com/en/docs/claude-code/mcp)
+
+### Best Practices
+
+- [Arize Best Practices](https://arize.com/blog/claude-md-best-practices-learned-from-optimizing-claude-code-with-prompt-learning/)
+- [What is CLAUDE.md](https://claudelog.com/faqs/what-is-claude-md/)
+- [Plan Mode](https://claudelog.com/mechanics/plan-mode/)
+- [Teaching Consistency](https://www.brandoncasci.com/2025/07/30/from-chaos-to-control-teaching-claude-code-consistency.html)
+- [Stop Overengineering](https://www.nathanonn.com/how-to-stop-claude-code-from-overengineering-everything/)
+- [Context Engineering](https://alabeduarte.com/context-engineering-with-claude-code-my-evolving-workflow/)
+
+### Language-Specific
+
+- [Go Development](https://dshills.medium.com/effective-go-development-with-claude-best-practices-for-ai-pair-programming-83fba0247a4f)
+- [golang-standards/project-layout](https://github.com/golang-standards/project-layout)
+- [Go Structure Guidelines](https://dev.to/jinxankit/go-project-structure-and-guidelines-4ccm)
+
+### Infrastructure
+
+- [DevOps](https://github.com/ruvnet/claude-flow/wiki/CLAUDE-MD-DevOps)
+- [Claude for DevOps](https://www.cloudnativedeepdive.com/using-claude-and-llms-as-your-devops-platform-engineering-assistant/)
+- [Terraform Workflow](https://medium.com/@balwant.matharu/how-claude-code-supercharged-my-terraform-workflow-0e0a53349251)
+
+### Large Codebases
+
+- [Monorepo Organization](https://dev.to/anvodev/how-i-organized-my-claudemd-in-a-monorepo-with-too-many-contexts-37k7)
+- [Claude Context MCP](https://github.com/zilliztech/claude-context)
+- [Large Codebase Practices](https://skywork.ai/blog/claude-code-plugin-best-practices-large-codebases-2025/)
+- [Working with Large Codebases](https://medium.com/@tl_99311/claude-codes-memory-working-with-ai-in-large-codebases-a948f66c2d7e)
+
+### Plan Mode
+
+- [Mastering Plan Mode](https://agiinprogress.substack.com/p/mastering-claude-code-plan-mode-the)
+- [Plan Mode Workflow](https://stevekinney.com/courses/ai-development/claude-code-plan-mode)
+- [Incremental Development](https://www.vibesparking.com/en/blog/ai/claude-code/2025-08-14-claude-code-save-money-right-model-lean-context-permissions/)
+
+### PR Review
+
+- [PR Review Slash Command](https://nakamasato.medium.com/resolve-github-pr-reviews-consistently-and-rapidly-with-custom-claude-code-slash-command-3cdb25e1c2cf)
+- [Automate Reviews](https://alirezarezvani.medium.com/5-tipps-to-automate-your-code-reviews-with-claude-code-5becd60bce5c)
+- [Security Review Action](https://github.com/anthropics/claude-code-security-review)
+- [Automate Security](https://www.claude.com/blog/automate-security-reviews-with-claude-code)
+
+### Team
+
+- [How Anthropic Teams Use Claude Code](https://www.anthropic.com/news/how-anthropic-teams-use-claude-code)
+
+### Advanced
+
+- [Configuring MCP](https://scottspence.com/posts/configuring-mcp-tools-in-claude-code)
+- [Best MCP Servers](https://mcpcat.io/guides/best-mcp-servers-for-claude-code/)
+- [Hooks Guide](https://liquidmetal.ai/casesAndBlogs/claude-code-hooks-guide/)
+- [Ultrathink](https://www.claudecode101.com/en/tutorial/optimization/ultrathink-mode)
+
+### Other Tools
+
+- [Cursor Rules](https://www.prompthub.us/blog/top-cursor-rules-for-coding-agents)
+- [awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules)
+- [Cursor Best Practices](https://kirill-markin.com/articles/cursor-ide-rules-for-ai/)
+- [Windsurf Cascade](https://docs.windsurf.com/windsurf/cascade/cascade)
+- [Windsurf Rules](https://medium.com/@wahengchang2024/mastering-windsurf-restricting-ai-output-with-windsurf-rules-d7e429654db2)
+- [Copilot Instructions](https://docs.github.com/en/copilot/how-tos/custom-instructions/adding-repository-custom-instructions-for-github-copilot)
+- [Tool Comparison](https://www.toolbit.ai/blog/best-ai-coding-tools-copilot-cursor-claude-comparison)
+- [Aider](https://aider.chat/)
+
+### Examples
+
+- [claude-md-examples](https://github.com/ArthurClune/claude-md-examples)
+- [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code)
+- [Claude Command Suite](https://github.com/qdhenry/Claude-Command-Suite)
+- [Subagents](https://github.com/VoltAgent/awesome-claude-code-subagents)
+- [Gist Examples](https://gist.github.com/cbh123/75dcd353b354b1eb3398c6d2781a502f)
+
+---
+
+**End of Research** | *Nov 29, 2025 - Verify against current docs as tools evolve rapidly*

--- a/src/agents/technical.py
+++ b/src/agents/technical.py
@@ -104,9 +104,16 @@ Rate your confidence (0.0-1.0) based on indicator alignment.
         """
         confidence = 0.5
 
-        if (indicators.rsi_oversold and indicators.macd_bullish) or (indicators.rsi_overbought and indicators.macd_bearish):
+        if (indicators.rsi_oversold and indicators.macd_bullish) or (
+            indicators.rsi_overbought and indicators.macd_bearish
+        ):
             confidence = 0.8
-        elif indicators.rsi_oversold or indicators.macd_bullish or indicators.rsi_overbought or indicators.macd_bearish:
+        elif (
+            indicators.rsi_oversold
+            or indicators.macd_bullish
+            or indicators.rsi_overbought
+            or indicators.macd_bearish
+        ):
             confidence = 0.6
 
         if "high confidence" in response.lower() or "strong signal" in response.lower():

--- a/src/main.py
+++ b/src/main.py
@@ -138,9 +138,7 @@ def main() -> None:
             period_idx = sys.argv.index("--period")
             period_days = int(sys.argv[period_idx + 1])
         except (IndexError, ValueError):
-            console.print(
-                "[bold yellow]Warning:[/bold yellow] Invalid period, using default 90 days"
-            )
+            console.print("[bold yellow]Warning:[/bold yellow] Invalid period, using default 90 days")
 
     setup_logging()
 

--- a/src/models/sentiment.py
+++ b/src/models/sentiment.py
@@ -112,8 +112,7 @@ class FinBERTSentiment:
 
         labels = ["positive", "negative", "neutral"]
         results = [
-            SentimentScore(**{labels[i]: float(probs[j][i]) for i in range(3)})
-            for j in range(len(texts))
+            SentimentScore(**{labels[i]: float(probs[j][i]) for i in range(3)}) for j in range(len(texts))
         ]
 
         logger.debug(f"Analyzed {len(results)} texts")

--- a/src/strategies/momentum.py
+++ b/src/strategies/momentum.py
@@ -58,8 +58,7 @@ class MomentumStrategy:
         self.macd_signal = macd_signal
 
         logger.info(
-            f"Initialized MomentumStrategy: RSI={rsi_period}, "
-            f"MACD=({macd_fast},{macd_slow},{macd_signal})"
+            f"Initialized MomentumStrategy: RSI={rsi_period}, MACD=({macd_fast},{macd_slow},{macd_signal})"
         )
 
     def calculate_indicators(self, data: pd.DataFrame) -> pd.DataFrame:

--- a/tests/test_models/test_sentiment.py
+++ b/tests/test_models/test_sentiment.py
@@ -31,9 +31,7 @@ def test_sentiment_score_score():
 def mock_finbert():
     with (
         patch("src.models.sentiment.AutoTokenizer.from_pretrained") as mock_tokenizer,
-        patch(
-            "src.models.sentiment.AutoModelForSequenceClassification.from_pretrained"
-        ) as mock_model,
+        patch("src.models.sentiment.AutoModelForSequenceClassification.from_pretrained") as mock_model,
     ):
         tokenizer = MagicMock()
         model = MagicMock()

--- a/tests/test_workflows/test_trading.py
+++ b/tests/test_workflows/test_trading.py
@@ -14,9 +14,7 @@ from src.workflows.trading import TradingWorkflow, TradingWorkflowResult
 
 
 @pytest.fixture
-def mock_workflow_dependencies(
-    mock_llm_client, mock_finbert, sample_ohlcv_data, sample_news_articles
-):
+def mock_workflow_dependencies(mock_llm_client, mock_finbert, sample_ohlcv_data, sample_news_articles):
     market_fetcher = MagicMock()
     market_data = MarketData(
         symbol="AAPL",


### PR DESCRIPTION
## Motivation

Claude Code reads CLAUDE.md at conversation start to understand project patterns, conventions, and domain context. This enables more accurate, project-specific code generation and reduces need for repetitive instructions.

## Implementation information

Generated via systematic codebase analysis:
1. Explored project structure, tech stack, code patterns
2. Analyzed actual code in src/agents, src/workflows, src/models
3. Extracted conventions from ruff.toml, pyproject.toml, .mise.toml
4. Identified domain-specific patterns (trading signals, confidence scoring, agent DI)
5. Tested all documented commands
6. Condensed to 414 lines (under 500-line performance target)

**Contents:**
- Development workflow (pre-commit checks, git conventions)
- Python conventions (ruff, type hints, docstrings, error handling)
- Architecture patterns (mandatory DI, LLM abstraction, agent pattern)
- Domain rules (Signal enum, risk levels, LLM temperatures)
- 15+ real code examples from codebase
- Common commands (mise tasks, CLI usage)
- Integration points (Alpha Vantage, Marketaux, Ollama)

**Alternatives considered:**
- Generic template: Rejected - needs project specifics
- Longer detailed version: Rejected - optimized for performance (<500 lines)

## Supporting documentation

- CLAUDE.md.template: Base template structure
- claude-md-best-practices.md: Research and best practices
- Both included for future maintenance