### PR TITLE
fix: Python 3.14 async compatibility and API key validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     # Trading
     "alpaca-py==0.43.2",
     "backtesting==0.6.5",
+    "bokeh>=3.3,<3.8",  # backtesting 0.6.5 incompatible with bokeh 3.8+
 
     # Optimization
     "optuna==4.7.0",

--- a/src/cli/chat.py
+++ b/src/cli/chat.py
@@ -44,9 +44,8 @@ def chat() -> None:
     )
 
     try:
-        import nest_asyncio
-
-        nest_asyncio.apply()
+        # NOTE: nest_asyncio removed - breaks Python 3.14 + anyio/httpcore
+        # Textual handles its own event loop
 
         from src.tui.app import TradingChatApp
 

--- a/src/models/providers/anthropic.py
+++ b/src/models/providers/anthropic.py
@@ -42,10 +42,18 @@ class AnthropicProvider(BaseLLMProvider):
             model: Model name (e.g., "claude-sonnet-4-20250514")
             api_key: API key (defaults to ANTHROPIC_API_KEY env var)
             max_tokens: Maximum tokens in response (default: 4096)
+
+        Raises:
+            ValueError: If API key is not provided and ANTHROPIC_API_KEY env var is empty
         """
+        resolved_key = api_key or os.getenv("ANTHROPIC_API_KEY")
+        if not resolved_key:
+            msg = "Anthropic API key required: set ANTHROPIC_API_KEY env var or pass api_key"
+            raise ValueError(msg)
+
         self._model = model
         self._max_tokens = max_tokens
-        self._client = AsyncAnthropic(api_key=api_key or os.getenv("ANTHROPIC_API_KEY"))
+        self._client = AsyncAnthropic(api_key=resolved_key)
         logger.debug(f"Initialized AnthropicProvider: model={model}, max_tokens={max_tokens}")
 
     async def close(self) -> None:

--- a/src/models/providers/openai.py
+++ b/src/models/providers/openai.py
@@ -20,11 +20,19 @@ class OpenAIProvider(BaseLLMProvider):
             model: Model name (e.g., "gpt-4o")
             api_key: API key (defaults to OPENAI_API_KEY env var)
             base_url: Custom base URL (defaults to OPENAI_API_BASE env var)
+
+        Raises:
+            ValueError: If API key is not provided and OPENAI_API_KEY env var is empty
         """
+        resolved_key = api_key or os.getenv("OPENAI_API_KEY")
+        if not resolved_key:
+            msg = "OpenAI API key required: set OPENAI_API_KEY env var or pass api_key"
+            raise ValueError(msg)
+
         self._model = model
         self._is_gpt5 = model.startswith("gpt-5")
         self._client = AsyncOpenAI(
-            api_key=api_key or os.getenv("OPENAI_API_KEY"),
+            api_key=resolved_key,
             base_url=base_url or os.getenv("OPENAI_API_BASE"),
         )
         logger.debug(f"Initialized OpenAIProvider: model={model}")

--- a/src/tools/analyze_stock.py
+++ b/src/tools/analyze_stock.py
@@ -1,14 +1,12 @@
 """Analyze stock tool for full trading workflow."""
 
 import asyncio
+import concurrent.futures
 from typing import TYPE_CHECKING
 
-import nest_asyncio
 from loguru import logger
 
 from src.tools.base import BaseTool
-
-nest_asyncio.apply()
 
 if TYPE_CHECKING:
     from src.workflows.trading import TradingWorkflowResult
@@ -73,8 +71,14 @@ class AnalyzeStockTool(BaseTool):
         """
         logger.info(f"Running full analysis for {symbol} ({period_days} days)")
 
-        try:
+        def run_in_thread() -> str:
             return asyncio.run(self._run_analysis(symbol.upper(), period_days))
+
+        try:
+            # Run in thread to avoid nested event loop issues with Python 3.14
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(run_in_thread)
+                return future.result()
         except Exception as e:
             logger.error(f"Analysis failed for {symbol}: {e}")
             return f"Analysis failed for {symbol}: {e}"

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,7 @@ dependencies = [
     { name = "anthropic" },
     { name = "asyncpg" },
     { name = "backtesting" },
+    { name = "bokeh" },
     { name = "ddgs" },
     { name = "diskcache" },
     { name = "httpx" },
@@ -58,6 +59,7 @@ requires-dist = [
     { name = "anthropic", specifier = "==0.77.1" },
     { name = "asyncpg", specifier = "==0.31.0" },
     { name = "backtesting", specifier = "==0.6.5" },
+    { name = "bokeh", specifier = ">=3.3,<3.8" },
     { name = "ddgs", specifier = "==9.10.0" },
     { name = "diskcache", specifier = "==5.6.3" },
     { name = "httpx", specifier = "==0.28.1" },
@@ -307,7 +309,7 @@ wheels = [
 
 [[package]]
 name = "bokeh"
-version = "3.8.1"
+version = "3.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "contourpy" },
@@ -321,9 +323,9 @@ dependencies = [
     { name = "tornado", marker = "sys_platform != 'emscripten'" },
     { name = "xyzservices" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/42/777c0627dbd78a2a7c6c6a1c3327e8a787ec99a4b84ae93245ce49c96af7/bokeh-3.8.1.tar.gz", hash = "sha256:40df8e632de367399d06979cbd76c9e68a133a3138e1adde37c4a4715ecb4d6e", size = 6529791, upload-time = "2025-11-07T20:50:59.565Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/18/12d0d6024177ad18ba65deffc363046d0cbafe116f8b964a9efa85d2800f/bokeh-3.7.3.tar.gz", hash = "sha256:70a89a9f797b103d5ee6ad15fb7944adda115cf0da996ed0b75cfba61cb12f2b", size = 6366610, upload-time = "2025-05-12T12:13:29.318Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/e7/b18bee0772d49c0f78d57f15a68e85257abf7224d9b910706abe8bd1dc0f/bokeh-3.8.1-py3-none-any.whl", hash = "sha256:89a66cb8bfe85e91bce144e3ccf3c4a6f0f1347e7006282972568ea0ecacbb00", size = 7206137, upload-time = "2025-11-07T20:50:58.108Z" },
+    { url = "https://files.pythonhosted.org/packages/91/48/08b2382e739236aa3360b7976360ba3e0c043b6234e25951c18c1eb6fa06/bokeh-3.7.3-py3-none-any.whl", hash = "sha256:b0e79dd737f088865212e4fdcb0f3b95d087f0f088bf8ca186a300ab1641e2c7", size = 7031447, upload-time = "2025-05-12T12:13:27.47Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Motivation

TUI crashes on Python 3.14 with `TypeError: cannot create weak reference to 'NoneType' object` due to nest_asyncio + anyio/httpcore incompatibility. Also, empty API keys cause cryptic connection errors instead of clear validation messages.

## Implementation information

- **bokeh pin**: backtesting 0.6.5 incompatible with bokeh 3.8+ (removed `bokeh.colors.RGB`)
- **nest_asyncio removal**: Textual handles its own event loop, nest_asyncio breaks anyio task context detection in Python 3.14
- **Thread-based async**: `analyze_stock` tool now runs async workflow in ThreadPoolExecutor to avoid nested loop issues
- **API key validation**: OpenAI/Anthropic providers now fail fast with clear error if API key missing

## Supporting documentation

Related to Python 3.14 compatibility work in #87