### PR TITLE
feat(llm): add custom API base support for OpenAI provider

### DIFF
--- a/src/models/llm.py
+++ b/src/models/llm.py
@@ -29,6 +29,8 @@ class LLMClient:
         self.model = model or os.getenv("LLM_MODEL", "qwen3:14b")
         self.base_url = base_url or os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
 
+        self._api_base: str | None = None
+
         if self.provider == "ollama":
             os.environ["OLLAMA_API_BASE"] = self.base_url
             self._model_id = f"ollama/{self.model}"
@@ -36,6 +38,7 @@ class LLMClient:
             self._model_id = f"anthropic/{self.model}"
         elif self.provider == "openai":
             self._model_id = f"openai/{self.model}"
+            self._api_base = os.getenv("OPENAI_API_BASE")
         else:
             msg = f"Unsupported provider: {self.provider}"
             raise ValueError(msg)
@@ -61,11 +64,14 @@ class LLMClient:
         messages.append({"role": "user", "content": prompt})
 
         try:
-            response = completion(
-                model=self._model_id,
-                messages=messages,
-                temperature=temperature,
-            )
+            kwargs: dict = {
+                "model": self._model_id,
+                "messages": messages,
+                "temperature": temperature,
+            }
+            if self._api_base:
+                kwargs["api_base"] = self._api_base
+            response = completion(**kwargs)
             content = response.choices[0].message.content
             logger.debug(f"LLM response length: {len(content)} chars")
             return content
@@ -84,11 +90,14 @@ class LLMClient:
             Generated text response
         """
         try:
-            response = completion(
-                model=self._model_id,
-                messages=messages,
-                temperature=temperature,
-            )
+            kwargs: dict = {
+                "model": self._model_id,
+                "messages": messages,
+                "temperature": temperature,
+            }
+            if self._api_base:
+                kwargs["api_base"] = self._api_base
+            response = completion(**kwargs)
             content = response.choices[0].message.content
             logger.debug(f"LLM chat response length: {len(content)} chars")
             return content

--- a/tests/test_models/test_llm.py
+++ b/tests/test_models/test_llm.py
@@ -44,12 +44,28 @@ def test_llm_client_init_openai(monkeypatch):
     monkeypatch.setenv("LLM_PROVIDER", "openai")
     monkeypatch.setenv("LLM_MODEL", "gpt-4o")
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
 
     client = LLMClient()
 
     assert client.provider == "openai"
     assert client.model == "gpt-4o"
     assert client._model_id == "openai/gpt-4o"
+    assert client._api_base is None
+
+
+def test_llm_client_init_openai_custom_api_base(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "hf:moonshotai/Kimi-K2.5")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("OPENAI_API_BASE", "https://api.synthetic.new/openai/v1")
+
+    client = LLMClient()
+
+    assert client.provider == "openai"
+    assert client.model == "hf:moonshotai/Kimi-K2.5"
+    assert client._model_id == "openai/hf:moonshotai/Kimi-K2.5"
+    assert client._api_base == "https://api.synthetic.new/openai/v1"
 
 
 def test_llm_client_unsupported_provider(monkeypatch):
@@ -73,6 +89,20 @@ def test_complete_with_system_prompt(mock_completion, monkeypatch):
         {"role": "user", "content": "Test prompt"},
     ]
     assert call_args.kwargs["temperature"] == 0.5
+
+
+def test_complete_with_api_base(mock_completion, monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "hf:moonshotai/Kimi-K2.5")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("OPENAI_API_BASE", "https://api.synthetic.new/openai/v1")
+
+    client = LLMClient()
+    result = client.complete("Test prompt")
+
+    assert result == "Mocked response"
+    call_args = mock_completion.call_args
+    assert call_args.kwargs["api_base"] == "https://api.synthetic.new/openai/v1"
 
 
 def test_complete_without_system_prompt(mock_completion, monkeypatch):


### PR DESCRIPTION
## Motivation

Support OpenAI-compatible endpoints like synthetic.new for Kimi K2.5 model via `OPENAI_API_BASE` env var.

## Implementation information

- Read `OPENAI_API_BASE` env var when provider is openai
- Pass `api_base` kwarg to LiteLLM `completion()` calls when set
- No changes needed for existing OpenAI/Anthropic/Ollama usage

## Usage

```bash
export LLM_PROVIDER=openai
export LLM_MODEL=hf:moonshotai/Kimi-K2.5
export OPENAI_API_KEY=<synthetic-api-key>
export OPENAI_API_BASE=https://api.synthetic.new/openai/v1

python -m src.main AAPL
```