### PR TITLE
fix(tools): add TOOL_NAME class attr to WebSearchTool

### DIFF
--- a/src/tools/websearch.py
+++ b/src/tools/websearch.py
@@ -11,6 +11,8 @@ BODY_TRUNCATE_LENGTH = 300
 class WebSearchTool(BaseTool):
     """Web search tool wrapper for LLM agents."""
 
+    TOOL_NAME = "web_search"
+
     def __init__(self, fetcher: WebSearchFetcher | None = None) -> None:
         """Initialize web search tool.
 


### PR DESCRIPTION
## Motivation

WebResearchAgent's tool executor was failing with `AttributeError: type object 'WebSearchTool' has no attribute 'TOOL_NAME'` during `/analyze` command execution. This blocked all web search functionality in trading analysis.

## Implementation information

Added `TOOL_NAME = "web_search"` class attribute to `WebSearchTool` class. The agent code at `web_researcher.py:136` expects this class attribute for tool name comparison in the executor callback, but the class only provided an instance property `name`.

## Supporting documentation

Error log: `~/.ai-casino/tui.log` showed repeated failures during technical analysis phase