### PR TITLE
feat(data): add Finnhub social sentiment fetcher

### DIFF
--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -7,11 +7,25 @@ from src.data.comparative import (
     Sector,
     StockInfo,
 )
+from src.data.finnhub import (
+    BuzzData,
+    FinnhubFetcher,
+    NewsSentimentData,
+    SentimentBreakdown,
+    SocialSentimentData,
+    SocialSentimentEntry,
+)
 
 __all__ = [
+    "BuzzData",
     "ComparativeData",
     "ComparativeDataFetcher",
+    "FinnhubFetcher",
+    "NewsSentimentData",
     "PerformanceData",
     "Sector",
+    "SentimentBreakdown",
+    "SocialSentimentData",
+    "SocialSentimentEntry",
     "StockInfo",
 ]

--- a/src/data/finnhub.py
+++ b/src/data/finnhub.py
@@ -1,0 +1,252 @@
+"""Finnhub social sentiment data fetcher."""
+
+import hashlib
+import os
+from datetime import datetime
+from pathlib import Path
+
+import httpx
+from diskcache import Cache
+from loguru import logger
+from pydantic import BaseModel
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    retry_if_not_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+# Cache TTL in seconds
+FINNHUB_CACHE_TTL = 3600  # 1 hour
+
+HTTP_RETRY = retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    retry=retry_if_exception_type(Exception) & retry_if_not_exception_type(ValueError),
+    reraise=True,
+    before_sleep=lambda retry_state: logger.warning(
+        f"Retry {retry_state.attempt_number} after {retry_state.outcome.exception()}"
+    ),
+)
+
+
+class SocialSentimentEntry(BaseModel):
+    """Single social sentiment data point."""
+
+    at_time: datetime
+    mention: int
+    score: float
+
+
+class SocialSentimentData(BaseModel):
+    """Social sentiment data from Reddit and Twitter."""
+
+    symbol: str
+    reddit: list[SocialSentimentEntry]
+    twitter: list[SocialSentimentEntry]
+    fetched_at: datetime
+
+
+class BuzzData(BaseModel):
+    """News buzz metrics."""
+
+    articles_in_last_week: int
+    buzz: float
+    weekly_average: float
+
+
+class SentimentBreakdown(BaseModel):
+    """Bearish/bullish sentiment breakdown."""
+
+    bearish_percent: float
+    bullish_percent: float
+
+
+class NewsSentimentData(BaseModel):
+    """News sentiment indicator data."""
+
+    symbol: str
+    buzz: BuzzData
+    company_news_score: float
+    sector_avg_bullish_percent: float
+    sector_avg_news_score: float
+    sentiment: SentimentBreakdown
+    fetched_at: datetime
+
+
+class FinnhubFetcher:
+    """Fetch social sentiment data from Finnhub API."""
+
+    BASE_URL = "https://finnhub.io/api/v1"
+
+    def __init__(self, api_key: str | None = None, cache_dir: str | None = None) -> None:
+        """Initialize Finnhub fetcher.
+
+        Args:
+            api_key: Finnhub API key
+            cache_dir: Cache directory path
+        """
+        self._api_key = api_key or os.getenv("FINNHUB_API_KEY")
+
+        self._cache_dir = Path(cache_dir or "data/cache/finnhub")
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+        self._cache = Cache(str(self._cache_dir))
+
+        if not self._api_key:
+            logger.warning("Finnhub API key not set - API calls will fail")
+        else:
+            logger.info(f"Initialized FinnhubFetcher (cache_dir={self._cache_dir})")
+
+    def _cache_key(self, prefix: str, *args: str) -> str:
+        """Generate cache key.
+
+        Args:
+            prefix: Cache key prefix
+            args: Additional key components
+
+        Returns:
+            Cache key string
+        """
+        raw = f"{prefix}:{':'.join(str(a) for a in args)}"
+        return hashlib.sha256(raw.encode()).hexdigest()[:32]
+
+    @HTTP_RETRY
+    def fetch_social_sentiment(
+        self, symbol: str, from_date: str | None = None, to_date: str | None = None
+    ) -> SocialSentimentData:
+        """Fetch social sentiment data for a symbol.
+
+        Args:
+            symbol: Stock ticker symbol
+            from_date: Start date (YYYY-MM-DD)
+            to_date: End date (YYYY-MM-DD)
+
+        Returns:
+            SocialSentimentData with Reddit and Twitter sentiment
+        """
+        logger.info(f"Fetching Finnhub social sentiment for {symbol}")
+
+        cache_key = self._cache_key("social", symbol, from_date or "", to_date or "")
+        cached = self._cache.get(cache_key)
+        if cached:
+            logger.debug(f"Cache hit for {symbol} social sentiment")
+            return SocialSentimentData.model_validate(cached)
+
+        if not self._api_key:
+            msg = "Finnhub API key not configured"
+            raise ValueError(msg)
+
+        try:
+            params = {"symbol": symbol, "token": self._api_key}
+            if from_date:
+                params["from"] = from_date
+            if to_date:
+                params["to"] = to_date
+
+            with httpx.Client(timeout=30.0) as client:
+                response = client.get(f"{self.BASE_URL}/stock/social-sentiment", params=params)
+                response.raise_for_status()
+                data = response.json()
+
+            reddit_entries = [
+                SocialSentimentEntry(
+                    at_time=datetime.fromisoformat(entry["atTime"].replace("Z", "+00:00")),
+                    mention=entry["mention"],
+                    score=entry["score"],
+                )
+                for entry in data.get("reddit", [])
+            ]
+
+            twitter_entries = [
+                SocialSentimentEntry(
+                    at_time=datetime.fromisoformat(entry["atTime"].replace("Z", "+00:00")),
+                    mention=entry["mention"],
+                    score=entry["score"],
+                )
+                for entry in data.get("twitter", [])
+            ]
+
+            result = SocialSentimentData(
+                symbol=symbol,
+                reddit=reddit_entries,
+                twitter=twitter_entries,
+                fetched_at=datetime.now(),
+            )
+
+            self._cache.set(cache_key, result.model_dump(mode="json"), expire=FINNHUB_CACHE_TTL)
+            r_count, t_count = len(reddit_entries), len(twitter_entries)
+            logger.info(f"Fetched {symbol} social sentiment: {r_count} reddit, {t_count} twitter")
+            return result
+
+        except Exception as e:
+            logger.error(f"Finnhub social sentiment fetch failed: {e}")
+            raise
+
+    @HTTP_RETRY
+    def fetch_sentiment_indicator(self, symbol: str) -> NewsSentimentData:
+        """Fetch news sentiment indicator for a symbol.
+
+        Args:
+            symbol: Stock ticker symbol
+
+        Returns:
+            NewsSentimentData with buzz and sentiment metrics
+        """
+        logger.info(f"Fetching Finnhub sentiment indicator for {symbol}")
+
+        cache_key = self._cache_key("indicator", symbol)
+        cached = self._cache.get(cache_key)
+        if cached:
+            logger.debug(f"Cache hit for {symbol} sentiment indicator")
+            return NewsSentimentData.model_validate(cached)
+
+        if not self._api_key:
+            msg = "Finnhub API key not configured"
+            raise ValueError(msg)
+
+        try:
+            params = {"symbol": symbol, "token": self._api_key}
+
+            with httpx.Client(timeout=30.0) as client:
+                response = client.get(f"{self.BASE_URL}/news-sentiment", params=params)
+                response.raise_for_status()
+                data = response.json()
+
+            buzz_data = data.get("buzz", {})
+            sentiment_data = data.get("sentiment", {})
+
+            result = NewsSentimentData(
+                symbol=symbol,
+                buzz=BuzzData(
+                    articles_in_last_week=buzz_data.get("articlesInLastWeek", 0),
+                    buzz=buzz_data.get("buzz", 0.0),
+                    weekly_average=buzz_data.get("weeklyAverage", 0.0),
+                ),
+                company_news_score=data.get("companyNewsScore", 0.0),
+                sector_avg_bullish_percent=data.get("sectorAverageBullishPercent", 0.0),
+                sector_avg_news_score=data.get("sectorAverageNewsScore", 0.0),
+                sentiment=SentimentBreakdown(
+                    bearish_percent=sentiment_data.get("bearishPercent", 0.0),
+                    bullish_percent=sentiment_data.get("bullishPercent", 0.0),
+                ),
+                fetched_at=datetime.now(),
+            )
+
+            self._cache.set(cache_key, result.model_dump(mode="json"), expire=FINNHUB_CACHE_TTL)
+            logger.info(f"Fetched sentiment indicator for {symbol}")
+            return result
+
+        except Exception as e:
+            logger.error(f"Finnhub sentiment indicator fetch failed: {e}")
+            raise
+
+    def clear_cache(self) -> None:
+        """Clear all cached Finnhub data."""
+        self._cache.clear()
+        logger.info("Cleared Finnhub cache")
+
+    def __repr__(self) -> str:
+        """String representation."""
+        authenticated = bool(self._api_key)
+        return f"FinnhubFetcher(authenticated={authenticated}, cache_dir={self._cache_dir})"

--- a/tests/test_data/test_finnhub.py
+++ b/tests/test_data/test_finnhub.py
@@ -1,0 +1,363 @@
+"""Tests for FinnhubFetcher."""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from src.data.finnhub import (
+    BuzzData,
+    FinnhubFetcher,
+    NewsSentimentData,
+    SentimentBreakdown,
+    SocialSentimentData,
+    SocialSentimentEntry,
+)
+
+
+@pytest.fixture
+def mock_social_response():
+    """Mock social sentiment API response."""
+    return {
+        "reddit": [
+            {"atTime": "2024-01-01T12:00:00Z", "mention": 100, "score": 0.75},
+            {"atTime": "2024-01-01T13:00:00Z", "mention": 150, "score": 0.82},
+        ],
+        "twitter": [
+            {"atTime": "2024-01-01T12:00:00Z", "mention": 500, "score": 0.68},
+        ],
+        "symbol": "AAPL",
+    }
+
+
+@pytest.fixture
+def mock_indicator_response():
+    """Mock sentiment indicator API response."""
+    return {
+        "buzz": {
+            "articlesInLastWeek": 42,
+            "buzz": 1.5,
+            "weeklyAverage": 28.0,
+        },
+        "companyNewsScore": 0.72,
+        "sectorAverageBullishPercent": 0.55,
+        "sectorAverageNewsScore": 0.65,
+        "sentiment": {
+            "bearishPercent": 0.25,
+            "bullishPercent": 0.75,
+        },
+        "symbol": "AAPL",
+    }
+
+
+@pytest.fixture
+def fetcher(tmp_path):
+    """Create FinnhubFetcher with temp cache dir and mock API key."""
+    with patch.dict("os.environ", {"FINNHUB_API_KEY": "test_api_key"}):
+        return FinnhubFetcher(cache_dir=str(tmp_path / "cache"))
+
+
+class TestSocialSentimentEntry:
+    """Tests for SocialSentimentEntry model."""
+
+    def test_create_entry(self):
+        """Test creating a SocialSentimentEntry."""
+        entry = SocialSentimentEntry(
+            at_time=datetime(2024, 1, 1, 12, 0, 0),
+            mention=100,
+            score=0.75,
+        )
+        assert entry.mention == 100
+        assert entry.score == 0.75
+        assert entry.at_time == datetime(2024, 1, 1, 12, 0, 0)
+
+
+class TestSocialSentimentData:
+    """Tests for SocialSentimentData model."""
+
+    def test_create_data(self):
+        """Test creating SocialSentimentData."""
+        entry = SocialSentimentEntry(
+            at_time=datetime(2024, 1, 1, 12, 0, 0),
+            mention=100,
+            score=0.75,
+        )
+        data = SocialSentimentData(
+            symbol="AAPL",
+            reddit=[entry],
+            twitter=[],
+            fetched_at=datetime.now(),
+        )
+        assert data.symbol == "AAPL"
+        assert len(data.reddit) == 1
+        assert len(data.twitter) == 0
+
+
+class TestBuzzData:
+    """Tests for BuzzData model."""
+
+    def test_create_buzz(self):
+        """Test creating BuzzData."""
+        buzz = BuzzData(
+            articles_in_last_week=42,
+            buzz=1.5,
+            weekly_average=28.0,
+        )
+        assert buzz.articles_in_last_week == 42
+        assert buzz.buzz == 1.5
+        assert buzz.weekly_average == 28.0
+
+
+class TestSentimentBreakdown:
+    """Tests for SentimentBreakdown model."""
+
+    def test_create_breakdown(self):
+        """Test creating SentimentBreakdown."""
+        breakdown = SentimentBreakdown(
+            bearish_percent=0.25,
+            bullish_percent=0.75,
+        )
+        assert breakdown.bearish_percent == 0.25
+        assert breakdown.bullish_percent == 0.75
+
+    def test_breakdown_sums_to_one(self):
+        """Test that typical breakdown sums to 1.0."""
+        breakdown = SentimentBreakdown(
+            bearish_percent=0.3,
+            bullish_percent=0.7,
+        )
+        assert abs(breakdown.bearish_percent + breakdown.bullish_percent - 1.0) < 0.001
+
+
+class TestNewsSentimentData:
+    """Tests for NewsSentimentData model."""
+
+    def test_create_news_sentiment(self):
+        """Test creating NewsSentimentData."""
+        data = NewsSentimentData(
+            symbol="AAPL",
+            buzz=BuzzData(articles_in_last_week=42, buzz=1.5, weekly_average=28.0),
+            company_news_score=0.72,
+            sector_avg_bullish_percent=0.55,
+            sector_avg_news_score=0.65,
+            sentiment=SentimentBreakdown(bearish_percent=0.25, bullish_percent=0.75),
+            fetched_at=datetime.now(),
+        )
+        assert data.symbol == "AAPL"
+        assert data.company_news_score == 0.72
+        assert data.buzz.articles_in_last_week == 42
+
+
+class TestFinnhubFetcher:
+    """Tests for FinnhubFetcher."""
+
+    def test_init_creates_cache_dir(self, tmp_path):
+        """Test that init creates cache directory."""
+        cache_dir = tmp_path / "new_cache"
+        with patch.dict("os.environ", {"FINNHUB_API_KEY": "test"}):
+            fetcher = FinnhubFetcher(cache_dir=str(cache_dir))
+            assert cache_dir.exists()
+            assert fetcher._cache_dir == cache_dir
+
+    def test_init_with_explicit_key(self, tmp_path):
+        """Test init with explicit API key."""
+        fetcher = FinnhubFetcher(api_key="explicit_key", cache_dir=str(tmp_path / "cache"))
+        assert fetcher._api_key == "explicit_key"
+
+    def test_init_without_key_logs_warning(self, tmp_path):
+        """Test that missing API key logs warning."""
+        with patch.dict("os.environ", {}, clear=True):
+            fetcher = FinnhubFetcher(cache_dir=str(tmp_path / "cache"))
+            assert fetcher._api_key is None
+
+    def test_repr_shows_auth_status(self, tmp_path):
+        """Test __repr__ shows authentication status."""
+        # Authenticated
+        with patch.dict("os.environ", {"FINNHUB_API_KEY": "test"}):
+            fetcher = FinnhubFetcher(cache_dir=str(tmp_path / "cache1"))
+            assert "authenticated=True" in repr(fetcher)
+
+        # Not authenticated
+        with patch.dict("os.environ", {}, clear=True):
+            fetcher = FinnhubFetcher(cache_dir=str(tmp_path / "cache2"))
+            assert "authenticated=False" in repr(fetcher)
+
+    def test_cache_key_deterministic(self, fetcher):
+        """Test cache key generation is deterministic."""
+        key1 = fetcher._cache_key("social", "AAPL", "2024-01-01", "2024-01-31")
+        key2 = fetcher._cache_key("social", "AAPL", "2024-01-01", "2024-01-31")
+        key3 = fetcher._cache_key("social", "TSLA", "2024-01-01", "2024-01-31")
+
+        assert key1 == key2
+        assert key1 != key3
+        assert len(key1) == 32
+
+
+class TestFetchSocialSentiment:
+    """Tests for fetch_social_sentiment method."""
+
+    def test_returns_correct_data(self, fetcher, mock_social_response):
+        """Test fetch_social_sentiment returns correct data structure."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_social_response
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.Client") as mock_client:
+            mock_client.return_value.__enter__.return_value.get.return_value = mock_response
+
+            result = fetcher.fetch_social_sentiment("AAPL")
+
+            assert isinstance(result, SocialSentimentData)
+            assert result.symbol == "AAPL"
+            assert len(result.reddit) == 2
+            assert len(result.twitter) == 1
+            assert result.reddit[0].mention == 100
+            assert result.reddit[0].score == 0.75
+
+    def test_uses_cache_on_second_call(self, fetcher, mock_social_response):
+        """Test that repeated fetches use cache."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_social_response
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.Client") as mock_client:
+            mock_client.return_value.__enter__.return_value.get.return_value = mock_response
+
+            fetcher.fetch_social_sentiment("AAPL")
+            fetcher.fetch_social_sentiment("AAPL")
+
+            # Should only call API once due to caching
+            assert mock_client.return_value.__enter__.return_value.get.call_count == 1
+
+    def test_respects_date_params(self, fetcher, mock_social_response):
+        """Test that date parameters are passed to API."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_social_response
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.Client") as mock_client:
+            mock_client.return_value.__enter__.return_value.get.return_value = mock_response
+
+            fetcher.fetch_social_sentiment("AAPL", from_date="2024-01-01", to_date="2024-01-31")
+
+            call_args = mock_client.return_value.__enter__.return_value.get.call_args
+            params = call_args[1]["params"]
+            assert params["from"] == "2024-01-01"
+            assert params["to"] == "2024-01-31"
+
+    def test_raises_without_api_key(self, tmp_path):
+        """Test that fetch raises ValueError without API key."""
+        with patch.dict("os.environ", {}, clear=True):
+            fetcher = FinnhubFetcher(cache_dir=str(tmp_path / "cache"))
+            with pytest.raises(ValueError, match="API key not configured"):
+                fetcher.fetch_social_sentiment("AAPL")
+
+    def test_retries_on_timeout(self, fetcher, mock_social_response):
+        """Test that timeout errors trigger retry."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_social_response
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.Client") as mock_client:
+            mock_get = mock_client.return_value.__enter__.return_value.get
+            mock_get.side_effect = [
+                httpx.TimeoutException("Timeout"),
+                mock_response,
+            ]
+
+            result = fetcher.fetch_social_sentiment("AAPL")
+
+            assert result.symbol == "AAPL"
+            assert mock_get.call_count == 2
+
+    def test_exhausts_retries(self, fetcher):
+        """Test that retries are exhausted after max attempts."""
+        with patch("httpx.Client") as mock_client:
+            mock_get = mock_client.return_value.__enter__.return_value.get
+            mock_get.side_effect = httpx.TimeoutException("Timeout")
+
+            with pytest.raises(httpx.TimeoutException):
+                fetcher.fetch_social_sentiment("AAPL")
+
+            # Should have retried 3 times
+            assert mock_get.call_count == 3
+
+
+class TestFetchSentimentIndicator:
+    """Tests for fetch_sentiment_indicator method."""
+
+    def test_returns_correct_data(self, fetcher, mock_indicator_response):
+        """Test fetch_sentiment_indicator returns correct data structure."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_indicator_response
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.Client") as mock_client:
+            mock_client.return_value.__enter__.return_value.get.return_value = mock_response
+
+            result = fetcher.fetch_sentiment_indicator("AAPL")
+
+            assert isinstance(result, NewsSentimentData)
+            assert result.symbol == "AAPL"
+            assert result.company_news_score == 0.72
+            assert result.buzz.articles_in_last_week == 42
+            assert result.sentiment.bullish_percent == 0.75
+
+    def test_uses_cache_on_second_call(self, fetcher, mock_indicator_response):
+        """Test that repeated fetches use cache."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_indicator_response
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.Client") as mock_client:
+            mock_client.return_value.__enter__.return_value.get.return_value = mock_response
+
+            fetcher.fetch_sentiment_indicator("AAPL")
+            fetcher.fetch_sentiment_indicator("AAPL")
+
+            assert mock_client.return_value.__enter__.return_value.get.call_count == 1
+
+    def test_raises_without_api_key(self, tmp_path):
+        """Test that fetch raises ValueError without API key."""
+        with patch.dict("os.environ", {}, clear=True):
+            fetcher = FinnhubFetcher(cache_dir=str(tmp_path / "cache"))
+            with pytest.raises(ValueError, match="API key not configured"):
+                fetcher.fetch_sentiment_indicator("AAPL")
+
+    def test_retries_on_connection_error(self, fetcher, mock_indicator_response):
+        """Test that connection errors trigger retry."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_indicator_response
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.Client") as mock_client:
+            mock_get = mock_client.return_value.__enter__.return_value.get
+            mock_get.side_effect = [
+                httpx.ConnectError("Connection failed"),
+                mock_response,
+            ]
+
+            result = fetcher.fetch_sentiment_indicator("AAPL")
+
+            assert result.symbol == "AAPL"
+            assert mock_get.call_count == 2
+
+
+class TestClearCache:
+    """Tests for clear_cache method."""
+
+    def test_cache_cleared_refetches(self, fetcher, mock_social_response):
+        """Test cache is cleared and re-fetches on next call."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_social_response
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.Client") as mock_client:
+            mock_client.return_value.__enter__.return_value.get.return_value = mock_response
+
+            fetcher.fetch_social_sentiment("AAPL")
+            fetcher.clear_cache()
+            fetcher.fetch_social_sentiment("AAPL")
+
+            assert mock_client.return_value.__enter__.return_value.get.call_count == 2


### PR DESCRIPTION
## Motivation

Add Finnhub API integration for social sentiment data (#68). Complements existing Reddit fetcher with aggregated sentiment metrics.

## Implementation information

- `FinnhubFetcher` class with 2 fetch methods:
  - `fetch_social_sentiment()` - Reddit/Twitter mentions and scores by time
  - `fetch_sentiment_indicator()` - news buzz, company/sector sentiment breakdown
- 6 Pydantic models for type-safe data
- 1hr cache TTL with diskcache
- 3 retries with exponential backoff (2-10s)
- 22 tests covering models, caching, retries, error handling

## Supporting documentation

Closes #68