### PR TITLE
feat: add typecheck to mandatory pre-commit checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,24 @@ jobs:
       - name: Lint
         run: mise run lint
 
+  typecheck:
+    name: Type Check (pyrefly)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install mise
+        uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8  # v3.6.1
+
+      - name: Install dependencies
+        run: uv sync --frozen --all-extras
+
+      - name: Activate venv
+        run: echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV" && echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+
+      - name: Run typecheck
+        run: mise run typecheck
+
   test:
     name: Test (pytest)
     runs-on: ubuntu-latest

--- a/.mise.toml
+++ b/.mise.toml
@@ -29,8 +29,8 @@ description = "Run pytest with coverage"
 run = "uv run pytest --cov=src --cov-report=term-missing"
 
 [tasks.check]
-description = "Run all checks (format, lint, test)"
-depends = ["format:check", "lint", "test"]
+description = "Run all checks (format, lint, typecheck, test)"
+depends = ["format:check", "lint", "typecheck", "test"]
 
 [tasks.audit]
 description = "Run pip-audit to check for CVEs"


### PR DESCRIPTION
## Motivation

Enforce type safety by adding typecheck to mandatory pre-commit checks. With all type errors fixed (reduced from 171 to 0), typecheck should now prevent new type errors from being introduced.

## Implementation information

**Changes:**
- Updated `.mise.toml` check task to include typecheck in depends list
- Added typecheck job to CI workflow (runs `pyrefly check`)
- Updated task description to reflect new checks

**Verification:**
- `mise check` passes locally with 0 type errors (42 suppressed)
- All 1632 tests pass
- Follows existing CI job pattern (lint, test)

## Supporting documentation

Closes #294