### PR TITLE
refactor: migrate CLI/TUI/Daemon to use DI container

### DIFF
--- a/src/cli/analyze.py
+++ b/src/cli/analyze.py
@@ -3,6 +3,7 @@
 import asyncio
 import os
 import sys
+from collections.abc import Callable
 from typing import Annotated
 
 import typer
@@ -11,12 +12,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
-from src.cache.historical import HistoricalCache
-from src.data.broker import AlpacaBroker
-from src.data.fundamental import FundamentalDataFetcher
-from src.data.market import MarketDataFetcher
-from src.data.news import NewsFetcher
-from src.di.container import create_container
+from src.di.container import AppContainer, create_container
 from src.metrics.execution import WorkflowExecutionMetrics
 from src.metrics.tracker import MetricsTracker
 from src.workflows.trading import TradingWorkflow
@@ -373,6 +369,19 @@ def _print_metrics_summary(tracker: MetricsTracker) -> None:
     console.print("[dim]Metrics saved to: logs/metrics_summary.json[/dim]\n")
 
 
+def _select_workflow_factory(
+    container: AppContainer,
+    use_meta_agent: bool,
+    trump_mode: bool,
+) -> Callable[..., TradingWorkflow]:
+    """Select workflow factory based on CLI flags."""
+    if trump_mode:
+        return container.workflow_trump
+    if use_meta_agent:
+        return container.workflow_meta
+    return container.workflow_momentum
+
+
 async def _analyze_stock(
     symbol: str,
     period_days: int,
@@ -390,35 +399,20 @@ async def _analyze_stock(
     console.print(f"\n[bold]Initializing trading system ({mode_str}{trump_str} mode)...[/bold]")
 
     container = create_container()
-    historical_cache = HistoricalCache()
 
-    llm_client = container.llm_client()
-    market_fetcher = MarketDataFetcher(use_alpha_vantage=False, historical_cache=historical_cache)
-    news_fetcher = NewsFetcher(historical_cache=historical_cache)
-    finbert = container.finbert_sentiment()
-    fundamental_fetcher = FundamentalDataFetcher(historical_cache=historical_cache)
-
-    broker = None
+    broker = container.alpaca_broker() if enable_trading else None
     if enable_trading:
         if os.getenv("ALPACA_API_KEY") and os.getenv("ALPACA_SECRET_KEY"):
-            broker = AlpacaBroker(paper=True, historical_cache=historical_cache)
             console.print("[bold green]Paper trading enabled[/bold green]")
         else:
             console.print("[yellow]Warning: Trading enabled but Alpaca credentials not found[/yellow]")
 
     metrics_tracker = MetricsTracker() if show_metrics else None
 
-    workflow = TradingWorkflow(
-        llm_client,
-        market_fetcher,
-        news_fetcher,
-        finbert,
-        fundamental_fetcher,
-        broker,
-        metrics_tracker,
-        use_meta_agent=use_meta_agent,
-        trump_mode=trump_mode,
-        historical_cache=historical_cache,
+    workflow_factory = _select_workflow_factory(container, use_meta_agent, trump_mode)
+    workflow = workflow_factory(
+        broker=broker,
+        metrics_tracker=metrics_tracker,
     )
 
     console.print(f"\n[bold]Analyzing {symbol}...[/bold]\n")

--- a/src/daemon/runner.py
+++ b/src/daemon/runner.py
@@ -38,13 +38,10 @@ from src.daemon.prefetch import DataPrefetcher
 from src.daemon.scheduler import MarketScheduler
 from src.daemon.state import DaemonState, EarningsEventRecord, RiskReportRecord, SectorRotationRecord
 from src.daemon.task_runner import ScheduledTaskRunner
-from src.data.fundamental import FundamentalDataFetcher
 from src.data.market import MarketDataFetcher
-from src.data.news import NewsFetcher
 from src.database.connection import get_db_engine
 from src.metrics.sector_rotation import SectorRotationAnalysis
 from src.metrics.tracker import BaseMetricsTracker, create_metrics_tracker
-from src.models.llm import LLMClient
 from src.optimization.param_store import OptimizedParamStore
 from src.workflows.trading import TradingWorkflow
 from src.workflows.types import TradingWorkflowResult
@@ -190,13 +187,7 @@ class DaemonRunner:
             from src.daemon.rebalancing import DaemonRebalancer
             from src.optimization.portfolio import PortfolioOptimizer
 
-            market_fetcher = MarketDataFetcher(
-                use_alpha_vantage=False,
-                api_key=self._resolve_config_or_env(
-                    self.config.api_keys.alpha_vantage_api_key, "ALPHA_VANTAGE_API_KEY"
-                ),
-                historical_cache=self._historical_cache,
-            )
+            market_fetcher = self._container.market_fetcher()
             portfolio_optimizer = PortfolioOptimizer(
                 market_fetcher=market_fetcher,
                 broker=self.broker,
@@ -262,43 +253,6 @@ class DaemonRunner:
 
         logger.info(f"DaemonRunner initialized with {config}")
 
-    def _resolve_config_or_env(self, config_value: str | None, env_var: str) -> str | None:
-        """Resolve config value from daemon config or env var.
-
-        Config takes priority over environment variable.
-
-        Args:
-            config_value: Value from daemon config (priority)
-            env_var: Environment variable name (fallback)
-
-        Returns:
-            Resolved config value or None
-        """
-        return config_value or os.getenv(env_var)
-
-    def _create_llm_client(self) -> LLMClient:
-        """Create LLM client with config/env resolution.
-
-        Returns:
-            Configured LLMClient instance
-        """
-        provider = self.config.llm.provider or os.getenv("LLM_PROVIDER", "ollama")
-        if provider == "anthropic":
-            api_key = self._resolve_config_or_env(self.config.api_keys.anthropic_api_key, "ANTHROPIC_API_KEY")
-        elif provider == "openai":
-            api_key = self._resolve_config_or_env(self.config.api_keys.openai_api_key, "OPENAI_API_KEY")
-        else:
-            api_key = None
-
-        return LLMClient(
-            provider=self.config.llm.provider,
-            model=self.config.llm.model,
-            api_key=api_key,
-            openai_base_url=self._resolve_config_or_env(
-                self.config.api_keys.openai_api_base, "OPENAI_API_BASE"
-            ),
-        )
-
     def _init_discovery_engine(self) -> StockDiscoveryEngine:
         """Initialize stock discovery engine.
 
@@ -356,13 +310,7 @@ class DaemonRunner:
 
         # Market fetcher (create if not exists)
         if self.market_fetcher is None:
-            self.market_fetcher = MarketDataFetcher(
-                use_alpha_vantage=False,
-                api_key=self._resolve_config_or_env(
-                    self.config.api_keys.alpha_vantage_api_key, "ALPHA_VANTAGE_API_KEY"
-                ),
-                historical_cache=self._historical_cache,
-            )
+            self.market_fetcher = self._container.market_fetcher()
 
         # Trigger detector
         trigger_detector = TriggerDetector(
@@ -406,25 +354,9 @@ class DaemonRunner:
         """
         if self._prefetcher is None:
             try:
-                market_fetcher = MarketDataFetcher(
-                    use_alpha_vantage=False,
-                    api_key=self._resolve_config_or_env(
-                        self.config.api_keys.alpha_vantage_api_key, "ALPHA_VANTAGE_API_KEY"
-                    ),
-                    historical_cache=self._historical_cache,
-                )
-                news_fetcher = NewsFetcher(
-                    api_key=self._resolve_config_or_env(
-                        self.config.api_keys.marketaux_api_key, "MARKETAUX_API_KEY"
-                    ),
-                    historical_cache=self._historical_cache,
-                )
-                fundamental_fetcher = FundamentalDataFetcher(
-                    api_key=self._resolve_config_or_env(
-                        self.config.api_keys.alpha_vantage_api_key, "ALPHA_VANTAGE_API_KEY"
-                    ),
-                    historical_cache=self._historical_cache,
-                )
+                market_fetcher = self._container.market_fetcher()
+                news_fetcher = self._container.news_fetcher()
+                fundamental_fetcher = self._container.fundamental_fetcher()
 
                 self._prefetcher = DataPrefetcher(
                     market_fetcher=market_fetcher,
@@ -445,15 +377,7 @@ class DaemonRunner:
             GamePlanAgent instance
         """
         if self._game_plan_agent is None:
-            llm_client = self._container.llm_client()
-            market_fetcher = MarketDataFetcher(
-                use_alpha_vantage=False,
-                api_key=self._resolve_config_or_env(
-                    self.config.api_keys.alpha_vantage_api_key, "ALPHA_VANTAGE_API_KEY"
-                ),
-                historical_cache=self._historical_cache,
-            )
-            self._game_plan_agent = GamePlanAgent(llm_client, market_fetcher)
+            self._game_plan_agent = self._container.game_plan_agent()
         return self._game_plan_agent
 
     def _init_analysis_orchestrator(self) -> AnalysisOrchestrator:
@@ -1043,16 +967,7 @@ class DaemonRunner:
         console.print(f"\n[bold magenta]Generating trade journal for {today}...[/bold magenta]")
 
         try:
-            from src.agents.journal import TradeJournalAgent
-
-            workflow = self._init_workflow()
-            market_fetcher = MarketDataFetcher(
-                use_alpha_vantage=False,
-                api_key=self._resolve_config_or_env(
-                    self.config.api_keys.alpha_vantage_api_key, "ALPHA_VANTAGE_API_KEY"
-                ),
-            )
-            journal_agent = TradeJournalAgent(workflow.llm_client, market_fetcher)
+            journal_agent = self._container.trade_journal_agent()
 
             journal = await journal_agent.generate(today, today_records)
             file_path = journal_agent.persist(journal, self.config.journal.journal_dir)
@@ -1847,7 +1762,6 @@ class DaemonRunner:
     def _run_peer_analysis(self) -> None:
         """Run weekly deep peer benchmarking analysis."""
         from src.daemon.peer_analysis import DeepPeerAnalyzer
-        from src.data.universe import StockUniverseFetcher
 
         # Dedup check
         now = datetime.now(self.scheduler.timezone)
@@ -1862,13 +1776,8 @@ class DaemonRunner:
         console.print("-" * 50)
 
         try:
-            fundamental_fetcher = FundamentalDataFetcher(
-                api_key=self._resolve_config_or_env(
-                    self.config.api_keys.alpha_vantage_api_key, "ALPHA_VANTAGE_API_KEY"
-                ),
-                historical_cache=self._historical_cache,
-            )
-            universe_fetcher = StockUniverseFetcher()
+            fundamental_fetcher = self._container.fundamental_fetcher()
+            universe_fetcher = self._container.stock_universe_fetcher()
             analyzer = DeepPeerAnalyzer(
                 fundamental_fetcher=fundamental_fetcher,
                 universe_fetcher=universe_fetcher,

--- a/tests/test_daemon/test_runner.py
+++ b/tests/test_daemon/test_runner.py
@@ -8,7 +8,7 @@ from unittest.mock import ANY, AsyncMock, Mock, patch
 
 import pytest
 
-from src.daemon.config import ApiKeysConfig, DaemonConfig, ScreeningConfig, SectorRotationConfig
+from src.daemon.config import DaemonConfig, ScreeningConfig, SectorRotationConfig
 from src.daemon.runner import DaemonRunner
 from src.daemon.state import ScreeningRecord
 from src.data.broker import BrokerAccountInfo, BrokerPosition, OrderStatus
@@ -141,36 +141,6 @@ def test_get_merged_watchlist_empty_positions(sample_config: DaemonConfig, mock_
     assert len(watchlist) == 2
 
 
-def test_resolve_config_or_env_prefers_config(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Config api_keys take priority over env vars."""
-    monkeypatch.setenv("ALPHA_VANTAGE_API_KEY", "env_key")
-    config = DaemonConfig(
-        watchlist=["AAPL"],
-        api_keys=ApiKeysConfig(alpha_vantage_api_key="config_key"),
-    )
-    runner = DaemonRunner(config)
-    result = runner._resolve_config_or_env(config.api_keys.alpha_vantage_api_key, "ALPHA_VANTAGE_API_KEY")
-    assert result == "config_key"
-
-
-def test_resolve_config_or_env_falls_back_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Env var used when config api_key is None."""
-    monkeypatch.setenv("MARKETAUX_API_KEY", "env_key")
-    config = DaemonConfig(watchlist=["AAPL"])
-    runner = DaemonRunner(config)
-    result = runner._resolve_config_or_env(None, "MARKETAUX_API_KEY")
-    assert result == "env_key"
-
-
-def test_resolve_config_or_env_returns_none_when_both_missing(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Returns None when both config and env are missing."""
-    monkeypatch.delenv("MARKETAUX_API_KEY", raising=False)
-    config = DaemonConfig(watchlist=["AAPL"])
-    runner = DaemonRunner(config)
-    result = runner._resolve_config_or_env(None, "MARKETAUX_API_KEY")
-    assert result is None
-
-
 @patch("src.daemon.broker_manager.AlpacaBroker")
 def test_broker_init_with_credentials(mock_broker_class: Mock, sample_config: DaemonConfig) -> None:
     """Test broker initialization for watchlist merging when credentials present."""
@@ -279,6 +249,8 @@ async def test_run_cycle_uses_merged_watchlist(
     sample_config: DaemonConfig, mock_broker: Mock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test _run_cycle logs correct merged watchlist count."""
+    from src.daemon.degradation import DegradationContext, DegradationTier
+
     runner = DaemonRunner(sample_config)
     runner.broker = mock_broker
     runner._broker_manager.broker = mock_broker
@@ -287,6 +259,16 @@ async def test_run_cycle_uses_merged_watchlist(
     monkeypatch.setattr(runner.scheduler, "is_market_open", lambda: True)
     monkeypatch.setattr(runner, "_analyze_watchlist", AsyncMock(return_value=[]))
     monkeypatch.setattr(runner, "_log_results", Mock())
+    monkeypatch.setattr(
+        runner,
+        "_evaluate_degradation",
+        lambda: DegradationContext(
+            tier=DegradationTier.FULL,
+            available_agents=set(),
+            unavailable_services=[],
+            confidence_adjustment=1.0,
+        ),
+    )
 
     # Capture log messages
     logged_messages: list[str] = []
@@ -683,6 +665,8 @@ class TestSectorRotationIntegration:
 
 async def test_runner_publishes_cycle_events(sample_config: DaemonConfig, event_bus) -> None:
     """Test runner publishes CYCLE_START and CYCLE_COMPLETE events."""
+    from src.daemon.degradation import DegradationContext, DegradationTier
+
     runner = DaemonRunner(sample_config, event_bus=event_bus)
 
     sub_id, queue = await event_bus.subscribe()
@@ -691,6 +675,16 @@ async def test_runner_publishes_cycle_events(sample_config: DaemonConfig, event_
         patch.object(runner, "_analyze_watchlist", new_callable=AsyncMock) as mock_analyze,
         patch.object(runner.scheduler, "is_market_open", return_value=True),
         patch.object(runner, "_maybe_run_journal", new_callable=AsyncMock),
+        patch.object(
+            runner,
+            "_evaluate_degradation",
+            return_value=DegradationContext(
+                tier=DegradationTier.FULL,
+                available_agents=set(),
+                unavailable_services=[],
+                confidence_adjustment=1.0,
+            ),
+        ),
     ):
         mock_analyze.return_value = []
 


### PR DESCRIPTION
## Motivation

Manual dependency construction duplicated across CLI/TUI/daemon (~200 LOC):
- `analyze.py`: Creates own `HistoricalCache`, manually constructs 4 fetchers (~30 LOC)
- `runner.py`: Creates `MarketDataFetcher` 5+ times with duplicate API key resolution (~58 LOC)
- Each location re-implements API key resolution, cache management

Using existing DI container's singleton fetchers and workflow factories eliminates duplication and establishes single source of truth.

## Implementation information

### CLI Migration (`src/cli/analyze.py`) - 22 LOC reduced
- Added `_select_workflow_factory()` to map flags (meta/momentum/trump) to workflow variants
- Replaced manual construction (llm_client, 4 fetchers, broker) with workflow factory pattern
- Factory accepts runtime overrides: `workflow_factory(broker=..., metrics_tracker=...)`
- Removed 5 imports: `HistoricalCache`, `MarketDataFetcher`, `NewsFetcher`, `FundamentalDataFetcher`, `AlpacaBroker`

### Daemon Migration (`src/daemon/runner.py`) - 81 LOC reduced
Replaced 8 manual fetcher instantiations with container singletons:
1. **Rebalancing** (line 193): `MarketDataFetcher(...)` → `self._container.market_fetcher()`
2. **Discovery** (line 359): `self.market_fetcher = MarketDataFetcher(...)` → `self._container.market_fetcher()`
3. **Prefetcher** (lines 409-427): 3 manual fetchers → 3 container calls
4. **Game plan** (line 449): Manual construction → `self._container.game_plan_agent()`
5. **Trade journal** (line 1049): Manual construction → `self._container.trade_journal_agent()`
6. **Peer analysis** (line 1865): 2 manual fetchers → container singletons

Removed dead code:
- `_resolve_config_or_env()` method (13 LOC) - now handled by container providers
- `_create_llm_client()` method (22 LOC) - never used, container provides this
- Unused imports: `NewsFetcher`, `FundamentalDataFetcher`, `LLMClient`

### Test Updates
- Removed 3 obsolete `_resolve_config_or_env` tests (26 LOC) - functionality now tested in provider tests
- Fixed 2 failing cycle tests by adding proper `DegradationContext` mocking
- Removed unused `ApiKeysConfig` import

### TUI Status
- Already optimal (line 122: `container.workflow_meta()`), verified no regressions

**Alternatives considered:**
- Keep manual construction: Rejected - maintains duplication, inconsistent config resolution
- Unified historical_cache: Deferred - BrokerManager dependency complicates, tracked separately

## Supporting documentation

Fixes #314

**Verification:**
- ✅ Format: Clean (ruff)
- ✅ Lint: Clean (ruff)
- ✅ Type check: 0 errors (pyrefly)
- ✅ Tests: 1719 passed

**Impact:**
- Net reduction: **-103 LOC** (54 insertions, 157 deletions)
- Single source of truth for dependencies
- Eliminated API key resolution duplication
- Consistent fetcher configuration across all entry points