### PR TITLE
fix: use context manager for stderr log file in chat TUI

### DIFF
--- a/src/cli/chat.py
+++ b/src/cli/chat.py
@@ -1,5 +1,6 @@
 """Chat subcommand for TUI mode."""
 
+import contextlib
 import logging
 import sys
 from pathlib import Path
@@ -42,23 +43,23 @@ def chat() -> None:
 
     # Redirect stderr to log file to catch library output
     stderr_backup = sys.stderr
-    log_file_handle = open(log_file, "a", encoding="utf-8")  # noqa: SIM115, PTH123
-    sys.stderr = log_file_handle
 
-    try:
-        # NOTE: nest_asyncio removed - breaks Python 3.14 + anyio/httpcore
-        # Textual handles its own event loop
+    with contextlib.ExitStack() as stack:
+        log_file_handle = stack.enter_context(log_file.open("a", encoding="utf-8"))
+        sys.stderr = log_file_handle
 
-        from src.tui.app import TradingChatApp
+        try:
+            # NOTE: nest_asyncio removed - breaks Python 3.14 + anyio/httpcore
+            # Textual handles its own event loop
 
-        app = TradingChatApp()
-        app.run()
-    except Exception as e:
-        typer.echo(f"TUI error: {e}")
-        logger.exception("TUI failed")
-        raise typer.Exit(1) from e
-    finally:
-        # Always restore stderr before closing to avoid corrupted file object
-        if sys.stderr != stderr_backup:
+            from src.tui.app import TradingChatApp
+
+            app = TradingChatApp()
+            app.run()
+        except Exception as e:
+            typer.echo(f"TUI error: {e}")
+            logger.exception("TUI failed")
+            raise typer.Exit(1) from e
+        finally:
+            # Restore stderr before ExitStack closes file
             sys.stderr = stderr_backup
-            log_file_handle.close()


### PR DESCRIPTION
## Motivation

Fixes linter violations SIM115 (open without context manager) and PTH123 (use pathlib for file operations) in `src/cli/chat.py:45`. Code was using bare `open()` with manual close in finally block.

## Implementation information

- Wrapped file handling in `contextlib.ExitStack()` context manager
- Replaced `open(log_file)` with `log_file.open()` (pathlib method)
- Maintains same behavior: stderr redirected during TUI execution, restored in finally before file closes
- ExitStack allows proper resource management while keeping file open for entire app lifecycle

## Supporting documentation

Related to code quality improvements and ruff linter compliance.