### PR TITLE
fix: remove _set_asyncio_context() workaround after nest_asyncio removal

### DIFF
--- a/src/models/llm.py
+++ b/src/models/llm.py
@@ -9,7 +9,6 @@ from collections.abc import AsyncIterator, Callable
 from types import TracebackType
 from typing import TypeVar, cast
 
-import sniffio
 from dotenv import load_dotenv
 from loguru import logger
 from pydantic import BaseModel
@@ -21,15 +20,6 @@ from src.models.providers.base import ToolCall
 T = TypeVar("T", bound=BaseModel)
 
 load_dotenv()
-
-
-def _set_asyncio_context() -> None:
-    """Set sniffio context to asyncio for httpx/httpcore compatibility.
-
-    httpx/httpcore uses sniffio to detect the async library. This explicitly
-    sets it to asyncio to ensure proper detection in CLI and daemon contexts.
-    """
-    sniffio.current_async_library_cvar.set("asyncio")  # type: ignore[bad-argument-type]
 
 
 _DEFAULT_CONCURRENT_REQUESTS = 5
@@ -197,7 +187,6 @@ class LLMClient:
         Returns:
             Generated text response
         """
-        _set_asyncio_context()
         messages = self._build_messages(prompt, system)
         start = time.perf_counter() if self._metrics_collector else None
         error_msg = None
@@ -239,7 +228,6 @@ class LLMClient:
         Returns:
             Generated text response
         """
-        _set_asyncio_context()
         start = time.perf_counter() if self._metrics_collector else None
         error_msg = None
         try:
@@ -271,7 +259,6 @@ class LLMClient:
         Yields:
             Individual tokens as they're generated
         """
-        _set_asyncio_context()
         messages = self._build_messages(prompt, system)
         async with _get_semaphore():
             async for token in self._provider.astream(messages, temperature):
@@ -339,7 +326,6 @@ class LLMClient:
         Raises:
             StructuredOutputError: If response cannot be parsed or validated
         """
-        _set_asyncio_context()
         messages = self._build_messages(prompt, system)
         start = time.perf_counter() if self._metrics_collector else None
         error_msg = None
@@ -413,7 +399,6 @@ class LLMClient:
         Returns:
             Final text response after tool execution
         """
-        _set_asyncio_context()
         messages: list[dict] = self._build_messages(prompt, system)
         tool_calls_made = 0
 


### PR DESCRIPTION
## Motivation

The `_set_asyncio_context()` function was added as a workaround to manually set the sniffio context for httpx/httpcore compatibility when using nest_asyncio. After removing nest_asyncio (#7), this function now interferes with httpx/httpcore's normal async library detection, causing "LLM service unavailable" errors in daemon health checks.

## Implementation information

**Removed:**
- `_set_asyncio_context()` function that called `sniffio.current_async_library_cvar.set("asyncio")`
- All 5 calls to `_set_asyncio_context()` at the start of async methods:
  - `acomplete()`
  - `achat()`
  - `astream()`
  - `astructured()`
  - `acomplete_with_tools()`
- `import sniffio` (sniffio remains as transitive dependency via httpx/httpcore)

**Why this fixes the issue:**
With nest_asyncio removed, httpx/httpcore can properly detect the running async library on their own. The manual context setting was interfering with this detection, causing async operations to fail.

**Testing:**
- All 1712 tests pass (0 failures)
- Specific validation:
  - `test_models/test_llm.py`: 24 tests pass
  - `test_daemon/test_health.py`: 30 tests pass
- Linting, type checking, and formatting all pass

## Supporting documentation

- Related to nest_asyncio removal effort (mentioned in directory name)
- See CLAUDE.md line 333: "❌ `nest_asyncio` — archived, breaks cancellation/exceptions"
- See src/cli/chat.py:52 comment about nest_asyncio removal