### PR TITLE
feat(tui): add Nord theme with auto dark/light detection

### DIFF
--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -11,6 +11,7 @@ from textual.widgets import Input
 
 from src.models.llm import LLMClient
 from src.tui.commands import CommandHandler
+from src.tui.themes import NORD_LIGHT_THEME, detect_dark_mode
 from src.tui.widgets.chat_view import ChatView
 from src.tui.widgets.status_bar import StatusBar
 from src.workflows.trading import TradingWorkflowResult
@@ -27,6 +28,7 @@ class TradingChatApp(App):
     BINDINGS = [
         Binding("ctrl+c", "quit", "Quit"),
         Binding("ctrl+l", "clear", "Clear"),
+        Binding("ctrl+t", "toggle_theme", "Toggle Theme"),
         Binding("escape", "focus_input", "Focus Input"),
     ]
 
@@ -73,6 +75,8 @@ class TradingChatApp(App):
 
     def on_mount(self) -> None:
         """Handle app mount."""
+        self.register_theme(NORD_LIGHT_THEME)
+        self.theme = "nord" if detect_dark_mode() else "nord-light"
         chat = self.query_one(ChatView)
         chat.show_welcome(self._model_name)
         self.query_one(Input).focus()
@@ -173,3 +177,7 @@ Be concise but informative. Use markdown formatting for readability."""
     def action_focus_input(self) -> None:
         """Focus the input box."""
         self.query_one(Input).focus()
+
+    def action_toggle_theme(self) -> None:
+        """Toggle between Nord dark and light themes."""
+        self.theme = "nord-light" if self.theme == "nord" else "nord"

--- a/src/tui/app.tcss
+++ b/src/tui/app.tcss
@@ -1,9 +1,9 @@
-/* AI Casino TUI Theme */
+/* AI Casino TUI Theme - Nord */
 
-/* Screen base - dark slate background */
+/* Screen base - uses theme colors */
 Screen {
-    background: #1E2530;
-    color: #C5CDD9;
+    background: $background;
+    color: $foreground;
 }
 
 /* Remove default header styling */
@@ -19,35 +19,35 @@ Footer {
 /* Main chat container - NO borders, clean look */
 #chat-container {
     height: 1fr;
-    background: #1E2530;
+    background: $background;
     padding: 0 1;
     border: none;
 }
 
 ChatView {
     height: 1fr;
-    background: #1E2530;
+    background: $background;
     padding: 0;
     border: none;
 }
 
 /* Welcome/Logo area */
 .logo {
-    color: #5DADE2;
+    color: $accent;
     margin-bottom: 1;
 }
 
 .welcome-text {
-    color: #8899A6;
+    color: $text-muted;
     margin-bottom: 0;
 }
 
 .model-info {
-    color: #8899A6;
+    color: $text-muted;
 }
 
 .model-name {
-    color: #5DADE2;
+    color: $accent;
 }
 
 /* User message - highlighted with prompt */
@@ -59,11 +59,11 @@ UserMessage {
 }
 
 .user-prompt {
-    color: #5DADE2;
+    color: $accent;
 }
 
 .user-input {
-    background: #2D3848;
+    background: $surface;
     padding: 0 1;
 }
 
@@ -73,34 +73,35 @@ AssistantMessage {
     padding: 0;
     margin: 1 0;
     border: none;
+    color: $foreground;
 }
 
 AssistantMessage.streaming {
-    color: #8899A6;
+    color: $text-muted;
 }
 
-/* Tool call indicator - cyan with bullet */
+/* Tool call indicator - accent with bullet */
 ToolCallWidget {
-    color: #5DADE2;
+    color: $accent;
     padding: 0;
     margin: 1 0 0 0;
 }
 
 .tool-name {
-    color: #5DADE2;
+    color: $accent;
 }
 
 .tool-args {
-    color: #8899A6;
+    color: $text-muted;
 }
 
 .tool-timing {
-    color: #5DADE2;
+    color: $accent;
 }
 
 /* Response text */
 .response-text {
-    color: #C5CDD9;
+    color: $foreground;
     margin: 1 0;
 }
 
@@ -113,12 +114,12 @@ ProgressPanel {
 }
 
 ProgressPanel LoadingIndicator {
-    color: #5DADE2;
+    color: $accent;
     height: 1;
 }
 
 .progress-header {
-    color: #5DADE2;
+    color: $accent;
 }
 
 /* Task steps */
@@ -128,15 +129,15 @@ TaskStep {
 }
 
 TaskStep.pending {
-    color: #5A6778;
+    color: $text-disabled;
 }
 
 TaskStep.active {
-    color: #5DADE2;
+    color: $accent;
 }
 
 TaskStep.complete {
-    color: #5DADE2;
+    color: $accent;
 }
 
 /* Result box - minimal table style */
@@ -148,7 +149,7 @@ ResultBox {
 }
 
 .result-header {
-    color: #C5CDD9;
+    color: $foreground;
     text-style: bold;
     margin-bottom: 1;
 }
@@ -162,42 +163,42 @@ ResultBox {
 }
 
 .result-label {
-    color: #8899A6;
+    color: $text-muted;
     width: 15;
 }
 
 .result-value {
-    color: #C5CDD9;
+    color: $foreground;
 }
 
-/* Signal colors */
+/* Signal colors - Nord Aurora */
 .signal-buy {
-    color: #27AE60;
+    color: #A3BE8C;
 }
 
 .signal-sell {
-    color: #E74C3C;
+    color: #BF616A;
 }
 
 .signal-hold {
-    color: #F39C12;
+    color: #EBCB8B;
 }
 
 /* Input at bottom */
 #input-box {
     dock: bottom;
     margin: 1 1;
-    background: #1E2530;
-    border: solid #3D4F5F;
-    color: #C5CDD9;
+    background: $background;
+    border: solid $panel;
+    color: $foreground;
 }
 
 #input-box:focus {
-    border: solid #5DADE2;
+    border: solid $accent;
 }
 
 #input-box.-placeholder {
-    color: #5A6778;
+    color: $text-disabled;
 }
 
 /* Status bar - minimal */
@@ -205,6 +206,6 @@ StatusBar {
     dock: bottom;
     height: 1;
     background: transparent;
-    color: #5A6778;
+    color: $text-disabled;
     padding: 0 1;
 }

--- a/src/tui/themes.py
+++ b/src/tui/themes.py
@@ -1,0 +1,133 @@
+"""Nord theme definitions and dark/light detection."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from loguru import logger
+from textual.theme import Theme
+
+# Nord color palette
+NORD = {
+    # Polar Night (dark backgrounds)
+    "nord0": "#2E3440",
+    "nord1": "#3B4252",
+    "nord2": "#434C5E",
+    "nord3": "#4C566A",
+    # Snow Storm (light backgrounds/text)
+    "nord4": "#D8DEE9",
+    "nord5": "#E5E9F0",
+    "nord6": "#ECEFF4",
+    # Frost (accent colors)
+    "nord7": "#8FBCBB",
+    "nord8": "#88C0D0",
+    "nord9": "#81A1C1",
+    "nord10": "#5E81AC",
+    # Aurora (semantic colors)
+    "nord11": "#BF616A",  # red/error
+    "nord12": "#D08770",  # orange
+    "nord13": "#EBCB8B",  # yellow/warning
+    "nord14": "#A3BE8C",  # green/success
+    "nord15": "#B48EAD",  # purple
+}
+
+NORD_LIGHT_THEME = Theme(
+    name="nord-light",
+    primary=NORD["nord10"],
+    secondary=NORD["nord9"],
+    accent=NORD["nord8"],
+    foreground=NORD["nord0"],
+    background=NORD["nord6"],
+    success=NORD["nord14"],
+    warning=NORD["nord13"],
+    error=NORD["nord11"],
+    surface=NORD["nord5"],
+    panel=NORD["nord4"],
+    dark=False,
+)
+
+
+def _is_light_color(hex_color: str) -> bool:
+    """Check if hex color is light based on luminance."""
+    hex_color = hex_color.lstrip("#")
+    if len(hex_color) != 6:
+        return False
+    r, g, b = int(hex_color[0:2], 16), int(hex_color[2:4], 16), int(hex_color[4:6], 16)
+    # Perceived luminance formula
+    luminance = 0.299 * r + 0.587 * g + 0.114 * b
+    return luminance > 128
+
+
+def _detect_ghostty_theme() -> bool | None:
+    """Detect theme from Ghostty config. Returns True=dark, False=light, None=unknown."""
+    config_path = Path.home() / ".config" / "ghostty" / "config"
+    if not config_path.exists():
+        return None
+    try:
+        for raw_line in config_path.read_text().splitlines():
+            stripped = raw_line.strip()
+            if stripped.startswith("background") and "=" in stripped:
+                bg_color = stripped.split("=", 1)[1].strip()
+                if bg_color.startswith("#"):
+                    is_dark = not _is_light_color(bg_color)
+                    logger.debug(f"Ghostty detection: {'dark' if is_dark else 'light'} (bg={bg_color})")
+                    return is_dark
+    except Exception as e:
+        logger.debug(f"Ghostty config read failed: {e}")
+    return None
+
+
+def detect_dark_mode() -> bool:
+    """Detect OS dark mode preference.
+
+    Returns:
+        True for dark mode, False for light mode.
+    """
+    # 1. AI_CASINO_THEME env override
+    override = os.getenv("AI_CASINO_THEME", "").lower()
+    if override == "dark":
+        logger.debug("Theme override: dark")
+        return True
+    if override == "light":
+        logger.debug("Theme override: light")
+        return False
+
+    # 2. Ghostty terminal config
+    if os.getenv("TERM_PROGRAM") == "ghostty":
+        result = _detect_ghostty_theme()
+        if result is not None:
+            return result
+
+    # 3. COLORFGBG env (iTerm2, Konsole)
+    colorfgbg = os.getenv("COLORFGBG", "")
+    if colorfgbg:
+        parts = colorfgbg.split(";")
+        if len(parts) >= 2:
+            try:
+                bg_color = int(parts[-1])
+                is_dark = bg_color < 8
+                logger.debug(f"COLORFGBG detection: {'dark' if is_dark else 'light'}")
+                return is_dark
+            except ValueError:
+                pass
+
+    # 4. macOS detection via defaults (system-wide fallback)
+    if sys.platform == "darwin":
+        try:
+            result = subprocess.run(
+                ["/usr/bin/defaults", "read", "-g", "AppleInterfaceStyle"],
+                capture_output=True,
+                text=True,
+                timeout=1,
+                check=False,
+            )
+            is_dark = result.returncode == 0 and "dark" in result.stdout.lower()
+            logger.debug(f"macOS theme detection: {'dark' if is_dark else 'light'}")
+            return is_dark
+        except Exception as e:
+            logger.debug(f"macOS theme detection failed: {e}")
+
+    # 5. Default to dark
+    logger.debug("Theme detection: defaulting to dark")
+    return True


### PR DESCRIPTION
## Motivation

TUI had hardcoded dark colors. Users with light terminal themes had poor readability. Need automatic theme detection and manual toggle.

## Implementation information

- Use Textual's built-in `nord` theme for dark mode
- Create `NORD_LIGHT_THEME` variant with inverted colors (nord6 bg, nord0 fg)
- Auto-detection priority:
  1. `AI_CASINO_THEME` env override (dark/light)
  2. Ghostty config (`~/.config/ghostty/config` background color luminance)
  3. `COLORFGBG` env (iTerm2, Konsole)
  4. macOS system appearance (`defaults read -g AppleInterfaceStyle`)
  5. Default: dark
- Add `Ctrl+T` binding to toggle themes at runtime
- Convert all hardcoded hex colors in CSS to theme variables ($background, $foreground, $accent, etc.)
- Signal colors (BUY/SELL/HOLD) use Nord Aurora palette

## Supporting documentation

N/A