### PR TITLE
feat(tui): add thinking spinner to chat

### DIFF
--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -268,11 +268,16 @@ class TradingChatApp(App):
         status_bar = self.query_one(StatusBar)
 
         status_bar.set_working("Thinking...")
+        chat.show_thinking()
         chat.start_streaming_message()
         response_text = ""
+        first_token = True
 
         try:
             async for token in self._llm.astream(text, system=STREAMING_SYSTEM_PROMPT, temperature=0.7):
+                if first_token:
+                    chat.hide_thinking()
+                    first_token = False
                 response_text += token
                 chat.append_token(token)
 
@@ -280,6 +285,7 @@ class TradingChatApp(App):
             self._history.append({"role": "assistant", "content": response_text})
         except Exception as e:
             logger.exception("Chat failed")
+            chat.hide_thinking()
             chat.finish_streaming()
             chat.add_assistant_message(f"Error: {e}")
         finally:
@@ -291,6 +297,7 @@ class TradingChatApp(App):
         status_bar = self.query_one(StatusBar)
 
         status_bar.set_working("Thinking...")
+        chat.show_thinking()
 
         confirmed_tools: set[str] = set()
         tool_history: list[dict[str, str]] = []
@@ -334,11 +341,13 @@ class TradingChatApp(App):
                 on_tool_call,
             )
 
+            chat.hide_thinking()
             chat.add_assistant_message(response)
             self._history.extend(tool_history)
             self._history.append({"role": "assistant", "content": response})
         except Exception as e:
             logger.exception("Agentic chat failed")
+            chat.hide_thinking()
             chat.add_assistant_message(f"Error: {e}")
         finally:
             status_bar.clear_working()

--- a/src/tui/app.tcss
+++ b/src/tui/app.tcss
@@ -81,6 +81,13 @@ AssistantMessage.streaming {
     color: $text-muted;
 }
 
+/* Thinking indicator - animated dots */
+ThinkingIndicator {
+    color: $text-muted;
+    padding: 0;
+    margin: 1 0 0 0;
+}
+
 /* Tool call indicator - accent with bullet */
 ToolCallWidget {
     color: $accent;

--- a/src/tui/widgets/__init__.py
+++ b/src/tui/widgets/__init__.py
@@ -3,5 +3,6 @@
 from src.tui.widgets.autocomplete_input import AutocompleteInput
 from src.tui.widgets.chat_view import ChatView
 from src.tui.widgets.status_bar import StatusBar
+from src.tui.widgets.thinking import ThinkingIndicator
 
-__all__ = ["AutocompleteInput", "ChatView", "StatusBar"]
+__all__ = ["AutocompleteInput", "ChatView", "StatusBar", "ThinkingIndicator"]

--- a/src/tui/widgets/chat_view.py
+++ b/src/tui/widgets/chat_view.py
@@ -5,6 +5,7 @@ from textual.containers import VerticalScroll
 from src.tui.widgets.message import AssistantMessage, ToolCallWidget, UserMessage, WelcomeWidget
 from src.tui.widgets.progress import ProgressPanel
 from src.tui.widgets.result_box import ResultBox
+from src.tui.widgets.thinking import ThinkingIndicator
 from src.workflows.trading import TradingWorkflowResult
 
 
@@ -25,6 +26,7 @@ class ChatView(VerticalScroll):
         super().__init__(**kwargs)
         self._streaming_message: AssistantMessage | None = None
         self._progress_panel: ProgressPanel | None = None
+        self._thinking_indicator: ThinkingIndicator | None = None
 
     def show_welcome(self, model_name: str = "ollama/qwen3:14b") -> None:
         """Show welcome screen with logo.
@@ -158,10 +160,24 @@ class ChatView(VerticalScroll):
         else:
             self.add_assistant_message(content)
 
+    def show_thinking(self) -> None:
+        """Show thinking indicator."""
+        if self._thinking_indicator is None:
+            self._thinking_indicator = ThinkingIndicator()
+            self.mount(self._thinking_indicator)
+            self.scroll_end(animate=False)
+
+    def hide_thinking(self) -> None:
+        """Hide thinking indicator."""
+        if self._thinking_indicator is not None:
+            self._thinking_indicator.remove()
+            self._thinking_indicator = None
+
     def clear_messages(self) -> None:
         """Clear all messages."""
         self._streaming_message = None
         self._progress_panel = None
+        self._thinking_indicator = None
         for child in list(self.children):
             child.remove()
 

--- a/src/tui/widgets/thinking.py
+++ b/src/tui/widgets/thinking.py
@@ -1,0 +1,32 @@
+"""Thinking indicator widget for chat."""
+
+import time
+
+from textual.widget import Widget
+
+
+class ThinkingIndicator(Widget):
+    """Animated thinking indicator shown while LLM processes."""
+
+    DEFAULT_CSS = """
+    ThinkingIndicator {
+        height: 1;
+    }
+    """
+
+    def __init__(self, **kwargs: object) -> None:
+        """Initialize thinking indicator."""
+        super().__init__(**kwargs)
+        self.auto_refresh = 1 / 8  # 8 FPS animation
+        self._start_time = time.monotonic()
+
+    def render(self) -> str:
+        """Render animated thinking indicator."""
+        elapsed = time.monotonic() - self._start_time
+        frame = int(elapsed * 3)  # 3 states per second
+        dots = "." * ((frame % 3) + 1)
+        return f"● Thinking{dots}"
+
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return "ThinkingIndicator()"


### PR DESCRIPTION
## Motivation

Status bar "Thinking..." text is easy to miss. Users need visual feedback in chat area when LLM is processing (especially for agentic mode where there's no streaming).

## Implementation information

- New `ThinkingIndicator` widget with animated `● Thinking...` (cycling dots)
- Time-based animation at 8 FPS using `auto_refresh`
- Integrated in both streaming (hides on first token) and agentic (hides on response) chat handlers
- Matches assistant message styling (muted color, bullet prefix)

**Files:**
- `src/tui/widgets/thinking.py` - new widget
- `src/tui/widgets/chat_view.py` - show/hide methods
- `src/tui/app.py` - handler integration
- `src/tui/app.tcss` - styling