### PR TITLE
fix: PromptLoader kwargs typing accepts multiple types

### DIFF
--- a/src/prompts/__init__.py
+++ b/src/prompts/__init__.py
@@ -31,12 +31,12 @@ class PromptLoader:
             msg = f"Prompt directory not found: {self.agent_dir}"
             raise PromptDirectoryNotFoundError(msg)
 
-    def load(self, prompt_name: str, **kwargs: str) -> str:
+    def load(self, prompt_name: str, **kwargs: object) -> str:
         """Load and render prompt with f-string style variables.
 
         Args:
             prompt_name: Filename without .txt extension
-            **kwargs: Variables to interpolate into template
+            **kwargs: Variables to interpolate into template (accepts str, int, float, list, etc.)
 
         Returns:
             Rendered prompt string
@@ -60,13 +60,13 @@ class PromptLoader:
             raise PromptVariableMissingError(msg) from e
 
 
-def load_prompt(agent_name: str, prompt_name: str, **kwargs: str) -> str:
+def load_prompt(agent_name: str, prompt_name: str, **kwargs: object) -> str:
     """Convenience function to load and render a prompt.
 
     Args:
         agent_name: Name of the agent
         prompt_name: Filename without .txt extension
-        **kwargs: Variables to interpolate
+        **kwargs: Variables to interpolate (accepts str, int, float, list, etc.)
 
     Returns:
         Rendered prompt string


### PR DESCRIPTION
## Motivation

PromptLoader `**kwargs` was typed as `str` only, but receives int/float/None/Literal values during prompt formatting, causing 13+ `[bad-argument-type]` errors in typecheck.

## Implementation information

Changed `**kwargs: str` to `**kwargs: object` in both `PromptLoader.load()` and `load_prompt()` helper. Using `object` type allows Python's `str.format()` to handle type conversion naturally (int, float, list, str, None, Literal types all work) while maintaining type safety at call sites.

Updated docstrings to clarify accepted types.

## Supporting documentation

Fixes #319