### PR TITLE
Fix test fixtures passing None instead of mocks (bad-argument-type)

### DIFF
--- a/tests/test_agents/test_fundamental.py
+++ b/tests/test_agents/test_fundamental.py
@@ -41,9 +41,11 @@ class TestFundamentalAnalyst:
         mock_fundamental_fetcher.fetch_overview.assert_called_once_with("AAPL")
         mock_llm_client.acomplete.assert_called_once()
 
-    def test_extract_metrics_complete_data(self, mock_fundamental_fetcher, sample_fundamental_overview):
+    def test_extract_metrics_complete_data(
+        self, mock_llm_client, mock_fundamental_fetcher, sample_fundamental_overview
+    ):
         """Test metrics extraction with complete data."""
-        analyst = FundamentalAnalyst(None, mock_fundamental_fetcher)
+        analyst = FundamentalAnalyst(mock_llm_client, mock_fundamental_fetcher)
 
         metrics = analyst._extract_metrics(sample_fundamental_overview)
 
@@ -54,9 +56,9 @@ class TestFundamentalAnalyst:
         assert metrics["debt_to_equity"] == 2.05
         assert metrics["current_ratio"] == 0.94
 
-    def test_extract_metrics_missing_data(self, mock_fundamental_fetcher):
+    def test_extract_metrics_missing_data(self, mock_llm_client, mock_fundamental_fetcher):
         """Test metrics extraction with missing data."""
-        analyst = FundamentalAnalyst(None, mock_fundamental_fetcher)
+        analyst = FundamentalAnalyst(mock_llm_client, mock_fundamental_fetcher)
         overview = {"Symbol": "TEST"}
 
         metrics = analyst._extract_metrics(overview)
@@ -68,9 +70,9 @@ class TestFundamentalAnalyst:
         assert metrics["debt_to_equity"] is None
         assert metrics["current_ratio"] is None
 
-    def test_extract_metrics_invalid_data(self, mock_fundamental_fetcher):
+    def test_extract_metrics_invalid_data(self, mock_llm_client, mock_fundamental_fetcher):
         """Test metrics extraction with invalid data."""
-        analyst = FundamentalAnalyst(None, mock_fundamental_fetcher)
+        analyst = FundamentalAnalyst(mock_llm_client, mock_fundamental_fetcher)
         overview = {
             "PERatio": "-",
             "EPS": "N/A",
@@ -85,46 +87,46 @@ class TestFundamentalAnalyst:
         assert metrics["revenue_growth_yoy"] is None
         assert metrics["debt_to_equity"] is None
 
-    def test_assess_valuation_undervalued(self, mock_fundamental_fetcher):
+    def test_assess_valuation_undervalued(self, mock_llm_client, mock_fundamental_fetcher):
         """Test valuation assessment for undervalued stock (P/E < 15)."""
-        analyst = FundamentalAnalyst(None, mock_fundamental_fetcher)
-        metrics = {"pe_ratio": 12.0}
+        analyst = FundamentalAnalyst(mock_llm_client, mock_fundamental_fetcher)
+        metrics: dict[str, float | None] = {"pe_ratio": 12.0}
 
         valuation = analyst._assess_valuation(metrics)
 
         assert valuation == "UNDERVALUED"
 
-    def test_assess_valuation_overvalued(self, mock_fundamental_fetcher):
+    def test_assess_valuation_overvalued(self, mock_llm_client, mock_fundamental_fetcher):
         """Test valuation assessment for overvalued stock (P/E > 30)."""
-        analyst = FundamentalAnalyst(None, mock_fundamental_fetcher)
-        metrics = {"pe_ratio": 35.0}
+        analyst = FundamentalAnalyst(mock_llm_client, mock_fundamental_fetcher)
+        metrics: dict[str, float | None] = {"pe_ratio": 35.0}
 
         valuation = analyst._assess_valuation(metrics)
 
         assert valuation == "OVERVALUED"
 
-    def test_assess_valuation_fairly_valued(self, mock_fundamental_fetcher):
+    def test_assess_valuation_fairly_valued(self, mock_llm_client, mock_fundamental_fetcher):
         """Test valuation assessment for fairly valued stock (15 <= P/E <= 30)."""
-        analyst = FundamentalAnalyst(None, mock_fundamental_fetcher)
-        metrics = {"pe_ratio": 20.0}
+        analyst = FundamentalAnalyst(mock_llm_client, mock_fundamental_fetcher)
+        metrics: dict[str, float | None] = {"pe_ratio": 20.0}
 
         valuation = analyst._assess_valuation(metrics)
 
         assert valuation == "FAIRLY_VALUED"
 
-    def test_assess_valuation_no_pe(self, mock_fundamental_fetcher):
+    def test_assess_valuation_no_pe(self, mock_llm_client, mock_fundamental_fetcher):
         """Test valuation assessment with no P/E ratio."""
-        analyst = FundamentalAnalyst(None, mock_fundamental_fetcher)
-        metrics = {"pe_ratio": None}
+        analyst = FundamentalAnalyst(mock_llm_client, mock_fundamental_fetcher)
+        metrics: dict[str, float | None] = {"pe_ratio": None}
 
         valuation = analyst._assess_valuation(metrics)
 
         assert valuation == "FAIRLY_VALUED"
 
-    def test_calculate_confidence_high_completeness(self, mock_fundamental_fetcher):
+    def test_calculate_confidence_high_completeness(self, mock_llm_client, mock_fundamental_fetcher):
         """Test confidence calculation with high data completeness."""
-        analyst = FundamentalAnalyst(None, mock_fundamental_fetcher)
-        metrics = {
+        analyst = FundamentalAnalyst(mock_llm_client, mock_fundamental_fetcher)
+        metrics: dict[str, float | None] = {
             "pe_ratio": 28.5,
             "eps": 6.15,
             "revenue_growth_yoy": 0.062,
@@ -138,10 +140,10 @@ class TestFundamentalAnalyst:
 
         assert confidence >= 0.8  # 0.5 base + 0.3 completeness + 0.1 signal
 
-    def test_calculate_confidence_low_completeness(self, mock_fundamental_fetcher):
+    def test_calculate_confidence_low_completeness(self, mock_llm_client, mock_fundamental_fetcher):
         """Test confidence calculation with low data completeness."""
-        analyst = FundamentalAnalyst(None, mock_fundamental_fetcher)
-        metrics = {
+        analyst = FundamentalAnalyst(mock_llm_client, mock_fundamental_fetcher)
+        metrics: dict[str, float | None] = {
             "pe_ratio": None,
             "eps": None,
             "revenue_growth_yoy": None,
@@ -155,10 +157,10 @@ class TestFundamentalAnalyst:
 
         assert confidence <= 0.5  # 0.5 base - 0.2 uncertainty signal
 
-    def test_calculate_confidence_uncertain_signal(self, mock_fundamental_fetcher):
+    def test_calculate_confidence_uncertain_signal(self, mock_llm_client, mock_fundamental_fetcher):
         """Test confidence calculation with uncertain LLM signal."""
-        analyst = FundamentalAnalyst(None, mock_fundamental_fetcher)
-        metrics = {
+        analyst = FundamentalAnalyst(mock_llm_client, mock_fundamental_fetcher)
+        metrics: dict[str, float | None] = {
             "pe_ratio": 28.5,
             "eps": 6.15,
             "revenue_growth_yoy": None,
@@ -173,50 +175,50 @@ class TestFundamentalAnalyst:
         # 0.5 base + 0.3 * (2/6) = 0.6, then -0.2 for "uncertain" = 0.4
         assert confidence < 0.5  # Should be reduced due to "uncertain" signal
 
-    def test_parse_float_valid_string(self, mock_fundamental_fetcher):
+    def test_parse_float_valid_string(self, mock_llm_client, mock_fundamental_fetcher):
         """Test float parsing with valid string."""
-        analyst = FundamentalAnalyst(None, mock_fundamental_fetcher)
+        analyst = FundamentalAnalyst(mock_llm_client, mock_fundamental_fetcher)
 
         result = analyst._parse_float("28.5")
 
         assert result == 28.5
 
-    def test_parse_float_valid_float(self, mock_fundamental_fetcher):
+    def test_parse_float_valid_float(self, mock_llm_client, mock_fundamental_fetcher):
         """Test float parsing with valid float."""
-        analyst = FundamentalAnalyst(None, mock_fundamental_fetcher)
+        analyst = FundamentalAnalyst(mock_llm_client, mock_fundamental_fetcher)
 
         result = analyst._parse_float(28.5)
 
         assert result == 28.5
 
-    def test_parse_float_none(self, mock_fundamental_fetcher):
+    def test_parse_float_none(self, mock_llm_client, mock_fundamental_fetcher):
         """Test float parsing with None."""
-        analyst = FundamentalAnalyst(None, mock_fundamental_fetcher)
+        analyst = FundamentalAnalyst(mock_llm_client, mock_fundamental_fetcher)
 
         result = analyst._parse_float(None)
 
         assert result is None
 
-    def test_parse_float_dash(self, mock_fundamental_fetcher):
+    def test_parse_float_dash(self, mock_llm_client, mock_fundamental_fetcher):
         """Test float parsing with dash."""
-        analyst = FundamentalAnalyst(None, mock_fundamental_fetcher)
+        analyst = FundamentalAnalyst(mock_llm_client, mock_fundamental_fetcher)
 
         result = analyst._parse_float("-")
 
         assert result is None
 
-    def test_parse_float_invalid_string(self, mock_fundamental_fetcher):
+    def test_parse_float_invalid_string(self, mock_llm_client, mock_fundamental_fetcher):
         """Test float parsing with invalid string."""
-        analyst = FundamentalAnalyst(None, mock_fundamental_fetcher)
+        analyst = FundamentalAnalyst(mock_llm_client, mock_fundamental_fetcher)
 
         result = analyst._parse_float("N/A")
 
         assert result is None
 
-    def test_build_analysis_prompt_complete_data(self, mock_fundamental_fetcher):
+    def test_build_analysis_prompt_complete_data(self, mock_llm_client, mock_fundamental_fetcher):
         """Test prompt building with complete data."""
-        analyst = FundamentalAnalyst(None, mock_fundamental_fetcher)
-        metrics = {
+        analyst = FundamentalAnalyst(mock_llm_client, mock_fundamental_fetcher)
+        metrics: dict[str, float | None] = {
             "pe_ratio": 28.5,
             "eps": 6.15,
             "revenue_growth_yoy": 0.062,
@@ -236,10 +238,10 @@ class TestFundamentalAnalyst:
         assert "2.05" in prompt
         assert "0.94" in prompt
 
-    def test_build_analysis_prompt_partial_data(self, mock_fundamental_fetcher):
+    def test_build_analysis_prompt_partial_data(self, mock_llm_client, mock_fundamental_fetcher):
         """Test prompt building with partial data."""
-        analyst = FundamentalAnalyst(None, mock_fundamental_fetcher)
-        metrics = {
+        analyst = FundamentalAnalyst(mock_llm_client, mock_fundamental_fetcher)
+        metrics: dict[str, float | None] = {
             "pe_ratio": 28.5,
             "eps": None,
             "revenue_growth_yoy": None,


### PR DESCRIPTION
## Motivation

Test fixtures in `tests/test_agents/test_fundamental.py` were incorrectly passing `None` to parameters expecting typed objects (`LLMClient`), causing 24 `[bad-argument-type]` type errors.

## Implementation information

Fixed by:
- Adding `mock_llm_client` fixture parameter to all 16 affected test methods
- Updating dict type annotations from `dict[str, float]` to `dict[str, float | None]` to match method signatures expecting nullable values

All tests pass with proper mocks, no type safety degraded.

## Supporting documentation

Fixes #318