### PR TITLE
chore: sync python version between mise and pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ai-casino"
 version = "0.1.0"
 description = "Agentic stock trading system with multi-agent architecture"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 dependencies = [
     # Technical Analysis
     "pandas==2.3.3",

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,21 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.mise\\.toml$"],
+      "matchStrings": ["python = \"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "python",
+      "datasourceTemplate": "docker",
+      "packageNameTemplate": "python"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchDepNames": ["python"],
+      "groupName": "python version"
+    }
   ]
 }


### PR DESCRIPTION
## Motivation

Python version mismatch between mise (3.13.1) and pyproject (>=3.12). Renovate would update them separately.

## Implementation information

- Bump `requires-python` to `>=3.13` to match mise
- Add renovate customManager to detect python version in `.mise.toml`
- Group both python deps under "python version" for single PR bumps

## Supporting documentation

N/A