### PR TITLE
fix: handle news fetch failures gracefully instead of blocking analysis

### DIFF
--- a/src/data/news.py
+++ b/src/data/news.py
@@ -62,6 +62,21 @@ class NewsFetcher:
         if not self.api_key:
             logger.warning("MARKETAUX_API_KEY not set - API calls may be limited")
 
+    def _log_rate_limit_headers(self, response: httpx.Response, symbol: str = "") -> None:
+        """Log Marketaux rate limit headers.
+
+        Args:
+            response: httpx Response object
+            symbol: Stock symbol (for context)
+        """
+        usage_limit = response.headers.get("X-UsageLimit-Limit")
+        rate_limit = response.headers.get("X-RateLimit-Limit")
+
+        if usage_limit:
+            logger.warning(f"Marketaux usage limit header (symbol={symbol}): {usage_limit}")
+        if rate_limit:
+            logger.info(f"Marketaux rate limit header (symbol={symbol}): {rate_limit}")
+
     @HTTP_RETRY
     def fetch_company_news(
         self,
@@ -93,6 +108,10 @@ class NewsFetcher:
             try:
                 with httpx.Client(timeout=30.0) as client:
                     response = client.get(self.BASE_URL, params=params)
+
+                    # Log rate limit headers before raising
+                    self._log_rate_limit_headers(response, symbol)
+
                     response.raise_for_status()
 
                     data = response.json()
@@ -118,6 +137,10 @@ class NewsFetcher:
 
                     return articles
 
+            except httpx.HTTPStatusError as e:
+                self._log_rate_limit_headers(e.response, symbol)
+                logger.error(f"News fetch failed: {e}")
+                raise
             except httpx.HTTPError as e:
                 logger.error(f"News fetch failed: {e}")
                 raise

--- a/src/workflows/trading.py
+++ b/src/workflows/trading.py
@@ -778,6 +778,11 @@ class TradingWorkflow:
             msg = "news_articles is None, cannot run sentiment/news analyses"
             raise ValueError(msg)
 
+        # Handle empty news with warning
+        if not news_articles:
+            logger.warning(f"No news articles available for {state['symbol']}, analyses may be degraded")
+            state["warnings"].append("No news articles available - sentiment and news analyses degraded")
+
         # Parallel Group 1: independent analyses (comparative, web_research, social, trump are optional)
         technical_task = self._timed_agent_call(
             "technical",
@@ -983,10 +988,11 @@ class TradingWorkflow:
 
         # Extract news data
         if isinstance(results[1], Exception):
-            logger.error(f"News fetch failed: {results[1]}")
-            raise results[1]
-        news_result = results[1]
-        assert isinstance(news_result, list)  # noqa: S101
+            logger.warning(f"News fetch failed, continuing with empty news: {results[1]}")
+            news_result = []
+        else:
+            news_result = results[1]
+            assert isinstance(news_result, list)  # noqa: S101
 
         # Extract trump data
         trump_posts: list[TruthPost] | None = None


### PR DESCRIPTION
## Motivation

Marketaux API returned 402 Payment Required (quota exceeded), causing news fetch to fail. This killed the entire analysis workflow, preventing any trading decisions from being made for **all symbols** (AAPL, TSLA, GOOGL, MSFT, NVDA, META, AMZN, SPY).

Root cause: `_fetch_data()` in trading workflow raised exception when news fetch failed, violating CLAUDE.md guidance: "Empty news: Handle with warning, not error"

## Implementation information

**Changes:**

1. **Workflow graceful degradation** (`src/workflows/trading.py`):
   - News fetch failure now continues with empty list instead of raising
   - Added warning log + state warning when no news available
   - Both sentiment and news agents already handle empty articles gracefully

2. **Rate limit header logging** (`src/data/news.py`):
   - Added `_log_rate_limit_headers()` to capture Marketaux headers
   - Logs `X-UsageLimit-Limit` (plan quota) and `X-RateLimit-Limit` (rate limits)
   - Helps diagnose quota issues for 402/429 errors

**Alternatives considered:**
- Retry with backoff: Not viable - 402 is quota exhaustion, not transient error
- Fallback news source: Out of scope - requires different API integration
- Skip news agents entirely: Rejected - degrades all analyses unnecessarily

## Supporting documentation

Research findings:
- [Marketaux API Documentation](https://www.marketaux.com/documentation) - confirms `X-UsageLimit-Limit` and `X-RateLimit-Limit` headers
- [HTTP 402 Status Code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/402) - payment required (non-retryable)

Fixes issue reported in conversation: AMZN (and all symbols) not buying despite BUY signals