### PR TITLE
fix: add uv lock --check to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,18 @@ jobs:
       - name: Run actionlint
         uses: devops-actions/actionlint@467e2ce19b2310e93c9ffa0b50fe31f86b5a7f23  # v0.1.10
 
+  uv-lock-check:
+    name: Check uv.lock
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install mise
+        uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8  # v3.6.1
+
+      - name: Check uv.lock is up-to-date
+        run: uv lock --check
+
   security-audit:
     name: Security Audit (pip-audit)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

CI doesn't verify that uv.lock is in sync with pyproject.toml, leading to potential inconsistencies if developers forget to run `uv lock` after modifying dependencies.

## Implementation information

Added new `uv-lock-check` job to CI workflow that runs `uv lock --check` to verify lock file is up-to-date. Positioned after actionlint and before security-audit for logical grouping.

## Supporting documentation

Fixes #278