### PR TITLE
feat: merge broker positions into daemon watchlist

### DIFF
--- a/src/daemon/runner.py
+++ b/src/daemon/runner.py
@@ -49,7 +49,7 @@ class DaemonRunner:
                 self.broker = AlpacaBroker(paper=True)
                 logger.info("Alpaca broker initialized for daemon")
             except Exception as e:
-                logger.warning(f"Failed to initialize broker: {e}")
+                logger.exception(f"Failed to initialize broker: {e}")
                 self.broker = None
         logger.info(f"DaemonRunner initialized with {config}")
 
@@ -79,30 +79,39 @@ class DaemonRunner:
         """Get watchlist merged with broker positions.
 
         Returns:
-            Deduplicated list combining config watchlist and broker positions
+            Deduplicated list combining config watchlist and broker positions.
+            Config order is preserved, new positions are appended alphabetically.
         """
-        base_watchlist = set(self.config.watchlist)
+        # Preserve config order - manual dedup to maintain insertion order
+        merged_watchlist = []
+        seen = set()
+
+        for symbol in self.config.watchlist:
+            if symbol not in seen:
+                merged_watchlist.append(symbol)
+                seen.add(symbol)
 
         if not self.broker:
             logger.debug("No broker configured, using config watchlist only")
-            return list(base_watchlist)
+            return merged_watchlist
 
         try:
             account_info = self.broker.get_account_info()
             position_symbols = set(account_info.positions.keys())
 
             if position_symbols:
-                merged = base_watchlist | position_symbols
-                added = position_symbols - base_watchlist
+                added = position_symbols - seen
                 if added:
                     logger.info(f"Merged {len(added)} positions into watchlist: {sorted(added)}")
-                return list(merged)
+                    # Append new positions in sorted order
+                    merged_watchlist.extend(sorted(added))
+                return merged_watchlist
 
             logger.debug("No positions to merge")
-            return list(base_watchlist)
+            return merged_watchlist
         except Exception as e:
             logger.warning(f"Failed to fetch positions for watchlist merge: {e}")
-            return list(base_watchlist)
+            return merged_watchlist
 
     async def _analyze_symbol(self, symbol: str) -> TradingWorkflowResult | None:
         """Analyze a single symbol.
@@ -138,14 +147,16 @@ class DaemonRunner:
             self.state.record_error(error_msg)
             return None
 
-    async def _analyze_watchlist(self) -> list[TradingWorkflowResult]:
-        """Analyze all symbols in watchlist (merged with positions).
+    async def _analyze_watchlist(self, watchlist: list[str]) -> list[TradingWorkflowResult]:
+        """Analyze all symbols in watchlist.
+
+        Args:
+            watchlist: List of symbols to analyze
 
         Returns:
             List of analysis results
         """
         results: list[TradingWorkflowResult] = []
-        watchlist = self._get_merged_watchlist()
         semaphore = asyncio.Semaphore(self.config.max_concurrent_analyses)
 
         async def analyze_with_limit(symbol: str) -> TradingWorkflowResult | None:
@@ -210,7 +221,7 @@ class DaemonRunner:
         logger.info(f"Starting analysis cycle for {len(watchlist)} symbols")
         console.print(f"\n[bold]Running analysis cycle...[/bold] ({datetime.now():%H:%M:%S})")  # noqa: DTZ005
 
-        results = await self._analyze_watchlist()
+        results = await self._analyze_watchlist(watchlist)
         self._log_results(results)
 
         self.state.save(self.config.state.state_file)

--- a/tests/test_daemon/test_runner.py
+++ b/tests/test_daemon/test_runner.py
@@ -16,17 +16,15 @@ def sample_config(tmp_path: Path) -> DaemonConfig:
     """Create sample daemon config."""
     config_dict = {
         "watchlist": ["TSLA", "MSFT"],
+        "interval_minutes": 30,
+        "market_hours_only": True,
+        "auto_trade": False,
+        "max_concurrent_analyses": 5,
         "schedule": {
             "start_time": "09:30",
             "end_time": "16:00",
             "timezone": "America/New_York",
             "enable_pre_market": False,
-        },
-        "trading": {
-            "interval_minutes": 30,
-            "market_hours_only": True,
-            "auto_trade": False,
-            "max_concurrent_analyses": 5,
         },
         "state": {
             "state_file": str(tmp_path / "daemon_state.json"),
@@ -179,7 +177,9 @@ async def test_analyze_watchlist_uses_merged(
 
     monkeypatch.setattr(runner, "_analyze_symbol", mock_analyze)
 
-    await runner._analyze_watchlist()
+    # Get merged watchlist and pass it to _analyze_watchlist
+    merged = runner._get_merged_watchlist()
+    await runner._analyze_watchlist(merged)
 
     # Should analyze merged watchlist: TSLA, MSFT from config + AAPL, NVDA from positions
     assert set(analyzed_symbols) == {"TSLA", "MSFT", "AAPL", "NVDA"}


### PR DESCRIPTION
## Motivation

Daemon watchlist is static (config-only). Open positions aren't monitored for exit signals unless manually added to config, causing missed opportunities and lack of risk oversight.

## Implementation information

**Core changes:**
- Initialize `AlpacaBroker` in `DaemonRunner.__init__` when credentials present
- Add `_get_merged_watchlist()` helper that deduplicates config watchlist + broker positions
- Integrate merged watchlist in `_analyze_watchlist()` and `_run_cycle()`
- Pass broker to `TradingWorkflow` for position-aware analysis

**Error handling:**
- No credentials → `broker=None` → config-only watchlist
- Broker init fails → log warning, fallback to config-only
- `get_account_info()` fails → catch exception, fallback to config-only
- Empty positions → config-only, no merge needed

**Alternatives considered:**
- Rejected: Modifying config file dynamically (persistence issues, race conditions)
- Rejected: Separate position monitoring loop (complexity, duplication)
- Chosen: Runtime merge each cycle (simple, no state management, graceful degradation)

**Performance:**
+1 API call per cycle (~100-200ms), negligible for 30min default interval

## Supporting documentation

Closes #146
Related: #190 (Active Position Management umbrella)
Related: #184 (Future: position management UI)