### PR TITLE
Standardize prompt loader naming to self._prompts

### DIFF
--- a/src/agents/bearish_researcher.py
+++ b/src/agents/bearish_researcher.py
@@ -55,7 +55,7 @@ class BearishResearcher:
             llm_client: LLM client for generating bear thesis
         """
         self.llm = llm_client
-        self.prompts = PromptLoader("bearish_researcher")
+        self._prompts = PromptLoader("bearish_researcher")
         logger.info("Initialized BearishResearcher")
 
     async def analyze(
@@ -88,8 +88,8 @@ class BearishResearcher:
             symbol, technical, sentiment, news, fundamental, comparative, trump_analysis
         )
 
-        system_prompt = self.prompts.load("system")
-        user_prompt = self.prompts.load("user", **prompt_vars)
+        system_prompt = self._prompts.load("system")
+        user_prompt = self._prompts.load("user", **prompt_vars)
 
         try:
             llm_response = await self.llm.astructured(

--- a/src/agents/comparative.py
+++ b/src/agents/comparative.py
@@ -61,7 +61,7 @@ class ComparativeAnalyst:
         """
         self.llm = llm_client
         self.fetcher = fetcher
-        self.prompt_loader = PromptLoader("comparative")
+        self._prompts = PromptLoader("comparative")
         logger.info("Initialized ComparativeAnalyst")
 
     async def analyze(self, symbol: str) -> ComparativeAnalysis:
@@ -80,7 +80,7 @@ class ComparativeAnalyst:
             metrics = self._calculate_relative_metrics(data)
             valuation = self._assess_relative_valuation(data, metrics)
 
-            system = self.prompt_loader.load("system")
+            system = self._prompts.load("system")
             user_prompt = self._build_analysis_prompt(symbol, data, metrics, valuation)
 
             interpretation = await self.llm.acomplete(user_prompt, system=system, temperature=0.5)
@@ -228,7 +228,7 @@ class ComparativeAnalyst:
             sign = "+" if metrics["perf_vs_market_ytd"] >= 0 else ""
             performance_parts.append(f"vs Market YTD: {sign}{metrics['perf_vs_market_ytd']:.1f}%")
 
-        return self.prompt_loader.load(
+        return self._prompts.load(
             "user",
             symbol=symbol,
             sector_etf=data.sector_etf,

--- a/src/agents/web_researcher.py
+++ b/src/agents/web_researcher.py
@@ -69,7 +69,7 @@ class WebResearchAgent:
         """
         self.llm = llm_client
         self.search_tool = search_tool or WebSearchTool()
-        self.prompts = PromptLoader("web_researcher")
+        self._prompts = PromptLoader("web_researcher")
         logger.info(f"Initialized WebResearchAgent (tools_enabled={llm_client.supports_tools})")
 
     async def research(
@@ -152,7 +152,7 @@ class WebResearchAgent:
             WebResearchResult
         """
         prompt = self._build_tool_prompt(symbol, category)
-        system = self.prompts.load("system")
+        system = self._prompts.load("system")
         tools = [self.search_tool.get_tool_definition()]
 
         def tool_executor(name: str, args: dict) -> str:
@@ -219,11 +219,11 @@ class WebResearchAgent:
 
         search_results = self.search_tool.execute(query, search_type=search_type, max_results=5)
 
-        prompt = self.prompts.load(
+        prompt = self._prompts.load(
             "user_template", symbol=symbol, category=category.value, search_results=search_results
         )
 
-        system = self.prompts.load("system_template")
+        system = self._prompts.load("system_template")
         response = await self.llm.acomplete(prompt, system=system, temperature=0.3)
 
         return self._parse_research_response(category, response, sources_count=5)
@@ -245,7 +245,7 @@ class WebResearchAgent:
             ResearchCategory.COMPETITOR_ANALYSIS: "tool_competitor_analysis",
         }
 
-        return self.prompts.load(prompt_map[category], symbol=symbol)
+        return self._prompts.load(prompt_map[category], symbol=symbol)
 
     def _parse_research_response(
         self,

--- a/tests/test_agents/test_bearish_researcher.py
+++ b/tests/test_agents/test_bearish_researcher.py
@@ -168,7 +168,7 @@ class TestBearishResearcher:
             sample_news_analysis,
             sample_fundamental_analysis,
         )
-        prompt = bearish_researcher.prompts.load("user", **prompt_vars)
+        prompt = bearish_researcher._prompts.load("user", **prompt_vars)
 
         assert "AAPL" in prompt
         assert "TECHNICAL:" in prompt
@@ -505,7 +505,7 @@ class TestBearishResearcher:
             sample_news_analysis,
             None,
         )
-        prompt = bearish_researcher.prompts.load("user", **prompt_vars)
+        prompt = bearish_researcher._prompts.load("user", **prompt_vars)
 
         assert "N/A (API rate limited)" in prompt
 


### PR DESCRIPTION
## Motivation

Naming inconsistency across agent classes: 14/16 agents used `self._prompts` (private convention), while 2 used `self.prompts` (public) and 1 used `self.prompt_loader`. This inconsistency makes the codebase harder to maintain and violates the established pattern.

## Implementation information

Renamed prompt loader attributes to `self._prompts` in three files:
- `bearish_researcher.py`: `self.prompts` → `self._prompts`
- `web_researcher.py`: `self.prompts` → `self._prompts`
- `comparative.py`: `self.prompt_loader` → `self._prompts`

Updated test file to use the new private attribute name. No behavioral changes - purely structural refactoring for consistency.

## Supporting documentation

Closes #266