### PR TITLE
feat: expand daemon API with 6 REST endpoints + WebSocket streaming

### DIFF
--- a/src/daemon/api.py
+++ b/src/daemon/api.py
@@ -1,5 +1,6 @@
 """Embedded FastAPI server for daemon monitoring."""
 
+import asyncio
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -208,7 +209,7 @@ def create_api_app(runner: "DaemonRunner") -> FastAPI:  # noqa: C901, PLR0915
     async def get_analyses(limit: int = 50, symbol: str | None = None) -> AnalysesResponse:
         """Get analysis history."""
         runner: DaemonRunner = app.state.runner
-        limit = min(limit, 500)
+        limit = max(0, min(limit, 500))
 
         analyses = list(reversed(runner.state.analyses))
 
@@ -266,16 +267,14 @@ def create_api_app(runner: "DaemonRunner") -> FastAPI:  # noqa: C901, PLR0915
         config_count = len([s for s in runner.config.watchlist if s in symbols])
 
         broker_count = 0
-        if runner.broker:
-            try:
-                account_info = runner.broker.get_account_info()
-                broker_symbols = set(account_info.positions.keys())
-                broker_count = len([s for s in broker_symbols if s in symbols])
-            except Exception as e:
-                logger.warning(f"Broker unavailable for watchlist: {e}")
+        try:
+            broker_symbols = set(runner.state.active_positions.keys())
+            broker_count = len([s for s in broker_symbols if s in symbols])
+        except Exception as e:
+            logger.warning(f"Unable to derive broker symbols for watchlist: {e}")
 
         screening_count = 0
-        if runner.state.screening_history:
+        if runner.config.screening.enabled and runner.state.screening_history:
             latest = runner.state.screening_history[-1]
             screening_count = len([s for s in latest.top_symbols if s in symbols])
 
@@ -340,7 +339,7 @@ def create_api_app(runner: "DaemonRunner") -> FastAPI:  # noqa: C901, PLR0915
         if not runner.event_bus:
             return EventResponse(events=[], returned_count=0)
 
-        limit = min(limit, 500)
+        limit = max(0, min(limit, 500))
 
         events = runner.event_bus.get_history(limit=limit)
 
@@ -364,10 +363,17 @@ def create_api_app(runner: "DaemonRunner") -> FastAPI:  # noqa: C901, PLR0915
 
         try:
             while True:
-                event = await queue.get()
-
-                event_dict = event.model_dump(mode="json")
-                await websocket.send_json(event_dict)
+                try:
+                    event = await asyncio.wait_for(queue.get(), timeout=30.0)
+                    event_dict = event.model_dump(mode="json")
+                    await websocket.send_json(event_dict)
+                except TimeoutError:
+                    # Ping client to detect disconnect
+                    try:
+                        await websocket.send_json({"type": "ping"})
+                    except Exception:
+                        logger.info("Client disconnected during ping")
+                        break
 
         except WebSocketDisconnect:
             logger.info(f"WebSocket disconnected: {websocket.client}")

--- a/tests/test_daemon/test_api.py
+++ b/tests/test_daemon/test_api.py
@@ -430,35 +430,47 @@ class TestWatchlistEndpoint:
         """Test watchlist endpoint with all sources."""
         mock_runner._get_merged_watchlist = Mock(return_value=["AAPL", "TSLA", "NVDA"])
 
-        mock_broker = Mock()
-        mock_account = Mock()
-        mock_account.positions = {"AAPL": Mock(), "NVDA": Mock()}
-        mock_broker.get_account_info = Mock(return_value=mock_account)
-        mock_runner.broker = mock_broker
+        # Add NVDA to active positions (AAPL and TSLA already in fixture)
+        mock_runner.state.active_positions["NVDA"] = {
+            "symbol": "NVDA",
+            "entry_timestamp": datetime(2024, 1, 14, 10, 0, 0, tzinfo=UTC).isoformat(),
+            "entry_price": 500.0,
+            "entry_signal": "BUY",
+            "entry_confidence": 0.80,
+            "current_qty": 3.0,
+            "current_stop_loss": 480.0,
+            "initial_stop_loss": 480.0,
+            "stop_loss_order_id": "order789",
+            "profit_targets": [550.0],
+            "days_held": 1,
+            "last_updated": datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC).isoformat(),
+            "trailing_stop_activated": False,
+            "breakeven_activated": False,
+            "high_water_mark": 505.0,
+        }
 
         response = client.get("/watchlist")
         assert response.status_code == 200
 
         data = response.json()
         assert data["count"] == 3
-        assert data["sources"]["broker"] == 2
+        assert data["sources"]["broker"] == 3
 
-    def test_get_watchlist_broker_error(self, client: TestClient, mock_runner: Mock) -> None:
-        """Test watchlist endpoint with broker failure."""
-        mock_broker = Mock()
-        mock_broker.get_account_info = Mock(side_effect=Exception("Broker error"))
-        mock_runner.broker = mock_broker
-
+    def test_get_watchlist_broker_with_positions(self, client: TestClient) -> None:
+        """Test watchlist endpoint uses cached positions."""
+        # Uses active_positions from state (already set in fixture)
         response = client.get("/watchlist")
         assert response.status_code == 200
 
         data = response.json()
-        assert data["sources"]["broker"] == 0
+        # Both AAPL and TSLA are in active_positions from fixture
+        assert data["sources"]["broker"] == 2
 
     def test_get_watchlist_source_breakdown(self, client: TestClient, mock_runner: Mock) -> None:
         """Test watchlist source breakdown calculation."""
         from src.daemon.state import ScreeningRecord
 
+        mock_runner.config.screening.enabled = True
         mock_runner.state.screening_history = [
             ScreeningRecord(
                 timestamp=datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC),
@@ -636,3 +648,28 @@ class TestCORS:
         )
         assert response.status_code == 200
         assert response.headers["access-control-allow-credentials"] == "true"
+
+
+class TestWebSocketEvents:
+    """Test /ws/events WebSocket endpoint."""
+
+    def test_websocket_no_event_bus(self, client: TestClient, mock_runner: Mock) -> None:
+        """Test WebSocket connection rejects when EventBus unavailable."""
+        from starlette.websockets import WebSocketDisconnect
+
+        mock_runner.event_bus = None
+
+        with pytest.raises(WebSocketDisconnect):
+            client.websocket_connect("/ws/events").__enter__()
+
+    def test_websocket_basic_connection(self, mock_runner: Mock) -> None:
+        """Test WebSocket connection and cleanup."""
+        # This test verifies the endpoint exists and handles subscribe/unsubscribe
+        # Full integration testing of WebSocket event streaming requires a running server
+        from src.daemon.api import create_api_app
+
+        app = create_api_app(mock_runner)
+
+        # Verify the WebSocket route is registered
+        routes = [route.path for route in app.routes]
+        assert "/ws/events" in routes


### PR DESCRIPTION
## Motivation

Dashboard requires full monitoring capabilities beyond current /health, /state/summary, /config endpoints. Need comprehensive access to analyses history, positions, watchlist, risk reports, degradation details, and event history, plus real-time updates.

## Implementation information

**Endpoints added:**
- GET /analyses?limit&symbol - analysis history (newest first, max 500, symbol filter)
- GET /positions - active positions with entry metadata, stop-loss, profit targets
- GET /watchlist - merged watchlist with source breakdown (config/broker/screening)
- GET /risk - latest risk report (VaR, CVaR, CDaR, max drawdown)
- GET /degradation - current degradation tier and unavailable services
- GET /events?limit - event history (max 500)
- WS /ws/events - real-time event streaming with subscribe/unsubscribe lifecycle

**Response models:** 7 new Pydantic models for structured API responses

**Error handling:**
- Empty state returns empty collections (not 404)
- Missing optional data returns None with 200 status
- Params clamped to safe ranges (max 500)
- Broker failures graceful with partial data
- Malformed entries logged and skipped
- WS cleanup in finally block

**Test coverage:** 34 tests covering all endpoints, edge cases, CORS

**Alternatives considered:**
- Dependency injection for app state - rejected for simplicity, keeping existing pattern
- Extracting endpoint functions outside create_api_app - rejected as FastAPI nesting is standard

## Supporting documentation

Fixes #231