### PR TITLE
refactor: consolidate HTTP clients from requests to httpx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     # Market Data
     "yfinance==1.1.0",
     "alpha-vantage==3.0.0",
-    "requests==2.32.5",
     # Trading
     "alpaca-py==0.43.2",
     "backtesting==0.6.5",
@@ -45,7 +44,7 @@ dependencies = [
     "rich==14.3.2",
     "loguru==0.7.3",
     "pydantic==2.12.5",
-    "pyyaml==6.0.3",
+    "pyyaml==6.0.2",
     # API Server
     "fastapi==0.128.5",
     "uvicorn[standard]==0.40.0",

--- a/src/data/news.py
+++ b/src/data/news.py
@@ -3,7 +3,7 @@
 import os
 from datetime import datetime
 
-import requests
+import httpx
 from dotenv import load_dotenv
 from loguru import logger
 from pydantic import BaseModel
@@ -19,9 +19,9 @@ HTTP_RETRY = retry(
     wait=wait_exponential(multiplier=1, min=2, max=10),
     retry=retry_if_exception_type(
         (
-            requests.exceptions.ReadTimeout,
-            requests.exceptions.ConnectionError,
-            requests.exceptions.Timeout,
+            httpx.ReadTimeout,
+            httpx.ConnectError,
+            httpx.TimeoutException,
         )
     ),
     reraise=True,
@@ -91,33 +91,34 @@ class NewsFetcher:
 
         with timed_operation("news_fetch", source="marketaux"):
             try:
-                response = requests.get(self.BASE_URL, params=params, timeout=30)
-                response.raise_for_status()
+                with httpx.Client(timeout=30.0) as client:
+                    response = client.get(self.BASE_URL, params=params)
+                    response.raise_for_status()
 
-                data = response.json()
-                articles = []
+                    data = response.json()
+                    articles = []
 
-                for item in data.get("data", []):
-                    articles.append(
-                        NewsArticle(
-                            title=item.get("title", ""),
-                            description=item.get("description", ""),
-                            url=item.get("url", ""),
-                            published_at=datetime.fromisoformat(
-                                item.get("published_at", "").replace("Z", "+00:00")
-                            ),
-                            source=item.get("source", ""),
+                    for item in data.get("data", []):
+                        articles.append(
+                            NewsArticle(
+                                title=item.get("title", ""),
+                                description=item.get("description", ""),
+                                url=item.get("url", ""),
+                                published_at=datetime.fromisoformat(
+                                    item.get("published_at", "").replace("Z", "+00:00")
+                                ),
+                                source=item.get("source", ""),
+                            )
                         )
-                    )
 
-                logger.info(f"Fetched {len(articles)} articles")
+                    logger.info(f"Fetched {len(articles)} articles")
 
-                if self._cache and articles:
-                    self._cache.store_news_articles(symbol, articles)
+                    if self._cache and articles:
+                        self._cache.store_news_articles(symbol, articles)
 
-                return articles
+                    return articles
 
-            except requests.exceptions.RequestException as e:
+            except httpx.HTTPError as e:
                 logger.error(f"News fetch failed: {e}")
                 raise
 
@@ -143,29 +144,30 @@ class NewsFetcher:
             params["api_token"] = self.api_key
 
         try:
-            response = requests.get(self.BASE_URL, params=params, timeout=30)
-            response.raise_for_status()
+            with httpx.Client(timeout=30.0) as client:
+                response = client.get(self.BASE_URL, params=params)
+                response.raise_for_status()
 
-            data = response.json()
-            articles = []
+                data = response.json()
+                articles = []
 
-            for item in data.get("data", []):
-                articles.append(
-                    NewsArticle(
-                        title=item.get("title", ""),
-                        description=item.get("description", ""),
-                        url=item.get("url", ""),
-                        published_at=datetime.fromisoformat(
-                            item.get("published_at", "").replace("Z", "+00:00")
-                        ),
-                        source=item.get("source", ""),
+                for item in data.get("data", []):
+                    articles.append(
+                        NewsArticle(
+                            title=item.get("title", ""),
+                            description=item.get("description", ""),
+                            url=item.get("url", ""),
+                            published_at=datetime.fromisoformat(
+                                item.get("published_at", "").replace("Z", "+00:00")
+                            ),
+                            source=item.get("source", ""),
+                        )
                     )
-                )
 
-            logger.info(f"Fetched {len(articles)} articles")
-            return articles
+                logger.info(f"Fetched {len(articles)} articles")
+                return articles
 
-        except requests.exceptions.RequestException as e:
+        except httpx.HTTPError as e:
             logger.error(f"Market news fetch failed: {e}")
             raise
 

--- a/src/data/truth_social.py
+++ b/src/data/truth_social.py
@@ -4,7 +4,7 @@ import hashlib
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-import requests
+import httpx
 from dateutil import parser
 from diskcache import Cache
 from loguru import logger
@@ -20,9 +20,9 @@ HTTP_RETRY = retry(
     wait=wait_exponential(multiplier=1, min=2, max=10),
     retry=retry_if_exception_type(
         (
-            requests.exceptions.ReadTimeout,
-            requests.exceptions.ConnectionError,
-            requests.exceptions.Timeout,
+            httpx.ReadTimeout,
+            httpx.ConnectError,
+            httpx.TimeoutException,
         )
     ),
     reraise=True,
@@ -124,13 +124,14 @@ class TruthSocialFetcher:
             return cached
 
         logger.info("Fetching Truth Social archive from CNN")
-        response = requests.get(self.CNN_ARCHIVE_URL, timeout=30)
-        response.raise_for_status()
+        with httpx.Client(timeout=30.0) as client:
+            response = client.get(self.CNN_ARCHIVE_URL)
+            response.raise_for_status()
 
-        data = response.json()
-        self._cache.set(cache_key, data, expire=CACHE_TTL)
-        logger.info(f"Fetched {len(data)} posts from archive")
-        return data
+            data = response.json()
+            self._cache.set(cache_key, data, expire=CACHE_TTL)
+            logger.info(f"Fetched {len(data)} posts from archive")
+            return data
 
     def fetch_recent(self, hours: int = 24) -> TrumpPostData:
         """Fetch recent Trump posts.

--- a/src/data/universe.py
+++ b/src/data/universe.py
@@ -4,7 +4,7 @@ import hashlib
 from datetime import datetime
 from pathlib import Path
 
-import requests
+import httpx
 from bs4 import BeautifulSoup
 from diskcache import Cache
 from loguru import logger
@@ -155,27 +155,28 @@ class StockUniverseFetcher:
         Returns:
             List of StockInfo
         """
-        response = requests.get(SP500_URL, timeout=30)
-        response.raise_for_status()
+        with httpx.Client(timeout=30.0) as client:
+            response = client.get(SP500_URL)
+            response.raise_for_status()
 
-        soup = BeautifulSoup(response.text, "html.parser")
-        table = soup.find("table", {"id": "constituents"})
-        if not table:
-            msg = "S&P 500 table not found on Wikipedia"
-            raise ValueError(msg)
+            soup = BeautifulSoup(response.text, "html.parser")
+            table = soup.find("table", {"id": "constituents"})
+            if not table:
+                msg = "S&P 500 table not found on Wikipedia"
+                raise ValueError(msg)
 
-        stocks = []
-        for row in table.find_all("tr")[1:]:  # Skip header
-            cols = row.find_all("td")
-            if len(cols) >= 4:
-                symbol = cols[0].get_text(strip=True).replace(".", "-")  # BRK.B -> BRK-B
-                name = cols[1].get_text(strip=True)
-                sector = cols[3].get_text(strip=True)
-                industry = cols[4].get_text(strip=True) if len(cols) > 4 else ""
+            stocks = []
+            for row in table.find_all("tr")[1:]:  # Skip header
+                cols = row.find_all("td")
+                if len(cols) >= 4:
+                    symbol = cols[0].get_text(strip=True).replace(".", "-")  # BRK.B -> BRK-B
+                    name = cols[1].get_text(strip=True)
+                    sector = cols[3].get_text(strip=True)
+                    industry = cols[4].get_text(strip=True) if len(cols) > 4 else ""
 
-                stocks.append(StockInfo(symbol=symbol, name=name, sector=sector, industry=industry))
+                    stocks.append(StockInfo(symbol=symbol, name=name, sector=sector, industry=industry))
 
-        return stocks
+            return stocks
 
     def _scrape_nasdaq100(self) -> list[StockInfo]:
         """Scrape NASDAQ 100 list from Wikipedia.
@@ -183,27 +184,28 @@ class StockUniverseFetcher:
         Returns:
             List of StockInfo
         """
-        response = requests.get(NASDAQ100_URL, timeout=30)
-        response.raise_for_status()
+        with httpx.Client(timeout=30.0) as client:
+            response = client.get(NASDAQ100_URL)
+            response.raise_for_status()
 
-        soup = BeautifulSoup(response.text, "html.parser")
-        table = soup.find("table", {"id": "constituents"})
-        if not table:
-            msg = "NASDAQ 100 table not found on Wikipedia"
-            raise ValueError(msg)
+            soup = BeautifulSoup(response.text, "html.parser")
+            table = soup.find("table", {"id": "constituents"})
+            if not table:
+                msg = "NASDAQ 100 table not found on Wikipedia"
+                raise ValueError(msg)
 
-        stocks = []
-        for row in table.find_all("tr")[1:]:  # Skip header
-            cols = row.find_all("td")
-            if len(cols) >= 3:
-                name = cols[0].get_text(strip=True)
-                symbol = cols[1].get_text(strip=True).replace(".", "-")
-                sector = cols[2].get_text(strip=True)
-                industry = cols[3].get_text(strip=True) if len(cols) > 3 else ""
+            stocks = []
+            for row in table.find_all("tr")[1:]:  # Skip header
+                cols = row.find_all("td")
+                if len(cols) >= 3:
+                    name = cols[0].get_text(strip=True)
+                    symbol = cols[1].get_text(strip=True).replace(".", "-")
+                    sector = cols[2].get_text(strip=True)
+                    industry = cols[3].get_text(strip=True) if len(cols) > 3 else ""
 
-                stocks.append(StockInfo(symbol=symbol, name=name, sector=sector, industry=industry))
+                    stocks.append(StockInfo(symbol=symbol, name=name, sector=sector, industry=industry))
 
-        return stocks
+            return stocks
 
     def clear_cache(self) -> None:
         """Clear all cached universes."""

--- a/tests/test_data/test_news.py
+++ b/tests/test_data/test_news.py
@@ -3,8 +3,8 @@
 from datetime import datetime
 from unittest.mock import Mock, patch
 
+import httpx
 import pytest
-import requests
 
 from src.data.news import NewsArticle, NewsFetcher
 
@@ -64,11 +64,16 @@ def test_fetcher_init_no_key(monkeypatch):
 
 
 def test_fetch_company_news(sample_news_response):
-    with patch("src.data.news.requests.get") as mock_get:
+    with patch("src.data.news.httpx.Client") as mock_client_class:
         mock_response = Mock()
         mock_response.json.return_value = sample_news_response
         mock_response.raise_for_status = Mock()
-        mock_get.return_value = mock_response
+
+        mock_client = Mock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = Mock(return_value=mock_client)
+        mock_client.__exit__ = Mock(return_value=False)
+        mock_client_class.return_value = mock_client
 
         fetcher = NewsFetcher(api_key="test-key")
         articles = fetcher.fetch_company_news("AAPL", limit=10)
@@ -78,18 +83,23 @@ def test_fetch_company_news(sample_news_response):
         assert articles[0].title == "Apple announces new product"
         assert articles[1].source == "Bloomberg"
 
-        mock_get.assert_called_once()
-        call_args = mock_get.call_args
+        mock_client.get.assert_called_once()
+        call_args = mock_client.get.call_args
         assert call_args.kwargs["params"]["symbols"] == "AAPL"
         assert call_args.kwargs["params"]["limit"] == 10
 
 
 def test_fetch_market_news(sample_news_response):
-    with patch("src.data.news.requests.get") as mock_get:
+    with patch("src.data.news.httpx.Client") as mock_client_class:
         mock_response = Mock()
         mock_response.json.return_value = sample_news_response
         mock_response.raise_for_status = Mock()
-        mock_get.return_value = mock_response
+
+        mock_client = Mock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = Mock(return_value=mock_client)
+        mock_client.__exit__ = Mock(return_value=False)
+        mock_client_class.return_value = mock_client
 
         fetcher = NewsFetcher(api_key="test-key")
         articles = fetcher.fetch_market_news(limit=20)
@@ -97,7 +107,7 @@ def test_fetch_market_news(sample_news_response):
         assert len(articles) == 2
         assert all(isinstance(a, NewsArticle) for a in articles)
 
-        call_args = mock_get.call_args
+        call_args = mock_client.get.call_args
         assert call_args.kwargs["params"]["limit"] == 20
         assert "symbols" not in call_args.kwargs["params"]
 
@@ -105,36 +115,49 @@ def test_fetch_market_news(sample_news_response):
 def test_fetch_company_news_no_api_key(monkeypatch):
     monkeypatch.delenv("MARKETAUX_API_KEY", raising=False)
 
-    with patch("src.data.news.requests.get") as mock_get:
+    with patch("src.data.news.httpx.Client") as mock_client_class:
         mock_response = Mock()
         mock_response.json.return_value = {"data": []}
         mock_response.raise_for_status = Mock()
-        mock_get.return_value = mock_response
+
+        mock_client = Mock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = Mock(return_value=mock_client)
+        mock_client.__exit__ = Mock(return_value=False)
+        mock_client_class.return_value = mock_client
 
         fetcher = NewsFetcher(api_key="")
         fetcher.fetch_company_news("AAPL")
 
-        call_args = mock_get.call_args
+        call_args = mock_client.get.call_args
         assert "api_token" not in call_args.kwargs["params"]
 
 
 def test_fetch_company_news_http_error():
-    with patch("src.data.news.requests.get") as mock_get:
-        mock_get.side_effect = requests.exceptions.RequestException("API Error")
+    with patch("src.data.news.httpx.Client") as mock_client_class:
+        mock_client = Mock()
+        mock_client.get.side_effect = httpx.HTTPError("API Error")
+        mock_client.__enter__ = Mock(return_value=mock_client)
+        mock_client.__exit__ = Mock(return_value=False)
+        mock_client_class.return_value = mock_client
 
         fetcher = NewsFetcher(api_key="test-key")
 
-        with pytest.raises(requests.exceptions.RequestException):
+        with pytest.raises(httpx.HTTPError):
             fetcher.fetch_company_news("AAPL")
 
 
 def test_fetch_market_news_http_error():
-    with patch("src.data.news.requests.get") as mock_get:
-        mock_get.side_effect = requests.exceptions.RequestException("API Error")
+    with patch("src.data.news.httpx.Client") as mock_client_class:
+        mock_client = Mock()
+        mock_client.get.side_effect = httpx.HTTPError("API Error")
+        mock_client.__enter__ = Mock(return_value=mock_client)
+        mock_client.__exit__ = Mock(return_value=False)
+        mock_client_class.return_value = mock_client
 
         fetcher = NewsFetcher(api_key="test-key")
 
-        with pytest.raises(requests.exceptions.RequestException):
+        with pytest.raises(httpx.HTTPError):
             fetcher.fetch_market_news()
 
 
@@ -149,64 +172,83 @@ def test_repr(monkeypatch):
 
 
 def test_fetch_company_news_retries_on_timeout(sample_news_response):
-    with patch("src.data.news.requests.get") as mock_get:
+    with patch("src.data.news.httpx.Client") as mock_client_class:
         mock_response = Mock()
         mock_response.json.return_value = sample_news_response
         mock_response.raise_for_status = Mock()
-        mock_get.side_effect = [
-            requests.exceptions.Timeout("timeout"),
+
+        mock_client = Mock()
+        mock_client.get.side_effect = [
+            httpx.TimeoutException("timeout"),
             mock_response,
         ]
+        mock_client.__enter__ = Mock(return_value=mock_client)
+        mock_client.__exit__ = Mock(return_value=False)
+        mock_client_class.return_value = mock_client
 
         fetcher = NewsFetcher(api_key="test-key")
         articles = fetcher.fetch_company_news("AAPL")
 
         assert len(articles) == 2
-        assert mock_get.call_count == 2
+        assert mock_client.get.call_count == 2
 
 
 def test_fetch_company_news_retries_on_connection_error(sample_news_response):
-    with patch("src.data.news.requests.get") as mock_get:
+    with patch("src.data.news.httpx.Client") as mock_client_class:
         mock_response = Mock()
         mock_response.json.return_value = sample_news_response
         mock_response.raise_for_status = Mock()
-        mock_get.side_effect = [
-            requests.exceptions.ConnectionError("connection failed"),
-            requests.exceptions.ConnectionError("connection failed again"),
+
+        mock_client = Mock()
+        mock_client.get.side_effect = [
+            httpx.ConnectError("connection failed"),
+            httpx.ConnectError("connection failed again"),
             mock_response,
         ]
+        mock_client.__enter__ = Mock(return_value=mock_client)
+        mock_client.__exit__ = Mock(return_value=False)
+        mock_client_class.return_value = mock_client
 
         fetcher = NewsFetcher(api_key="test-key")
         articles = fetcher.fetch_company_news("AAPL")
 
         assert len(articles) == 2
-        assert mock_get.call_count == 3
+        assert mock_client.get.call_count == 3
 
 
 def test_fetch_company_news_exhausts_retries():
-    with patch("src.data.news.requests.get") as mock_get:
-        mock_get.side_effect = requests.exceptions.Timeout("timeout")
+    with patch("src.data.news.httpx.Client") as mock_client_class:
+        mock_client = Mock()
+        mock_client.get.side_effect = httpx.TimeoutException("timeout")
+        mock_client.__enter__ = Mock(return_value=mock_client)
+        mock_client.__exit__ = Mock(return_value=False)
+        mock_client_class.return_value = mock_client
 
         fetcher = NewsFetcher(api_key="test-key")
 
-        with pytest.raises(requests.exceptions.Timeout):
+        with pytest.raises(httpx.TimeoutException):
             fetcher.fetch_company_news("AAPL")
 
-        assert mock_get.call_count == 3
+        assert mock_client.get.call_count == 3
 
 
 def test_fetch_market_news_retries_on_timeout(sample_news_response):
-    with patch("src.data.news.requests.get") as mock_get:
+    with patch("src.data.news.httpx.Client") as mock_client_class:
         mock_response = Mock()
         mock_response.json.return_value = sample_news_response
         mock_response.raise_for_status = Mock()
-        mock_get.side_effect = [
-            requests.exceptions.ReadTimeout("read timeout"),
+
+        mock_client = Mock()
+        mock_client.get.side_effect = [
+            httpx.ReadTimeout("read timeout"),
             mock_response,
         ]
+        mock_client.__enter__ = Mock(return_value=mock_client)
+        mock_client.__exit__ = Mock(return_value=False)
+        mock_client_class.return_value = mock_client
 
         fetcher = NewsFetcher(api_key="test-key")
         articles = fetcher.fetch_market_news()
 
         assert len(articles) == 2
-        assert mock_get.call_count == 2
+        assert mock_client.get.call_count == 2

--- a/tests/test_data/test_truth_social.py
+++ b/tests/test_data/test_truth_social.py
@@ -3,8 +3,8 @@
 from datetime import UTC, datetime
 from unittest.mock import Mock, patch
 
+import httpx
 import pytest
-import requests
 
 from src.data.truth_social import TrumpPostData, TruthPost, TruthSocialFetcher
 
@@ -88,11 +88,16 @@ def test_fetcher_init_custom_cache():
 
 
 def test_fetch_archive(sample_archive_response):
-    with patch("src.data.truth_social.requests.get") as mock_get:
+    with patch("src.data.truth_social.httpx.Client") as mock_client_class:
         mock_response = Mock()
         mock_response.json.return_value = sample_archive_response
         mock_response.raise_for_status = Mock()
-        mock_get.return_value = mock_response
+
+        mock_client = Mock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = Mock(return_value=mock_client)
+        mock_client.__exit__ = Mock(return_value=False)
+        mock_client_class.return_value = mock_client
 
         fetcher = TruthSocialFetcher()
         fetcher._cache.clear()  # Clear cache for test
@@ -100,15 +105,20 @@ def test_fetch_archive(sample_archive_response):
         data = fetcher._fetch_archive()
 
         assert len(data) == 2
-        mock_get.assert_called_once()
+        mock_client.get.assert_called_once()
 
 
 def test_fetch_recent(sample_archive_response):
-    with patch("src.data.truth_social.requests.get") as mock_get:
+    with patch("src.data.truth_social.httpx.Client") as mock_client_class:
         mock_response = Mock()
         mock_response.json.return_value = sample_archive_response
         mock_response.raise_for_status = Mock()
-        mock_get.return_value = mock_response
+
+        mock_client = Mock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = Mock(return_value=mock_client)
+        mock_client.__exit__ = Mock(return_value=False)
+        mock_client_class.return_value = mock_client
 
         fetcher = TruthSocialFetcher()
         fetcher._cache.clear()
@@ -120,11 +130,16 @@ def test_fetch_recent(sample_archive_response):
 
 
 def test_fetch_since(sample_archive_response):
-    with patch("src.data.truth_social.requests.get") as mock_get:
+    with patch("src.data.truth_social.httpx.Client") as mock_client_class:
         mock_response = Mock()
         mock_response.json.return_value = sample_archive_response
         mock_response.raise_for_status = Mock()
-        mock_get.return_value = mock_response
+
+        mock_client = Mock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = Mock(return_value=mock_client)
+        mock_client.__exit__ = Mock(return_value=False)
+        mock_client_class.return_value = mock_client
 
         fetcher = TruthSocialFetcher()
         fetcher._cache.clear()
@@ -139,11 +154,16 @@ def test_fetch_since(sample_archive_response):
 
 
 def test_fetch_all(sample_archive_response):
-    with patch("src.data.truth_social.requests.get") as mock_get:
+    with patch("src.data.truth_social.httpx.Client") as mock_client_class:
         mock_response = Mock()
         mock_response.json.return_value = sample_archive_response
         mock_response.raise_for_status = Mock()
-        mock_get.return_value = mock_response
+
+        mock_client = Mock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = Mock(return_value=mock_client)
+        mock_client.__exit__ = Mock(return_value=False)
+        mock_client_class.return_value = mock_client
 
         fetcher = TruthSocialFetcher()
         fetcher._cache.clear()
@@ -155,11 +175,16 @@ def test_fetch_all(sample_archive_response):
 
 
 def test_get_latest_post_id(sample_archive_response):
-    with patch("src.data.truth_social.requests.get") as mock_get:
+    with patch("src.data.truth_social.httpx.Client") as mock_client_class:
         mock_response = Mock()
         mock_response.json.return_value = sample_archive_response
         mock_response.raise_for_status = Mock()
-        mock_get.return_value = mock_response
+
+        mock_client = Mock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = Mock(return_value=mock_client)
+        mock_client.__exit__ = Mock(return_value=False)
+        mock_client_class.return_value = mock_client
 
         fetcher = TruthSocialFetcher()
         fetcher._cache.clear()
@@ -170,25 +195,34 @@ def test_get_latest_post_id(sample_archive_response):
 
 
 def test_http_error():
-    with patch("src.data.truth_social.requests.get") as mock_get:
-        mock_get.side_effect = requests.exceptions.RequestException("API Error")
+    with patch("src.data.truth_social.httpx.Client") as mock_client_class:
+        mock_client = Mock()
+        mock_client.get.side_effect = httpx.HTTPError("API Error")
+        mock_client.__enter__ = Mock(return_value=mock_client)
+        mock_client.__exit__ = Mock(return_value=False)
+        mock_client_class.return_value = mock_client
 
         fetcher = TruthSocialFetcher()
         fetcher._cache.clear()
 
-        with pytest.raises(requests.exceptions.RequestException):
+        with pytest.raises(httpx.HTTPError):
             fetcher._fetch_archive()
 
 
 def test_retries_on_timeout(sample_archive_response):
-    with patch("src.data.truth_social.requests.get") as mock_get:
+    with patch("src.data.truth_social.httpx.Client") as mock_client_class:
         mock_response = Mock()
         mock_response.json.return_value = sample_archive_response
         mock_response.raise_for_status = Mock()
-        mock_get.side_effect = [
-            requests.exceptions.Timeout("timeout"),
+
+        mock_client = Mock()
+        mock_client.get.side_effect = [
+            httpx.TimeoutException("timeout"),
             mock_response,
         ]
+        mock_client.__enter__ = Mock(return_value=mock_client)
+        mock_client.__exit__ = Mock(return_value=False)
+        mock_client_class.return_value = mock_client
 
         fetcher = TruthSocialFetcher()
         fetcher._cache.clear()
@@ -196,7 +230,7 @@ def test_retries_on_timeout(sample_archive_response):
         data = fetcher._fetch_archive()
 
         assert len(data) == 2
-        assert mock_get.call_count == 2
+        assert mock_client.get.call_count == 2
 
 
 def test_repr():

--- a/tests/test_data/test_universe.py
+++ b/tests/test_data/test_universe.py
@@ -86,13 +86,18 @@ class TestStockUniverseFetcher:
         assert cache_dir.exists()
         fetcher.clear_cache()
 
-    @patch("src.data.universe.requests.get")
-    def test_fetch_sp500(self, mock_get, universe_fetcher, mock_sp500_html):
+    @patch("src.data.universe.httpx.Client")
+    def test_fetch_sp500(self, mock_client_class, universe_fetcher, mock_sp500_html):
         """Test fetching S&P 500 stocks."""
         mock_response = MagicMock()
         mock_response.text = mock_sp500_html
         mock_response.raise_for_status = MagicMock()
-        mock_get.return_value = mock_response
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_class.return_value = mock_client
 
         universe = universe_fetcher.fetch_sp500()
 
@@ -101,13 +106,18 @@ class TestStockUniverseFetcher:
         assert universe.stocks[0].symbol == "AAPL"
         assert universe.stocks[2].symbol == "BRK-B"  # . replaced with -
 
-    @patch("src.data.universe.requests.get")
-    def test_fetch_nasdaq100(self, mock_get, universe_fetcher, mock_nasdaq100_html):
+    @patch("src.data.universe.httpx.Client")
+    def test_fetch_nasdaq100(self, mock_client_class, universe_fetcher, mock_nasdaq100_html):
         """Test fetching NASDAQ 100 stocks."""
         mock_response = MagicMock()
         mock_response.text = mock_nasdaq100_html
         mock_response.raise_for_status = MagicMock()
-        mock_get.return_value = mock_response
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_class.return_value = mock_client
 
         universe = universe_fetcher.fetch_nasdaq100()
 
@@ -116,16 +126,21 @@ class TestStockUniverseFetcher:
         assert universe.stocks[0].symbol == "AAPL"
         assert universe.stocks[1].symbol == "NVDA"
 
-    @patch("src.data.universe.requests.get")
+    @patch("src.data.universe.httpx.Client")
     def test_fetch_combined_deduplicates(
-        self, mock_get, universe_fetcher, mock_sp500_html, mock_nasdaq100_html
+        self, mock_client_class, universe_fetcher, mock_sp500_html, mock_nasdaq100_html
     ):
         """Test combined fetch deduplicates stocks."""
         responses = [
             MagicMock(text=mock_sp500_html, raise_for_status=MagicMock()),
             MagicMock(text=mock_nasdaq100_html, raise_for_status=MagicMock()),
         ]
-        mock_get.side_effect = responses
+
+        mock_client = MagicMock()
+        mock_client.get.side_effect = responses
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_class.return_value = mock_client
 
         universe = universe_fetcher.fetch_combined()
 
@@ -135,41 +150,56 @@ class TestStockUniverseFetcher:
         assert "NVDA" in symbols
         assert "MSFT" in symbols
 
-    @patch("src.data.universe.requests.get")
-    def test_caching(self, mock_get, universe_fetcher, mock_sp500_html):
+    @patch("src.data.universe.httpx.Client")
+    def test_caching(self, mock_client_class, universe_fetcher, mock_sp500_html):
         """Test that results are cached."""
         mock_response = MagicMock()
         mock_response.text = mock_sp500_html
         mock_response.raise_for_status = MagicMock()
-        mock_get.return_value = mock_response
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_class.return_value = mock_client
 
         universe1 = universe_fetcher.fetch_sp500()
         universe2 = universe_fetcher.fetch_sp500()
 
-        assert mock_get.call_count == 1  # Only called once
+        assert mock_client.get.call_count == 1  # Only called once
         assert universe1.stocks == universe2.stocks
 
-    @patch("src.data.universe.requests.get")
-    def test_clear_cache(self, mock_get, universe_fetcher, mock_sp500_html):
+    @patch("src.data.universe.httpx.Client")
+    def test_clear_cache(self, mock_client_class, universe_fetcher, mock_sp500_html):
         """Test cache clearing."""
         mock_response = MagicMock()
         mock_response.text = mock_sp500_html
         mock_response.raise_for_status = MagicMock()
-        mock_get.return_value = mock_response
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_class.return_value = mock_client
 
         universe_fetcher.fetch_sp500()
         universe_fetcher.clear_cache()
         universe_fetcher.fetch_sp500()
 
-        assert mock_get.call_count == 2
+        assert mock_client.get.call_count == 2
 
-    @patch("src.data.universe.requests.get")
-    def test_missing_table_raises(self, mock_get, universe_fetcher):
+    @patch("src.data.universe.httpx.Client")
+    def test_missing_table_raises(self, mock_client_class, universe_fetcher):
         """Test that missing table raises ValueError."""
         mock_response = MagicMock()
         mock_response.text = "<html><body>No table here</body></html>"
         mock_response.raise_for_status = MagicMock()
-        mock_get.return_value = mock_response
+
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_class.return_value = mock_client
 
         with pytest.raises(ValueError, match="table not found"):
             universe_fetcher.fetch_sp500()

--- a/uv.lock
+++ b/uv.lock
@@ -38,7 +38,6 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "quantstats" },
-    { name = "requests" },
     { name = "rich" },
     { name = "riskfolio-lib" },
     { name = "sqlalchemy", extra = ["asyncio"] },
@@ -95,9 +94,8 @@ requires-dist = [
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = "==3.15.1" },
     { name = "python-dateutil", specifier = "==2.9.0.post0" },
     { name = "python-dotenv", specifier = "==1.2.1" },
-    { name = "pyyaml", specifier = "==6.0.3" },
+    { name = "pyyaml", specifier = "==6.0.2" },
     { name = "quantstats", specifier = "==0.0.81" },
-    { name = "requests", specifier = "==2.32.5" },
     { name = "rich", specifier = "==14.3.2" },
     { name = "riskfolio-lib", specifier = "==6.3.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.0" },
@@ -2468,29 +2466,9 @@ wheels = [
 
 [[package]]
 name = "pyyaml"
-version = "6.0.3"
+version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
-    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
-    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
-    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
-    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
-    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
-]
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
 
 [[package]]
 name = "quantstats"


### PR DESCRIPTION
## Motivation

Project used two HTTP libraries (requests + httpx) across 9 files, creating inconsistent error types, timeout semantics, and retry patterns. httpx already used for async paths in 6 files.

## Implementation information

Migrated 3 files from `requests` to `httpx`:
- `src/data/news.py` - NewsFetcher
- `src/data/truth_social.py` - TruthSocialFetcher  
- `src/data/universe.py` - StockUniverseFetcher

**Changes:**
- Replaced `import requests` with `import httpx`
- Updated HTTP_RETRY decorator exceptions: `requests.exceptions.*` → `httpx.*` (ReadTimeout, ConnectError, TimeoutException)
- Changed `requests.get(url, timeout=30)` to `with httpx.Client(timeout=30.0) as client: client.get(url)`
- Updated exception handling: `requests.exceptions.RequestException` → `httpx.HTTPError`
- Updated all test mocks to use `httpx.Client` context manager pattern

**Note:** Removed `requests` from direct dependencies in `pyproject.toml`, but it remains as transitive dependency (alpaca-py, alpha-vantage, yfinance, etc. still use it).

Also fixed PyYAML version to 6.0.2 (was incorrectly bumped to 6.0.3).

## Supporting documentation

- All 1599 tests passing
- Linter clean, formatting correct
- Reduces surface area for network error handling patterns across codebase