### PR TITLE
fix: replace stub code with NotImplementedError in signal_tracker

### DIFF
--- a/src/daemon/signal_tracker.py
+++ b/src/daemon/signal_tracker.py
@@ -145,16 +145,28 @@ class SignalOutcomeTracker:
             # Query historical order fills for symbols with signals
             symbols = {s["symbol"] for s in signals}
 
-            for _symbol in symbols:
-                # Check if position was closed for this symbol
-                # This is simplified - full implementation would match signal timestamps
-                # to specific trade sequences in order_fills table
-                pass
+            # TODO: Match signal timestamps to specific trade sequences in order_fills table
+            # to detect early exits and populate exit_prices dict
+            self._raise_not_implemented(len(symbols))
 
+        except NotImplementedError:
+            raise
         except Exception as e:
             logger.warning(f"Failed to check early exits: {e}")
 
         return exit_prices
+
+    def _raise_not_implemented(self, symbol_count: int) -> None:
+        """Raise NotImplementedError for early exit detection.
+
+        Args:
+            symbol_count: Number of symbols being processed
+        """
+        msg = (
+            "Early exit detection not implemented - requires matching signals "
+            f"to closed positions in order_fills for {symbol_count} symbols"
+        )
+        raise NotImplementedError(msg)
 
     def __repr__(self) -> str:
         """Return string representation."""


### PR DESCRIPTION
## Motivation

The `_get_early_exits()` method in `SignalOutcomeTracker` had a loop body with only a `pass` statement and a comment about future implementation. This silent no-op makes it unclear that the functionality is intentionally not implemented yet.

## Implementation information

Replaced the `pass` statement with an explicit `NotImplementedError` that:
- Clearly indicates this is intentional, not forgotten code
- Provides a descriptive message explaining what needs to be implemented (matching signal timestamps to closed positions in order_fills table)
- Follows ruff linter rules:
  - Extracted raise to inner function `_raise_not_implemented()` (TRY301)
  - Pre-assigned f-string to variable before exception (EM102)

The method already handles the NotImplementedError by re-raising it, while catching other exceptions with a warning log.

## Supporting documentation

Code cleanup - addresses stub code at src/daemon/signal_tracker.py:148-152