### PR TITLE
fix: enable dashboard in mise dev with daemon API

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -41,9 +41,16 @@ description = "Check if Ollama is running"
 run = "pgrep -f 'ollama serve' && echo 'Ollama is running' || echo 'Ollama is not running'"
 
 [tasks.dev]
-description = "Run autonomous trading daemon"
-usage = 'option "-c --config" help="Config file path"'
-run = "uv run python -m src.main daemon ${usage_config:+--config \"$usage_config\"}"
+description = "Run daemon with dashboard (API enabled)"
+run = """
+  trap 'pkill -P $$' EXIT
+  uv run python -m src.main daemon --config daemon-dev.toml &
+  DAEMON_PID=$!
+  echo "Daemon started (PID: $DAEMON_PID)"
+  sleep 3
+  echo "Starting dashboard at http://localhost:8050"
+  uv run python -m src.main dashboard --api-url http://127.0.0.1:8484
+"""
 env = { LLM_PROVIDER = "ollama", LLM_MODEL = "qwen3:14b" }
 
 [tasks."dev:momentum"]
@@ -54,8 +61,7 @@ env = { LLM_PROVIDER = "ollama", LLM_MODEL = "qwen3:14b" }
 
 [tasks.daemon]
 description = "Run autonomous trading daemon"
-usage = 'option "-c --config" help="Config file path"'
-run = "uv run python -m src.main daemon ${usage_config:+--config \"$usage_config\"}"
+run = "uv run python -m src.main daemon"
 env = { LLM_PROVIDER = "ollama", LLM_MODEL = "qwen3:14b" }
 
 [tasks.chat]

--- a/daemon-dev.toml
+++ b/daemon-dev.toml
@@ -1,0 +1,12 @@
+# Development daemon configuration with API enabled
+[daemon]
+watchlist = ["AAPL", "TSLA", "GOOGL", "MSFT"]
+interval_minutes = 30
+market_hours_only = true
+auto_trade = false
+max_concurrent_analyses = 3
+
+[daemon.api]
+enabled = true
+host = "127.0.0.1"
+port = 8484

--- a/src/cli/dashboard.py
+++ b/src/cli/dashboard.py
@@ -82,7 +82,7 @@ def dashboard(
         console.print()
 
         try:
-            app.run_server(host=config.host, port=config.port, debug=debug)
+            app.run(host=config.host, port=config.port, debug=debug)
         finally:
             app.api_client.close()
 


### PR DESCRIPTION
## Motivation

The `mise dev` task was failing with "Invalid usage config" error and didn't provide an easy way to run the daemon with dashboard for development.

## Implementation information

**Fixed issues:**
- Removed invalid `usage` config syntax from `[tasks.dev]` and `[tasks.daemon]` in `.mise.toml`
- Updated deprecated `app.run_server()` to `app.run()` in dashboard code (Dash 6.x requirement)

**Enhanced development workflow:**
- Created `daemon-dev.toml` config with daemon API enabled
- Modified `mise dev` to run both daemon (background) and dashboard (foreground)
- Daemon API exposed on http://127.0.0.1:8484
- Dashboard GUI accessible at http://127.0.0.1:8050

**Usage:**
```bash
mise dev  # Starts both services
```

Ctrl+C stops both cleanly via trap signal handling.

## Supporting documentation

Fixes issues discovered while setting up development environment.