### PR TITLE
feat(workflow): parallelize trading agents with asyncio

### DIFF
--- a/src/agents/bearish_researcher.py
+++ b/src/agents/bearish_researcher.py
@@ -42,7 +42,7 @@ class BearishResearcher:
         self.llm = llm_client
         logger.info("Initialized BearishResearcher")
 
-    def analyze(
+    async def analyze(
         self,
         symbol: str,
         technical: TechnicalAnalysis,
@@ -71,7 +71,7 @@ class BearishResearcher:
             "and downside scenarios. Focus on vulnerabilities, threats, and negative catalysts."
         )
 
-        response = self.llm.complete(prompt, system=system_prompt, temperature=0.5)
+        response = await self.llm.acomplete(prompt, system=system_prompt, temperature=0.5)
 
         thesis = self._extract_thesis(response)
         key_weaknesses = self._extract_key_weaknesses(response)

--- a/src/agents/bullish_researcher.py
+++ b/src/agents/bullish_researcher.py
@@ -42,7 +42,7 @@ class BullishResearcher:
         self.llm = llm_client
         logger.info("Initialized BullishResearcher")
 
-    def analyze(
+    async def analyze(
         self,
         symbol: str,
         technical: TechnicalAnalysis,
@@ -71,7 +71,7 @@ class BullishResearcher:
             "and constructs bull theses. Focus on strengths, catalysts, and positive scenarios."
         )
 
-        response = self.llm.complete(prompt, system=system_prompt, temperature=0.5)
+        response = await self.llm.acomplete(prompt, system=system_prompt, temperature=0.5)
 
         thesis = self._extract_thesis(response)
         key_strengths = self._extract_key_strengths(response)

--- a/src/agents/fundamental.py
+++ b/src/agents/fundamental.py
@@ -37,7 +37,7 @@ class FundamentalAnalyst:
         self.fetcher = fetcher
         logger.info("Initialized FundamentalAnalyst")
 
-    def analyze(self, symbol: str, current_price: float | None = None) -> FundamentalAnalysis:
+    async def analyze(self, symbol: str, current_price: float | None = None) -> FundamentalAnalysis:
         """Perform fundamental analysis on a company.
 
         Args:
@@ -61,7 +61,7 @@ class FundamentalAnalyst:
                 "of the company's financial health and valuation in 2-3 sentences."
             )
 
-            interpretation = self.llm.complete(prompt, system=system, temperature=0.5)
+            interpretation = await self.llm.acomplete(prompt, system=system, temperature=0.5)
             confidence = self._calculate_confidence(metrics, interpretation)
 
             return FundamentalAnalysis(

--- a/src/agents/news.py
+++ b/src/agents/news.py
@@ -27,7 +27,7 @@ class NewsAnalyst:
         self.llm = llm_client
         logger.info("Initialized NewsAnalyst")
 
-    def analyze(self, symbol: str, articles: list[NewsArticle]) -> NewsAnalysis:
+    async def analyze(self, symbol: str, articles: list[NewsArticle]) -> NewsAnalysis:
         """Analyze news articles for trading implications.
 
         Args:
@@ -66,7 +66,7 @@ Be concise and focus on actionable insights.
             "their potential impact on stock price and trading decisions."
         )
 
-        response = self.llm.complete(prompt, system=system_prompt, temperature=0.4)
+        response = await self.llm.acomplete(prompt, system=system_prompt, temperature=0.4)
 
         key_themes = self._extract_themes(response)
         impact = self._extract_section(response, "impact")

--- a/src/agents/sentiment.py
+++ b/src/agents/sentiment.py
@@ -1,5 +1,7 @@
 """Sentiment Analysis Agent."""
 
+import asyncio
+
 from loguru import logger
 from pydantic import BaseModel
 
@@ -34,7 +36,7 @@ class SentimentAnalyst:
         self.finbert = finbert
         logger.info("Initialized SentimentAnalyst")
 
-    def analyze(self, symbol: str, articles: list[NewsArticle]) -> SentimentAnalysis:
+    async def analyze(self, symbol: str, articles: list[NewsArticle]) -> SentimentAnalysis:
         """Analyze sentiment from news articles.
 
         Args:
@@ -59,7 +61,9 @@ class SentimentAnalyst:
             )
 
         texts = [f"{article.title}. {article.description}" for article in articles]
-        scores = self.finbert.analyze_batch(texts)
+
+        loop = asyncio.get_running_loop()
+        scores = await loop.run_in_executor(None, self.finbert.analyze_batch, texts)
 
         overall_score = self._aggregate_sentiment(scores)
         sentiment_label = self._get_sentiment_label(overall_score)

--- a/src/agents/technical.py
+++ b/src/agents/technical.py
@@ -32,7 +32,7 @@ class TechnicalAnalyst:
         self.strategy = strategy
         logger.info("Initialized TechnicalAnalyst")
 
-    def analyze(self, symbol: str, market_data: pd.DataFrame) -> TechnicalAnalysis:
+    async def analyze(self, symbol: str, market_data: pd.DataFrame) -> TechnicalAnalysis:
         """Perform technical analysis on market data.
 
         Args:
@@ -74,7 +74,7 @@ Rate your confidence (0.0-1.0) based on indicator alignment.
             "Provide clear, actionable interpretations."
         )
 
-        response = self.llm.complete(prompt, system=system_prompt, temperature=0.3)
+        response = await self.llm.acomplete(prompt, system=system_prompt, temperature=0.3)
 
         confidence = self._extract_confidence(response, indicators)
 

--- a/src/agents/trader.py
+++ b/src/agents/trader.py
@@ -43,7 +43,7 @@ class TraderAgent:
         self.llm = llm_client
         logger.info("Initialized TraderAgent")
 
-    def decide(
+    async def decide(
         self,
         symbol: str,
         technical: TechnicalAnalysis,
@@ -153,7 +153,7 @@ Consider agreement/disagreement between signals. Higher agreement = higher confi
             "Be decisive but cautious."
         )
 
-        response = self.llm.complete(prompt, system=system_prompt, temperature=0.5)
+        response = await self.llm.acomplete(prompt, system=system_prompt, temperature=0.5)
 
         action = self._extract_action(response, technical.signal)
         confidence = self._extract_confidence(response, technical, sentiment, bullish, bearish, action)

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 """CLI for agentic trading system."""
 
+import asyncio
 import os
 import sys
 
@@ -200,7 +201,7 @@ def print_metrics_summary(tracker: MetricsTracker) -> None:
     console.print("[dim]Metrics saved to: logs/metrics_summary.json[/dim]\n")
 
 
-def analyze_stock(
+async def analyze_stock(
     symbol: str, period_days: int = 90, enable_trading: bool = False, show_metrics: bool = False
 ) -> None:
     """Analyze a stock and print results.
@@ -238,7 +239,7 @@ def analyze_stock(
 
         console.print(f"\n[bold]Analyzing {symbol}...[/bold]\n")
 
-        result = workflow.analyze(symbol, period_days)
+        result = await workflow.analyze(symbol, period_days)
 
         print_result(result)
 
@@ -274,7 +275,7 @@ def main() -> None:
 
     setup_logging()
 
-    analyze_stock(symbol, period_days, enable_trading, show_metrics)
+    asyncio.run(analyze_stock(symbol, period_days, enable_trading, show_metrics))
 
 
 if __name__ == "__main__":

--- a/src/models/llm.py
+++ b/src/models/llm.py
@@ -3,7 +3,7 @@
 import os
 
 from dotenv import load_dotenv
-from litellm import completion
+from litellm import acompletion, completion
 from loguru import logger
 
 load_dotenv()
@@ -77,6 +77,40 @@ class LLMClient:
             return content
         except Exception as e:
             logger.error(f"LLM completion failed: {e}")
+            raise
+
+    async def acomplete(self, prompt: str, system: str | None = None, temperature: float = 0.7) -> str:
+        """Generate completion from prompt asynchronously.
+
+        Args:
+            prompt: User prompt
+            system: System prompt (optional)
+            temperature: Sampling temperature (0.0-1.0)
+
+        Returns:
+            Generated text response
+        """
+        messages: list[dict[str, str]] = []
+
+        if system:
+            messages.append({"role": "system", "content": system})
+
+        messages.append({"role": "user", "content": prompt})
+
+        try:
+            kwargs: dict = {
+                "model": self._model_id,
+                "messages": messages,
+                "temperature": temperature,
+            }
+            if self._api_base:
+                kwargs["api_base"] = self._api_base
+            response = await acompletion(**kwargs)
+            content = response.choices[0].message.content
+            logger.debug(f"LLM async response length: {len(content)} chars")
+            return content
+        except Exception as e:
+            logger.error(f"LLM async completion failed: {e}")
             raise
 
     def chat(self, messages: list[dict[str, str]], temperature: float = 0.7) -> str:

--- a/src/models/sentiment.py
+++ b/src/models/sentiment.py
@@ -1,5 +1,7 @@
 """FinBERT sentiment analysis model wrapper."""
 
+import threading
+
 import torch
 from loguru import logger
 from pydantic import BaseModel
@@ -46,6 +48,7 @@ class FinBERTSentiment:
         self.model = AutoModelForSequenceClassification.from_pretrained(self.MODEL_NAME)
         self.model.to(self.device)
         self.model.eval()
+        self._lock = threading.Lock()
 
         logger.info("FinBERT model loaded successfully")
 
@@ -62,18 +65,19 @@ class FinBERTSentiment:
             logger.warning("Empty text provided for sentiment analysis")
             return SentimentScore(positive=0.0, negative=0.0, neutral=1.0)
 
-        inputs = self.tokenizer(
-            text,
-            return_tensors="pt",
-            truncation=True,
-            max_length=512,
-            padding=True,
-        )
-        inputs = {k: v.to(self.device) for k, v in inputs.items()}
+        with self._lock:
+            inputs = self.tokenizer(
+                text,
+                return_tensors="pt",
+                truncation=True,
+                max_length=512,
+                padding=True,
+            )
+            inputs = {k: v.to(self.device) for k, v in inputs.items()}
 
-        with torch.no_grad():
-            outputs = self.model(**inputs)
-            probs = torch.nn.functional.softmax(outputs.logits, dim=-1)[0]
+            with torch.no_grad():
+                outputs = self.model(**inputs)
+                probs = torch.nn.functional.softmax(outputs.logits, dim=-1)[0]
 
         labels = ["positive", "negative", "neutral"]
         result = SentimentScore(**{labels[i]: float(probs[i]) for i in range(3)})

--- a/src/workflows/trading.py
+++ b/src/workflows/trading.py
@@ -1,5 +1,7 @@
 """Trading workflow orchestrating all agents."""
 
+import asyncio
+
 import pandas as pd
 from loguru import logger
 from pydantic import BaseModel
@@ -103,7 +105,7 @@ class TradingWorkflow:
 
         logger.info("Initialized TradingWorkflow with all agents")
 
-    def analyze(self, symbol: str, period_days: int = 90) -> TradingWorkflowResult:
+    async def analyze(self, symbol: str, period_days: int = 90) -> TradingWorkflowResult:
         """Run complete trading analysis.
 
         Args:
@@ -116,23 +118,46 @@ class TradingWorkflow:
         logger.info(f"Starting trading workflow for {symbol}")
 
         state = self._fetch_data(symbol, period_days)
-
         state = self._fetch_account_info(state)
 
-        state = self._run_technical_analysis(state)
+        # Parallel Group 1: independent analyses
+        current_price = float(state["market_data"]["Close"].iloc[-1])
+        technical_task = self.technical_analyst.analyze(state["symbol"], state["market_data"])
+        sentiment_task = self.sentiment_analyst.analyze(state["symbol"], state["news_articles"])
+        news_task = self.news_analyst.analyze(state["symbol"], state["news_articles"])
+        fundamental_task = self.fundamental_analyst.analyze(state["symbol"], current_price)
 
-        state = self._run_sentiment_analysis(state)
+        technical, sentiment, news, fundamental = await asyncio.gather(
+            technical_task, sentiment_task, news_task, fundamental_task
+        )
 
-        state = self._run_news_analysis(state)
+        state["technical_analysis"] = technical
+        state["sentiment_analysis"] = sentiment
+        state["news_analysis"] = news
+        state["fundamental_analysis"] = fundamental
 
-        state = self._run_fundamental_analysis(state)
+        # Parallel Group 2: research (depends on Group 1)
+        bullish_task = self.bullish_researcher.analyze(
+            state["symbol"],
+            state["technical_analysis"],
+            state["sentiment_analysis"],
+            state["news_analysis"],
+            state["fundamental_analysis"],
+        )
+        bearish_task = self.bearish_researcher.analyze(
+            state["symbol"],
+            state["technical_analysis"],
+            state["sentiment_analysis"],
+            state["news_analysis"],
+            state["fundamental_analysis"],
+        )
 
-        state = self._run_bullish_research(state)
+        bullish, bearish = await asyncio.gather(bullish_task, bearish_task)
 
-        state = self._run_bearish_research(state)
+        state["bullish_research"] = bullish
+        state["bearish_research"] = bearish
 
-        state = self._make_decision(state)
-
+        state = await self._make_decision(state)
         state = self._assess_risk(state)
 
         if (
@@ -214,116 +239,7 @@ class TradingWorkflow:
         state["account_info"] = self._get_account_info()
         return state
 
-    def _run_technical_analysis(self, state: TradingState) -> TradingState:
-        """Run technical analysis.
-
-        Args:
-            state: Current workflow state
-
-        Returns:
-            Updated state with technical analysis
-        """
-        logger.info("Running technical analysis")
-
-        technical = self.technical_analyst.analyze(state["symbol"], state["market_data"])
-
-        state["technical_analysis"] = technical
-        return state
-
-    def _run_sentiment_analysis(self, state: TradingState) -> TradingState:
-        """Run sentiment analysis.
-
-        Args:
-            state: Current workflow state
-
-        Returns:
-            Updated state with sentiment analysis
-        """
-        logger.info("Running sentiment analysis")
-
-        sentiment = self.sentiment_analyst.analyze(state["symbol"], state["news_articles"])
-
-        state["sentiment_analysis"] = sentiment
-        return state
-
-    def _run_news_analysis(self, state: TradingState) -> TradingState:
-        """Run news analysis.
-
-        Args:
-            state: Current workflow state
-
-        Returns:
-            Updated state with news analysis
-        """
-        logger.info("Running news analysis")
-
-        news = self.news_analyst.analyze(state["symbol"], state["news_articles"])
-
-        state["news_analysis"] = news
-        return state
-
-    def _run_fundamental_analysis(self, state: TradingState) -> TradingState:
-        """Run fundamental analysis.
-
-        Args:
-            state: Current workflow state
-
-        Returns:
-            Updated state with fundamental analysis
-        """
-        logger.info("Running fundamental analysis")
-
-        current_price = float(state["market_data"]["Close"].iloc[-1])
-        fundamental = self.fundamental_analyst.analyze(state["symbol"], current_price)
-
-        state["fundamental_analysis"] = fundamental
-        return state
-
-    def _run_bullish_research(self, state: TradingState) -> TradingState:
-        """Run bullish research analysis.
-
-        Args:
-            state: Current workflow state
-
-        Returns:
-            Updated state with bullish research
-        """
-        logger.info("Running bullish research")
-
-        bullish = self.bullish_researcher.analyze(
-            state["symbol"],
-            state["technical_analysis"],
-            state["sentiment_analysis"],
-            state["news_analysis"],
-            state["fundamental_analysis"],
-        )
-
-        state["bullish_research"] = bullish
-        return state
-
-    def _run_bearish_research(self, state: TradingState) -> TradingState:
-        """Run bearish research analysis.
-
-        Args:
-            state: Current workflow state
-
-        Returns:
-            Updated state with bearish research
-        """
-        logger.info("Running bearish research")
-
-        bearish = self.bearish_researcher.analyze(
-            state["symbol"],
-            state["technical_analysis"],
-            state["sentiment_analysis"],
-            state["news_analysis"],
-            state["fundamental_analysis"],
-        )
-
-        state["bearish_research"] = bearish
-        return state
-
-    def _make_decision(self, state: TradingState) -> TradingState:
+    async def _make_decision(self, state: TradingState) -> TradingState:
         """Make final trading decision.
 
         Args:
@@ -339,7 +255,7 @@ class TradingWorkflow:
         owns_position = symbol in positions
         position_qty = positions.get(symbol)
 
-        decision = self.trader.decide(
+        decision = await self.trader.decide(
             symbol,
             state["technical_analysis"],
             state["sentiment_analysis"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """Shared pytest fixtures."""
 
 from datetime import UTC, datetime
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pandas as pd
 import pytest
@@ -63,6 +63,7 @@ def mock_llm_client():
     mock.provider = "ollama"
     mock.model = "qwen3:14b"
     mock.complete.return_value = "Mock LLM response with analysis and high confidence."
+    mock.acomplete = AsyncMock(return_value="Mock LLM response with analysis and high confidence.")
     return mock
 
 

--- a/tests/test_agents/test_bearish_researcher.py
+++ b/tests/test_agents/test_bearish_researcher.py
@@ -1,6 +1,6 @@
 """Tests for bearish researcher agent."""
 
-from unittest.mock import Mock
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -98,7 +98,8 @@ class TestBearishResearcher:
         assert researcher.llm == mock_llm_client
         assert repr(researcher) == "BearishResearcher(llm=ollama/qwen3:14b)"
 
-    def test_analyze_returns_bearish_research_analysis(
+    @pytest.mark.asyncio
+    async def test_analyze_returns_bearish_research_analysis(
         self,
         bearish_researcher,
         sample_technical_analysis,
@@ -108,9 +109,9 @@ class TestBearishResearcher:
         sample_llm_response,
     ):
         """Test analyze returns BearishResearchAnalysis."""
-        bearish_researcher.llm.complete = Mock(return_value=sample_llm_response)
+        bearish_researcher.llm.acomplete = AsyncMock(return_value=sample_llm_response)
 
-        result = bearish_researcher.analyze(
+        result = await bearish_researcher.analyze(
             "AAPL",
             sample_technical_analysis,
             sample_sentiment_analysis,
@@ -124,7 +125,8 @@ class TestBearishResearcher:
         assert result.target_downside == 25.0
         assert 0.0 <= result.confidence <= 1.0
 
-    def test_analyze_calls_llm(
+    @pytest.mark.asyncio
+    async def test_analyze_calls_llm(
         self,
         bearish_researcher,
         sample_technical_analysis,
@@ -134,9 +136,9 @@ class TestBearishResearcher:
         sample_llm_response,
     ):
         """Test analyze calls LLM with correct parameters."""
-        bearish_researcher.llm.complete = Mock(return_value=sample_llm_response)
+        bearish_researcher.llm.acomplete = AsyncMock(return_value=sample_llm_response)
 
-        bearish_researcher.analyze(
+        await bearish_researcher.analyze(
             "TSLA",
             sample_technical_analysis,
             sample_sentiment_analysis,
@@ -144,8 +146,8 @@ class TestBearishResearcher:
             sample_fundamental_analysis,
         )
 
-        bearish_researcher.llm.complete.assert_called_once()
-        call_args = bearish_researcher.llm.complete.call_args
+        bearish_researcher.llm.acomplete.assert_called_once()
+        call_args = bearish_researcher.llm.acomplete.call_args
         assert "TSLA" in call_args[0][0]
         assert "skeptical investment researcher" in call_args[1]["system"]
         assert call_args[1]["temperature"] == 0.5
@@ -426,7 +428,8 @@ class TestBearishResearcher:
 
         assert downside is None
 
-    def test_analyze_with_missing_fundamental_data(
+    @pytest.mark.asyncio
+    async def test_analyze_with_missing_fundamental_data(
         self,
         bearish_researcher,
         sample_technical_analysis,
@@ -447,9 +450,9 @@ class TestBearishResearcher:
             confidence=0.3,
         )
 
-        bearish_researcher.llm.complete = Mock(return_value=sample_llm_response)
+        bearish_researcher.llm.acomplete = AsyncMock(return_value=sample_llm_response)
 
-        result = bearish_researcher.analyze(
+        result = await bearish_researcher.analyze(
             "AAPL",
             sample_technical_analysis,
             sample_sentiment_analysis,

--- a/tests/test_agents/test_bullish_researcher.py
+++ b/tests/test_agents/test_bullish_researcher.py
@@ -1,6 +1,6 @@
 """Tests for bullish researcher agent."""
 
-from unittest.mock import Mock
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -98,7 +98,8 @@ class TestBullishResearcher:
         assert researcher.llm == mock_llm_client
         assert repr(researcher) == "BullishResearcher(llm=ollama/qwen3:14b)"
 
-    def test_analyze_returns_bullish_research_analysis(
+    @pytest.mark.asyncio
+    async def test_analyze_returns_bullish_research_analysis(
         self,
         bullish_researcher,
         sample_technical_analysis,
@@ -108,9 +109,9 @@ class TestBullishResearcher:
         sample_llm_response,
     ):
         """Test analyze returns BullishResearchAnalysis."""
-        bullish_researcher.llm.complete = Mock(return_value=sample_llm_response)
+        bullish_researcher.llm.acomplete = AsyncMock(return_value=sample_llm_response)
 
-        result = bullish_researcher.analyze(
+        result = await bullish_researcher.analyze(
             "AAPL",
             sample_technical_analysis,
             sample_sentiment_analysis,
@@ -124,7 +125,8 @@ class TestBullishResearcher:
         assert result.target_upside == 25.0
         assert 0.0 <= result.confidence <= 1.0
 
-    def test_analyze_calls_llm(
+    @pytest.mark.asyncio
+    async def test_analyze_calls_llm(
         self,
         bullish_researcher,
         sample_technical_analysis,
@@ -134,9 +136,9 @@ class TestBullishResearcher:
         sample_llm_response,
     ):
         """Test analyze calls LLM with correct parameters."""
-        bullish_researcher.llm.complete = Mock(return_value=sample_llm_response)
+        bullish_researcher.llm.acomplete = AsyncMock(return_value=sample_llm_response)
 
-        bullish_researcher.analyze(
+        await bullish_researcher.analyze(
             "TSLA",
             sample_technical_analysis,
             sample_sentiment_analysis,
@@ -144,8 +146,8 @@ class TestBullishResearcher:
             sample_fundamental_analysis,
         )
 
-        bullish_researcher.llm.complete.assert_called_once()
-        call_args = bullish_researcher.llm.complete.call_args
+        bullish_researcher.llm.acomplete.assert_called_once()
+        call_args = bullish_researcher.llm.acomplete.call_args
         assert "TSLA" in call_args[0][0]
         assert "optimistic investment researcher" in call_args[1]["system"]
         assert call_args[1]["temperature"] == 0.5
@@ -425,7 +427,8 @@ class TestBullishResearcher:
 
         assert upside is None
 
-    def test_analyze_with_missing_fundamental_data(
+    @pytest.mark.asyncio
+    async def test_analyze_with_missing_fundamental_data(
         self,
         bullish_researcher,
         sample_technical_analysis,
@@ -446,9 +449,9 @@ class TestBullishResearcher:
             confidence=0.3,
         )
 
-        bullish_researcher.llm.complete = Mock(return_value=sample_llm_response)
+        bullish_researcher.llm.acomplete = AsyncMock(return_value=sample_llm_response)
 
-        result = bullish_researcher.analyze(
+        result = await bullish_researcher.analyze(
             "AAPL",
             sample_technical_analysis,
             sample_sentiment_analysis,

--- a/tests/test_agents/test_fundamental.py
+++ b/tests/test_agents/test_fundamental.py
@@ -15,11 +15,12 @@ class TestFundamentalAnalyst:
         assert analyst.llm == mock_llm_client
         assert analyst.fetcher == mock_fundamental_fetcher
 
-    def test_analyze_returns_fundamental_analysis(self, mock_llm_client, mock_fundamental_fetcher):
+    @pytest.mark.asyncio
+    async def test_analyze_returns_fundamental_analysis(self, mock_llm_client, mock_fundamental_fetcher):
         """Test analyze returns FundamentalAnalysis with correct types."""
         analyst = FundamentalAnalyst(mock_llm_client, mock_fundamental_fetcher)
 
-        result = analyst.analyze("AAPL", current_price=150.0)
+        result = await analyst.analyze("AAPL", current_price=150.0)
 
         assert isinstance(result, FundamentalAnalysis)
         assert result.valuation in ["UNDERVALUED", "FAIRLY_VALUED", "OVERVALUED"]
@@ -32,14 +33,15 @@ class TestFundamentalAnalyst:
         assert isinstance(result.interpretation, str)
         assert 0.0 <= result.confidence <= 1.0
 
-    def test_analyze_calls_fetcher_and_llm(self, mock_llm_client, mock_fundamental_fetcher):
+    @pytest.mark.asyncio
+    async def test_analyze_calls_fetcher_and_llm(self, mock_llm_client, mock_fundamental_fetcher):
         """Test analyze calls fetcher and LLM."""
         analyst = FundamentalAnalyst(mock_llm_client, mock_fundamental_fetcher)
 
-        analyst.analyze("AAPL")
+        await analyst.analyze("AAPL")
 
         mock_fundamental_fetcher.fetch_overview.assert_called_once_with("AAPL")
-        mock_llm_client.complete.assert_called_once()
+        mock_llm_client.acomplete.assert_called_once()
 
     def test_extract_metrics_complete_data(self, mock_fundamental_fetcher, sample_fundamental_overview):
         """Test metrics extraction with complete data."""
@@ -256,16 +258,18 @@ class TestFundamentalAnalyst:
         assert "28.5" in prompt
         assert "$" not in prompt  # No price
 
-    def test_analyze_without_current_price(self, mock_llm_client, mock_fundamental_fetcher):
+    @pytest.mark.asyncio
+    async def test_analyze_without_current_price(self, mock_llm_client, mock_fundamental_fetcher):
         """Test analyze without providing current price."""
         analyst = FundamentalAnalyst(mock_llm_client, mock_fundamental_fetcher)
 
-        result = analyst.analyze("AAPL")
+        result = await analyst.analyze("AAPL")
 
         assert isinstance(result, FundamentalAnalysis)
         assert result.confidence > 0.0
 
-    def test_analyze_edge_case_negative_earnings(self, mock_llm_client, mock_fundamental_fetcher):
+    @pytest.mark.asyncio
+    async def test_analyze_edge_case_negative_earnings(self, mock_llm_client, mock_fundamental_fetcher):
         """Test analyze with negative earnings."""
         mock_fundamental_fetcher.fetch_overview.return_value = {
             "Symbol": "TEST",
@@ -275,19 +279,20 @@ class TestFundamentalAnalyst:
         }
         analyst = FundamentalAnalyst(mock_llm_client, mock_fundamental_fetcher)
 
-        result = analyst.analyze("TEST")
+        result = await analyst.analyze("TEST")
 
         assert isinstance(result, FundamentalAnalysis)
         assert result.eps is not None
         assert result.eps < 0
 
-    def test_analyze_raises_on_fetcher_error(self, mock_llm_client, mock_fundamental_fetcher):
+    @pytest.mark.asyncio
+    async def test_analyze_raises_on_fetcher_error(self, mock_llm_client, mock_fundamental_fetcher):
         """Test analyze raises exception when fetcher fails."""
         mock_fundamental_fetcher.fetch_overview.side_effect = ValueError("API error")
         analyst = FundamentalAnalyst(mock_llm_client, mock_fundamental_fetcher)
 
         with pytest.raises(ValueError, match="API error"):
-            analyst.analyze("INVALID")
+            await analyst.analyze("INVALID")
 
     def test_repr(self, mock_llm_client, mock_fundamental_fetcher):
         """Test string representation."""

--- a/tests/test_agents/test_news.py
+++ b/tests/test_agents/test_news.py
@@ -1,5 +1,7 @@
 """Tests for news analyst agent."""
 
+import pytest
+
 from src.agents.news import NewsAnalysis, NewsAnalyst
 
 
@@ -9,26 +11,28 @@ def test_news_analyst_init(mock_llm_client):
     assert analyst.llm == mock_llm_client
 
 
-def test_news_analyst_analyze(mock_llm_client, sample_news_articles):
+@pytest.mark.asyncio
+async def test_news_analyst_analyze(mock_llm_client, sample_news_articles):
     analyst = NewsAnalyst(mock_llm_client)
 
-    result = analyst.analyze("AAPL", sample_news_articles)
+    result = await analyst.analyze("AAPL", sample_news_articles)
 
     assert isinstance(result, NewsAnalysis)
     assert len(result.key_themes) > 0
     assert result.impact_assessment
     assert result.recommendation
-    mock_llm_client.complete.assert_called_once()
+    mock_llm_client.acomplete.assert_called_once()
 
 
-def test_news_analyst_analyze_empty(mock_llm_client):
+@pytest.mark.asyncio
+async def test_news_analyst_analyze_empty(mock_llm_client):
     analyst = NewsAnalyst(mock_llm_client)
 
-    result = analyst.analyze("AAPL", [])
+    result = await analyst.analyze("AAPL", [])
 
     assert result.key_themes == ["No recent news"]
     assert "Insufficient" in result.impact_assessment
-    mock_llm_client.complete.assert_not_called()
+    mock_llm_client.acomplete.assert_not_called()
 
 
 def test_format_articles(mock_llm_client, sample_news_articles):

--- a/tests/test_agents/test_sentiment.py
+++ b/tests/test_agents/test_sentiment.py
@@ -1,5 +1,7 @@
 """Tests for sentiment analyst agent."""
 
+import pytest
+
 from src.agents.sentiment import SentimentAnalysis, SentimentAnalyst
 
 
@@ -9,10 +11,11 @@ def test_sentiment_analyst_init(mock_finbert):
     assert analyst.finbert == mock_finbert
 
 
-def test_sentiment_analyst_analyze(mock_finbert, sample_news_articles):
+@pytest.mark.asyncio
+async def test_sentiment_analyst_analyze(mock_finbert, sample_news_articles):
     analyst = SentimentAnalyst(mock_finbert)
 
-    result = analyst.analyze("AAPL", sample_news_articles)
+    result = await analyst.analyze("AAPL", sample_news_articles)
 
     assert isinstance(result, SentimentAnalysis)
     assert result.overall_sentiment in ["positive", "negative", "neutral"]
@@ -22,10 +25,11 @@ def test_sentiment_analyst_analyze(mock_finbert, sample_news_articles):
     mock_finbert.analyze_batch.assert_called_once()
 
 
-def test_sentiment_analyst_analyze_empty_articles(mock_finbert):
+@pytest.mark.asyncio
+async def test_sentiment_analyst_analyze_empty_articles(mock_finbert):
     analyst = SentimentAnalyst(mock_finbert)
 
-    result = analyst.analyze("AAPL", [])
+    result = await analyst.analyze("AAPL", [])
 
     assert result.overall_sentiment == "neutral"
     assert result.sentiment_score == 0.0

--- a/tests/test_agents/test_technical.py
+++ b/tests/test_agents/test_technical.py
@@ -1,5 +1,7 @@
 """Tests for technical analyst agent."""
 
+import pytest
+
 from src.agents.technical import TechnicalAnalysis, TechnicalAnalyst
 from src.strategies.momentum import MomentumStrategy, Signal
 
@@ -12,26 +14,28 @@ def test_technical_analyst_init(mock_llm_client):
     assert analyst.strategy == strategy
 
 
-def test_technical_analyst_analyze(mock_llm_client, sample_ohlcv_data):
+@pytest.mark.asyncio
+async def test_technical_analyst_analyze(mock_llm_client, sample_ohlcv_data):
     strategy = MomentumStrategy()
     analyst = TechnicalAnalyst(mock_llm_client, strategy)
 
-    result = analyst.analyze("AAPL", sample_ohlcv_data)
+    result = await analyst.analyze("AAPL", sample_ohlcv_data)
 
     assert isinstance(result, TechnicalAnalysis)
     assert isinstance(result.signal, Signal)
     assert 0.0 <= result.confidence <= 1.0
     assert result.interpretation
-    mock_llm_client.complete.assert_called_once()
+    mock_llm_client.acomplete.assert_called_once()
 
 
-def test_technical_analyst_analyze_calls_strategy(mock_llm_client, sample_ohlcv_data):
+@pytest.mark.asyncio
+async def test_technical_analyst_analyze_calls_strategy(mock_llm_client, sample_ohlcv_data):
     strategy = MomentumStrategy()
     analyst = TechnicalAnalyst(mock_llm_client, strategy)
 
-    analyst.analyze("AAPL", sample_ohlcv_data)
+    await analyst.analyze("AAPL", sample_ohlcv_data)
 
-    call_args = mock_llm_client.complete.call_args
+    call_args = mock_llm_client.acomplete.call_args
     assert "AAPL" in call_args.args[0]
     assert "RSI" in call_args.args[0]
     assert "MACD" in call_args.args[0]

--- a/tests/test_agents/test_trader.py
+++ b/tests/test_agents/test_trader.py
@@ -1,5 +1,7 @@
 """Tests for trader agent."""
 
+import pytest
+
 from src.agents.fundamental import FundamentalAnalysis
 from src.agents.news import NewsAnalysis
 from src.agents.sentiment import SentimentAnalysis
@@ -14,7 +16,8 @@ def test_trader_agent_init(mock_llm_client):
     assert agent.llm == mock_llm_client
 
 
-def test_trader_agent_decide(mock_llm_client, sample_bullish_research, sample_bearish_research):
+@pytest.mark.asyncio
+async def test_trader_agent_decide(mock_llm_client, sample_bullish_research, sample_bearish_research):
     agent = TraderAgent(mock_llm_client)
 
     technical = TechnicalAnalysis(
@@ -53,7 +56,7 @@ def test_trader_agent_decide(mock_llm_client, sample_bullish_research, sample_be
         confidence=0.75,
     )
 
-    result = agent.decide(
+    result = await agent.decide(
         "AAPL", technical, sentiment, news, fundamental, sample_bullish_research, sample_bearish_research
     )
 
@@ -62,7 +65,7 @@ def test_trader_agent_decide(mock_llm_client, sample_bullish_research, sample_be
     assert 0.0 <= result.confidence <= 1.0
     assert result.risk_level in ["LOW", "MEDIUM", "HIGH"]
     assert result.reasoning
-    mock_llm_client.complete.assert_called_once()
+    mock_llm_client.acomplete.assert_called_once()
 
 
 def test_extract_action_from_response(mock_llm_client):
@@ -163,7 +166,8 @@ def test_repr(mock_llm_client):
     assert "ollama" in repr_str
 
 
-def test_decide_owns_position_true(mock_llm_client, sample_bullish_research, sample_bearish_research):
+@pytest.mark.asyncio
+async def test_decide_owns_position_true(mock_llm_client, sample_bullish_research, sample_bearish_research):
     agent = TraderAgent(mock_llm_client)
 
     technical = TechnicalAnalysis(
@@ -202,7 +206,7 @@ def test_decide_owns_position_true(mock_llm_client, sample_bullish_research, sam
         confidence=0.7,
     )
 
-    result = agent.decide(
+    result = await agent.decide(
         "AAPL",
         technical,
         sentiment,
@@ -218,7 +222,8 @@ def test_decide_owns_position_true(mock_llm_client, sample_bullish_research, sam
     assert result.position_qty == 100.0
 
 
-def test_decide_owns_position_false(mock_llm_client, sample_bullish_research, sample_bearish_research):
+@pytest.mark.asyncio
+async def test_decide_owns_position_false(mock_llm_client, sample_bullish_research, sample_bearish_research):
     agent = TraderAgent(mock_llm_client)
 
     technical = TechnicalAnalysis(
@@ -257,7 +262,7 @@ def test_decide_owns_position_false(mock_llm_client, sample_bullish_research, sa
         confidence=0.7,
     )
 
-    result = agent.decide(
+    result = await agent.decide(
         "TSLA",
         technical,
         sentiment,
@@ -273,7 +278,10 @@ def test_decide_owns_position_false(mock_llm_client, sample_bullish_research, sa
     assert result.position_qty is None
 
 
-def test_prompt_includes_portfolio_context(mock_llm_client, sample_bullish_research, sample_bearish_research):
+@pytest.mark.asyncio
+async def test_prompt_includes_portfolio_context(
+    mock_llm_client, sample_bullish_research, sample_bearish_research
+):
     agent = TraderAgent(mock_llm_client)
 
     technical = TechnicalAnalysis(
@@ -312,7 +320,7 @@ def test_prompt_includes_portfolio_context(mock_llm_client, sample_bullish_resea
         confidence=0.8,
     )
 
-    agent.decide(
+    await agent.decide(
         "AAPL",
         technical,
         sentiment,
@@ -324,7 +332,7 @@ def test_prompt_includes_portfolio_context(mock_llm_client, sample_bullish_resea
         position_qty=50.0,
     )
 
-    call_args = mock_llm_client.complete.call_args
+    call_args = mock_llm_client.acomplete.call_args
     prompt = call_args[0][0]
     assert "PORTFOLIO STATUS:" in prompt
     assert "currently own 50.0 shares" in prompt

--- a/tests/test_data/test_news.py
+++ b/tests/test_data/test_news.py
@@ -102,7 +102,9 @@ def test_fetch_market_news(sample_news_response):
         assert "symbols" not in call_args.kwargs["params"]
 
 
-def test_fetch_company_news_no_api_key():
+def test_fetch_company_news_no_api_key(monkeypatch):
+    monkeypatch.delenv("MARKETAUX_API_KEY", raising=False)
+
     with patch("src.data.news.requests.get") as mock_get:
         mock_response = Mock()
         mock_response.json.return_value = {"data": []}
@@ -136,7 +138,9 @@ def test_fetch_market_news_http_error():
             fetcher.fetch_market_news()
 
 
-def test_repr():
+def test_repr(monkeypatch):
+    monkeypatch.delenv("MARKETAUX_API_KEY", raising=False)
+
     fetcher = NewsFetcher(api_key="test-key")
     assert repr(fetcher) == "NewsFetcher(authenticated=True)"
 

--- a/tests/test_workflows/test_trading.py
+++ b/tests/test_workflows/test_trading.py
@@ -52,12 +52,13 @@ def test_trading_workflow_init(mock_workflow_dependencies):
     assert workflow.risk_manager is not None
 
 
-def test_trading_workflow_analyze(mock_workflow_dependencies):
+@pytest.mark.asyncio
+async def test_trading_workflow_analyze(mock_workflow_dependencies):
     market_fetcher, news_fetcher, llm_client, finbert, fundamental_fetcher = mock_workflow_dependencies
 
     workflow = TradingWorkflow(llm_client, market_fetcher, news_fetcher, finbert, fundamental_fetcher)
 
-    result = workflow.analyze("AAPL", period_days=90)
+    result = await workflow.analyze("AAPL", period_days=90)
 
     assert isinstance(result, TradingWorkflowResult)
     assert result.symbol == "AAPL"
@@ -88,53 +89,32 @@ def test_fetch_data(mock_workflow_dependencies):
     assert len(state["news_articles"]) > 0
 
 
-def test_run_technical_analysis(mock_workflow_dependencies, sample_ohlcv_data):
+@pytest.mark.asyncio
+async def test_run_technical_analysis(mock_workflow_dependencies, sample_ohlcv_data):
     market_fetcher, news_fetcher, llm_client, finbert, fundamental_fetcher = mock_workflow_dependencies
 
     workflow = TradingWorkflow(llm_client, market_fetcher, news_fetcher, finbert, fundamental_fetcher)
 
-    state = {
-        "symbol": "AAPL",
-        "market_data": sample_ohlcv_data,
-        "news_articles": [],
-        "technical_analysis": None,
-        "sentiment_analysis": None,
-        "news_analysis": None,
-        "final_decision": None,
-        "risk_assessment": None,
-        "account_info": None,
-    }
+    result = await workflow.technical_analyst.analyze("AAPL", sample_ohlcv_data)
 
-    result_state = workflow._run_technical_analysis(state)
-
-    assert result_state["technical_analysis"] is not None
-    assert isinstance(result_state["technical_analysis"], TechnicalAnalysis)
+    assert result is not None
+    assert isinstance(result, TechnicalAnalysis)
 
 
-def test_run_sentiment_analysis(mock_workflow_dependencies, sample_news_articles):
+@pytest.mark.asyncio
+async def test_run_sentiment_analysis(mock_workflow_dependencies, sample_news_articles):
     market_fetcher, news_fetcher, llm_client, finbert, fundamental_fetcher = mock_workflow_dependencies
 
     workflow = TradingWorkflow(llm_client, market_fetcher, news_fetcher, finbert, fundamental_fetcher)
 
-    state = {
-        "symbol": "AAPL",
-        "market_data": None,
-        "news_articles": sample_news_articles,
-        "technical_analysis": None,
-        "sentiment_analysis": None,
-        "news_analysis": None,
-        "final_decision": None,
-        "risk_assessment": None,
-        "account_info": None,
-    }
+    result = await workflow.sentiment_analyst.analyze("AAPL", sample_news_articles)
 
-    result_state = workflow._run_sentiment_analysis(state)
-
-    assert result_state["sentiment_analysis"] is not None
-    assert isinstance(result_state["sentiment_analysis"], SentimentAnalysis)
+    assert result is not None
+    assert isinstance(result, SentimentAnalysis)
 
 
-def test_make_decision(mock_workflow_dependencies, sample_bullish_research, sample_bearish_research):
+@pytest.mark.asyncio
+async def test_make_decision(mock_workflow_dependencies, sample_bullish_research, sample_bearish_research):
     market_fetcher, news_fetcher, llm_client, finbert, fundamental_fetcher = mock_workflow_dependencies
 
     workflow = TradingWorkflow(llm_client, market_fetcher, news_fetcher, finbert, fundamental_fetcher)
@@ -188,7 +168,7 @@ def test_make_decision(mock_workflow_dependencies, sample_bullish_research, samp
         "order_status": None,
     }
 
-    result_state = workflow._make_decision(state)
+    result_state = await workflow._make_decision(state)
 
     assert result_state["final_decision"] is not None
     assert isinstance(result_state["final_decision"], TradingDecision)
@@ -280,7 +260,8 @@ def test_execute_trade_error_handling(mock_workflow_dependencies, sample_ohlcv_d
     mock_broker.submit_order.assert_called_once()
 
 
-def test_account_info_passed_to_trader(
+@pytest.mark.asyncio
+async def test_account_info_passed_to_trader(
     mock_workflow_dependencies, sample_bullish_research, sample_bearish_research
 ):
     """Test portfolio info passed to trader for context-aware decisions."""
@@ -337,7 +318,7 @@ def test_account_info_passed_to_trader(
         "order_status": None,
     }
 
-    result_state = workflow._make_decision(state)
+    result_state = await workflow._make_decision(state)
 
     assert result_state["final_decision"].owns_position is True
     assert result_state["final_decision"].position_qty == 100.0


### PR DESCRIPTION
## Motivation

Reduce workflow latency by running independent agents concurrently instead of sequentially.

## Implementation information

**Async conversion:**
- Added `acomplete()` async method to LLMClient using `litellm.acompletion`
- Converted all agents to async (technical, sentiment, news, fundamental, bullish/bearish researchers, trader)

**Thread-safety:**
- Added `threading.Lock` to FinBERTSentiment for thread-safe PyTorch inference
- SentimentAnalyst uses `run_in_executor` for CPU-bound FinBERT calls

**Parallel execution groups:**
```
Sequential: fetch_data + fetch_account_info
    ↓
Group 1 (parallel): technical | sentiment | news | fundamental
    ↓
Group 2 (parallel): bullish_research | bearish_research
    ↓
Sequential: make_decision → assess_risk → execute_trade
```

**Alternative considered:** ThreadPoolExecutor - discarded in favor of native asyncio for better integration with async LLM APIs.

## Supporting documentation

Plan file: `.claude/plans/encapsulated-weaving-lollipop.md`