### PR TITLE
chore: repurpose mise dev task to start daemon

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -41,9 +41,9 @@ description = "Check if Ollama is running"
 run = "pgrep -f 'ollama serve' && echo 'Ollama is running' || echo 'Ollama is not running'"
 
 [tasks.dev]
-description = "Run analysis with meta-agent (dynamic strategy selection)"
-usage = 'arg "<symbol>" help="Stock ticker" default="AAPL"'
-run = "uv run python -m src.main analyze ${usage_symbol?}"
+description = "Run autonomous trading daemon"
+usage = 'option "-c --config" help="Config file path"'
+run = "uv run python -m src.main daemon ${usage_config:+--config \"$usage_config\"}"
 env = { LLM_PROVIDER = "ollama", LLM_MODEL = "qwen3:14b" }
 
 [tasks."dev:momentum"]


### PR DESCRIPTION
## Motivation

Streamline development workflow by making `mise dev` start the daemon instead of running single analysis.

## Implementation information

Updated `.mise.toml` to repurpose `mise dev` task:
- **Before**: Single analysis with meta-agent (`analyze` command)
- **After**: Start daemon with optional config (`daemon` command)

Single-shot analysis still available via `mise dev:momentum`.

## Supporting documentation

N/A - Developer workflow improvement