### PR TITLE
chore: pin PyYAML to exact version 6.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "rich==14.3.2",
     "loguru==0.7.3",
     "pydantic==2.12.5",
-    "pyyaml>=6.0.2",
+    "pyyaml==6.0.2",
     # API Server
     "fastapi==0.128.5",
     "uvicorn[standard]==0.40.0",


### PR DESCRIPTION
## Motivation

Prevent future major version breaking daemon config YAML parsing. Current loose constraint `pyyaml>=6.0.2` has no upper bound - future major version could introduce breaking changes.

## Implementation information

Changed `pyyaml>=6.0.2` to `pyyaml==6.0.2` in pyproject.toml to match pinning pattern used by all other dependencies (pydantic==2.12.5, rich==14.3.2, etc.).

## Supporting documentation

N/A - routine dependency pinning