### PR TITLE
chore: remove deprecated run_analysis_in_process API

### DIFF
--- a/src/tui/commands.py
+++ b/src/tui/commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -14,6 +15,71 @@ if TYPE_CHECKING:
 
 ProgressCallback = Callable[[str, str, str], None]
 CancelledCallback = Callable[[], bool]
+
+
+async def _run_analysis_async(
+    symbol: str,
+    period_days: int = 90,
+    progress_callback: ProgressCallback | None = None,
+    is_cancelled: CancelledCallback | None = None,
+) -> dict:
+    """Run analysis using callback-based API with async/await interface.
+
+    Args:
+        symbol: Stock symbol
+        period_days: Number of days of data to fetch
+        progress_callback: Progress callback
+        is_cancelled: Cancellation check callback
+
+    Returns:
+        Analysis result dict
+
+    Raises:
+        asyncio.CancelledError: If analysis was cancelled
+        RuntimeError: If analysis failed
+    """
+    from src.tui.worker import start_analysis
+
+    result_holder: dict = {}
+    error_holder: list[str] = []
+    done_event = asyncio.Event()
+
+    def on_result(result: dict) -> None:
+        result_holder["data"] = result
+        done_event.set()
+
+    def on_error(error: str) -> None:
+        error_holder.append(error)
+        done_event.set()
+
+    def progress_with_cancel_check(step_id: str, status: str, detail: str) -> None:
+        if progress_callback:
+            progress_callback(step_id, status, detail)
+
+    start_analysis(
+        symbol=symbol,
+        period_days=period_days,
+        progress_callback=progress_with_cancel_check,
+        result_callback=on_result,
+        error_callback=on_error,
+    )
+
+    # Wait for completion with cancellation checks
+    while not done_event.is_set():
+        if is_cancelled and is_cancelled():
+            from src.tui.worker import cancel_analysis
+
+            cancel_analysis(symbol)
+            msg = "Analysis cancelled by user"
+            raise asyncio.CancelledError(msg)
+        await asyncio.sleep(0.1)
+
+    if error_holder:
+        if "cancelled" in error_holder[0].lower():
+            raise asyncio.CancelledError(error_holder[0])
+        raise RuntimeError(error_holder[0])
+
+    return result_holder["data"]
 
 
 @dataclass
@@ -169,9 +235,7 @@ Type freely to chat about markets or ask questions."""
 
         symbol = args[0].upper()
 
-        from src.tui.worker import run_analysis_in_process
-
-        result_dict = await run_analysis_in_process(
+        result_dict = await _run_analysis_async(
             symbol, period_days=90, progress_callback=progress_callback, is_cancelled=is_cancelled
         )
         from src.workflows.types import TradingWorkflowResult
@@ -196,9 +260,8 @@ Type freely to chat about markets or ask questions."""
             return CommandResult(success=False, message="Usage: /technical SYMBOL")
 
         symbol = args[0].upper()
-        from src.tui.worker import run_analysis_in_process
 
-        result_dict = await run_analysis_in_process(
+        result_dict = await _run_analysis_async(
             symbol,
             period_days=90,
             progress_callback=progress_callback,
@@ -225,9 +288,8 @@ Type freely to chat about markets or ask questions."""
             return CommandResult(success=False, message="Usage: /sentiment SYMBOL")
 
         symbol = args[0].upper()
-        from src.tui.worker import run_analysis_in_process
 
-        result_dict = await run_analysis_in_process(
+        result_dict = await _run_analysis_async(
             symbol,
             period_days=90,
             progress_callback=progress_callback,
@@ -254,9 +316,8 @@ Type freely to chat about markets or ask questions."""
             return CommandResult(success=False, message="Usage: /news SYMBOL")
 
         symbol = args[0].upper()
-        from src.tui.worker import run_analysis_in_process
 
-        result_dict = await run_analysis_in_process(
+        result_dict = await _run_analysis_async(
             symbol,
             period_days=90,
             progress_callback=progress_callback,

--- a/src/tui/worker.py
+++ b/src/tui/worker.py
@@ -360,68 +360,6 @@ def is_analysis_running(symbol: str) -> bool:
     return job is not None and job.thread.is_alive()
 
 
-# --- Legacy API (for backwards compatibility) ---
-
-
-async def run_analysis_in_process(
-    symbol: str,
-    period_days: int = 90,
-    progress_callback: ProgressCallback | None = None,
-    is_cancelled: Callable[[], bool] | None = None,
-) -> dict:
-    """Run analysis in isolated thread (legacy async API).
-
-    DEPRECATED: Use start_analysis() for fire-and-forget pattern.
-    """
-    result_holder: dict = {}
-    error_holder: list[str] = []
-    done_event = threading.Event()
-    cancelled_event = threading.Event()
-
-    def on_result(result: dict) -> None:
-        result_holder["data"] = result
-        done_event.set()
-
-    def on_error(error: str) -> None:
-        error_holder.append(error)
-        done_event.set()
-
-    def progress_with_cancel_check(step_id: str, status: str, detail: str) -> None:
-        if is_cancelled and is_cancelled():
-            cancelled_event.set()
-        if progress_callback:
-            progress_callback(step_id, status, detail)
-
-    params = AnalysisParams(
-        symbol=_validate_symbol(symbol),
-        period_days=period_days,
-        progress_callback=progress_with_cancel_check,
-        result_callback=on_result,
-        error_callback=on_error,
-        cancelled_event=cancelled_event,
-    )
-
-    thread = threading.Thread(
-        target=_analysis_thread_target,
-        args=(params,),
-        name=f"analysis-{params.symbol}",
-        daemon=True,
-    )
-    thread.start()
-
-    while not done_event.is_set():
-        await asyncio.sleep(0.1)
-        if is_cancelled and is_cancelled():
-            cancelled_event.set()
-
-    if error_holder:
-        if "cancelled" in error_holder[0].lower():
-            raise asyncio.CancelledError(error_holder[0])
-        raise RuntimeError(error_holder[0])
-
-    return result_holder["data"]
-
-
 async def _run_screening_async(params: ScreeningParams) -> dict:
     """Internal async function that runs in isolated thread's event loop."""
     from src.tui.log_capture import clear_active_step

--- a/tests/test_tui/test_commands.py
+++ b/tests/test_tui/test_commands.py
@@ -127,10 +127,10 @@ class TestCancellationCallback:
     """Tests for cancellation callback propagation."""
 
     async def test_execute_analyze_passes_is_cancelled(self, monkeypatch):
-        """is_cancelled callback is passed to run_analysis_in_process."""
+        """is_cancelled callback is passed to _run_analysis_async."""
         import asyncio
 
-        from src.tui import worker
+        from src.tui import commands
 
         captured_is_cancelled = None
 
@@ -164,7 +164,7 @@ class TestCancellationCallback:
                 "news": {"key_themes": [], "impact_assessment": "", "recommendation": ""},
             }
 
-        monkeypatch.setattr(worker, "run_analysis_in_process", mock_run_analysis)
+        monkeypatch.setattr(commands, "_run_analysis_async", mock_run_analysis)
 
         handler = CommandHandler()
 
@@ -179,14 +179,14 @@ class TestCancellationCallback:
         """is_cancelled=True raises CancelledError."""
         import asyncio
 
-        from src.tui import worker
+        from src.tui import commands
 
         async def mock_run_analysis(symbol, period_days=90, progress_callback=None, is_cancelled=None):
             if is_cancelled and is_cancelled():
                 raise asyncio.CancelledError
             pytest.fail("Should have been cancelled")
 
-        monkeypatch.setattr(worker, "run_analysis_in_process", mock_run_analysis)
+        monkeypatch.setattr(commands, "_run_analysis_async", mock_run_analysis)
 
         handler = CommandHandler()
 


### PR DESCRIPTION
## Motivation

Remove deprecated `run_analysis_in_process` API that was marked for removal in favor of fire-and-forget pattern with `start_analysis()`.

## Implementation information

- Created `_run_analysis_async()` in commands.py as async wrapper around callback-based `start_analysis()` API
- Uses `asyncio.Event` instead of `threading.Event` for cleaner async code
- Replaced all 4 callers in commands.py (`_cmd_analyze`, `_cmd_technical`, `_cmd_sentiment`, `_cmd_news`)
- Updated tests to mock `_run_analysis_async` instead of `run_analysis_in_process`
- Deleted deprecated function and "Legacy API" section from worker.py

**Alternative considered:** Direct fire-and-forget with callbacks - rejected because commands need synchronous result returns

## Supporting documentation

Related to cleanup effort. No issue filed.