### PR TITLE
fix: align dashboard CLI default port to 8484

### DIFF
--- a/src/cli/dashboard.py
+++ b/src/cli/dashboard.py
@@ -53,7 +53,7 @@ def dashboard(
     """Launch Dash dashboard for daemon monitoring.
 
     Args:
-        api_url: Daemon API URL (default: http://localhost:8484)
+        api_url: Daemon API URL. If not provided, DashboardConfig uses $DAEMON_API_URL or defaults to http://localhost:8484
         port: Dashboard server port (default: 8050)
         debug: Enable debug mode (default: False)
     """
@@ -72,8 +72,15 @@ def dashboard(
 
     try:
         # Create config - let DashboardConfig handle api_url default
+        # Normalize empty/whitespace-only strings to None so DashboardConfig applies env/default
+        normalized_api_url = None
         if api_url is not None:
-            config = DashboardConfig(api_url=api_url, port=port)
+            stripped_api_url = api_url.strip()
+            if stripped_api_url:
+                normalized_api_url = stripped_api_url
+
+        if normalized_api_url is not None:
+            config = DashboardConfig(api_url=normalized_api_url, port=port)
         else:
             config = DashboardConfig(port=port)
 


### PR DESCRIPTION
## Motivation

Dashboard CLI defaulted to `http://localhost:8001` while `DashboardConfig` defaulted to `http://localhost:8484`, causing "connection refused" errors when using defaults.

## Implementation information

Removed hardcoded `8001` default from `src/cli/dashboard.py:76`. CLI now conditionally passes `api_url` to `DashboardConfig`, letting it handle the default via `Field(default_factory=...)` which checks `DAEMON_API_URL` env var and falls back to `8484`.

Alternative considered: Hardcode `8484` in CLI. Rejected because it duplicates logic - single source of truth is cleaner.

## Supporting documentation

Fixes #362