### PR TITLE
chore: add __repr__ to 23 classes

### DIFF
--- a/src/agents/thesis_researcher.py
+++ b/src/agents/thesis_researcher.py
@@ -258,6 +258,10 @@ class ThesisResearcher(BaseResearcher):
             return BullishConfidenceCalculator()
         return BearishConfidenceCalculator()
 
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return f"ThesisResearcher(direction={self.direction.value})"
+
     @property
     def llm_response_model(self) -> type[BaseModel]:
         """LLM response model type."""

--- a/src/daemon/analysis_orchestrator.py
+++ b/src/daemon/analysis_orchestrator.py
@@ -93,6 +93,10 @@ class AnalysisOrchestrator:
         self._notification_helper = DaemonNotificationHelper()
         logger.info("AnalysisOrchestrator initialized")
 
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return f"AnalysisOrchestrator(max_concurrent={self.config.max_concurrent_analyses})"
+
     def _sync_positions_with_broker(self) -> bool:
         """Sync positions with broker and update state.
 

--- a/src/daemon/broker_manager.py
+++ b/src/daemon/broker_manager.py
@@ -33,6 +33,11 @@ class BrokerManager:
         self.broker: AlpacaBroker | None = None
         logger.info("BrokerManager initialized (broker not yet configured)")
 
+    def __repr__(self) -> str:
+        """Return string representation."""
+        status = "configured" if self.broker else "not_configured"
+        return f"BrokerManager(broker={status})"
+
     def initialize_broker(self) -> None:
         """Initialize Alpaca broker based on config.
 

--- a/src/daemon/context_builder.py
+++ b/src/daemon/context_builder.py
@@ -34,6 +34,10 @@ class DaemonContextBuilder:
         self.components = components
         self.container = container
 
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return "DaemonContextBuilder()"
+
     def build_analysis_contexts(
         self,
         symbol: str,

--- a/src/daemon/cycle_orchestrator.py
+++ b/src/daemon/cycle_orchestrator.py
@@ -51,6 +51,10 @@ class DaemonCycleOrchestrator:
         self.runner = runner  # For delegating to runner methods
         self._notification_helper = DaemonNotificationHelper()
 
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return "DaemonCycleOrchestrator()"
+
     async def run_cycle(self) -> CycleResult:
         """Run single daemon cycle: tasks → health → discovery → degradation → analysis → journal.
 

--- a/src/daemon/factory.py
+++ b/src/daemon/factory.py
@@ -85,6 +85,10 @@ class DaemonFactory:
         self.config = config
         self._container = self._create_or_wire_container(container)
 
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return "DaemonFactory()"
+
     def _create_or_wire_container(self, container: AppContainer | None) -> AppContainer:
         """Create container or wire existing one with config.
 

--- a/src/daemon/lifecycle.py
+++ b/src/daemon/lifecycle.py
@@ -29,6 +29,10 @@ class DaemonLifecycle:
         self._api_server: uvicorn.Server | None = None
         self._api_task: asyncio.Task | None = None
 
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return f"DaemonLifecycle(running={self.running})"
+
     async def startup(self) -> None:
         """Execute startup sequence: DB migrations, signal handlers, API server."""
         self.running = True

--- a/src/daemon/notification_formatter.py
+++ b/src/daemon/notification_formatter.py
@@ -7,6 +7,10 @@ from src.daemon.notifications import NotificationMessage
 class NotificationFormatter:
     """Format notification messages for different channels."""
 
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return "NotificationFormatter()"
+
     @staticmethod
     def _escape_markdown(text: str) -> str:
         """Escape markdown special characters for Telegram Markdown (legacy) mode.

--- a/src/daemon/notification_helper.py
+++ b/src/daemon/notification_helper.py
@@ -17,6 +17,10 @@ if TYPE_CHECKING:
 class DaemonNotificationHelper:
     """Helper for sending daemon notifications."""
 
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return "DaemonNotificationHelper()"
+
     async def notify_degradation(
         self,
         degradation_context: DegradationContext,

--- a/src/daemon/notifications.py
+++ b/src/daemon/notifications.py
@@ -57,6 +57,10 @@ class NotificationRateLimiter:
         self.limit_minutes = limit_minutes
         self._last_notified: dict[str, datetime] = {}
 
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return f"NotificationRateLimiter(limit_minutes={self.limit_minutes})"
+
     def can_notify(self, symbol: str, trigger: NotificationTrigger) -> bool:
         """Check if notification is allowed by rate limit.
 

--- a/src/daemon/rebalancing.py
+++ b/src/daemon/rebalancing.py
@@ -40,6 +40,10 @@ class DaemonRebalancer:
             f"auto_execute={'yes' if broker else 'no'})"
         )
 
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return f"DaemonRebalancer(threshold={self.rebalance_threshold:.2%})"
+
     def run(self, watchlist: list[str], method: str, auto_execute: bool) -> RebalancingResult:
         """Run portfolio rebalancing.
 

--- a/src/daemon/stress_testing.py
+++ b/src/daemon/stress_testing.py
@@ -32,6 +32,10 @@ class DaemonStressTester:
         self.market = market_fetcher
         self.config = config
 
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return f"DaemonStressTester(simulations={self.config.num_simulations})"
+
     def execute(self) -> MonteCarloRecord:
         """Run Monte Carlo simulation on current portfolio.
 

--- a/src/daemon/task_runner.py
+++ b/src/daemon/task_runner.py
@@ -80,6 +80,10 @@ class ScheduledTaskRunner:
         self._task_service: DaemonTaskService | None = None  # Wired later via set_task_service
         logger.info("ScheduledTaskRunner initialized")
 
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return f"ScheduledTaskRunner(tasks={len(self.TASKS)})"
+
     def set_task_service(self, task_service: DaemonTaskService) -> None:
         """Wire task service after initialization.
 

--- a/src/daemon/task_service.py
+++ b/src/daemon/task_service.py
@@ -59,6 +59,10 @@ class DaemonTaskService:
         self._last_readiness_check: datetime | None = None
         self._notified_paper_ready = False
 
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return "DaemonTaskService()"
+
     async def run_optimization(self) -> None:
         """Run parameter optimization task."""
         if self.components.daemon_optimizer is None:

--- a/src/metrics/correlation.py
+++ b/src/metrics/correlation.py
@@ -86,6 +86,12 @@ class CorrelationAuditor:
             f"lookback={lookback_days}d)"
         )
 
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return (
+            f"CorrelationAuditor(threshold={self.correlation_threshold:.2f}, lookback={self.lookback_days}d)"
+        )
+
     def audit(
         self,
         positions: dict[str, BrokerPosition],

--- a/src/metrics/execution.py
+++ b/src/metrics/execution.py
@@ -119,6 +119,13 @@ class ExecutionMetricsCollector:
         self._pipeline_stages: list[PipelineStageMetric] = []
         self._agent_call_counts: dict[str, int] = defaultdict(int)
 
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return (
+            f"ExecutionMetricsCollector(symbol={self._symbol}, provider={self._provider}, "
+            f"model={self._model})"
+        )
+
     def record_llm_call(
         self,
         method: str,

--- a/src/metrics/monte_carlo.py
+++ b/src/metrics/monte_carlo.py
@@ -63,6 +63,10 @@ class MonteCarloSimulator:
             logger.warning("Singular covariance matrix, adding ridge regularization")
             self.cov_matrix += 1e-6 * np.eye(len(self.cov_matrix))
 
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return f"MonteCarloSimulator(symbols={len(self.returns.columns)}, days={len(self.returns)})"
+
     def simulate(  # noqa: PLR0913
         self,
         positions: dict[str, float],

--- a/src/metrics/tracker.py
+++ b/src/metrics/tracker.py
@@ -142,6 +142,10 @@ class BaseMetricsTracker(ABC):
         else:
             self.risk_free_rate = risk_free_rate
 
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return f"BaseMetricsTracker(risk_free_rate={self.risk_free_rate:.4f})"
+
     @property
     @abstractmethod
     def trades(self) -> list[TradeRecord]:

--- a/src/prompts/__init__.py
+++ b/src/prompts/__init__.py
@@ -31,6 +31,10 @@ class PromptLoader:
             msg = f"Prompt directory not found: {self.agent_dir}"
             raise PromptDirectoryNotFoundError(msg)
 
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return f"PromptLoader(agent={self.agent_dir.name})"
+
     def load(self, prompt_name: str, **kwargs: object) -> str:
         """Load and render prompt with f-string style variables.
 

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -77,6 +77,12 @@ class TradingChatApp(App):
         self._personality: str = "casino"  # "casino" or "trump"
         self._load_history()
 
+    def __repr__(self) -> str:
+        """Return string representation."""
+        model = getattr(self, "_model_name", "unknown")
+        personality = getattr(self, "_personality", "unknown")
+        return f"TradingChatApp(model={model}, personality={personality})"
+
     def _create_tool_registry(self) -> ToolRegistry:
         """Create and populate tool registry."""
         registry = ToolRegistry()

--- a/src/tui/events.py
+++ b/src/tui/events.py
@@ -87,6 +87,10 @@ class AnalysisProgress(Message):
         self.detail = detail
         super().__init__()
 
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return f"AnalysisProgress(step={self.step_id}, status={self.status})"
+
 
 class AnalysisComplete(Message):
     """Analysis completed message."""
@@ -103,3 +107,7 @@ class AnalysisComplete(Message):
         self.symbol = symbol
         self.command_type = command_type
         super().__init__()
+
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return f"AnalysisComplete(symbol={self.symbol}, command={self.command_type})"


### PR DESCRIPTION
## Motivation

CLAUDE.md mandates `__repr__` on all classes for better debugging. 23 non-trivial classes were missing this method, hindering debugger output and log readability.

## Implementation information

Added `__repr__` methods to all 23 classes following existing codebase pattern:
- Standard docstring: "Return string representation."
- Format: `ClassName(key_attr=value)`
- Key attributes selected for debugging value (e.g., config values, status, counts)

Special handling:
- **TradingChatApp**: Used `getattr()` with fallbacks to handle Textual framework calling `__repr__` during `super().__init__()` before attributes are set
- **ExecutionMetricsCollector**: Split long line to meet 110-char limit

Classes updated:
- 1 agent: ThesisResearcher
- 12 daemon: AnalysisOrchestrator, BrokerManager, DaemonContextBuilder, DaemonCycleOrchestrator, DaemonFactory, DaemonLifecycle, NotificationRateLimiter, NotificationFormatter, DaemonNotificationHelper, DaemonRebalancer, DaemonStressTester, ScheduledTaskRunner, DaemonTaskService
- 4 metrics: CorrelationAuditor, ExecutionMetricsCollector, MonteCarloSimulator, BaseMetricsTracker
- 1 prompt: PromptLoader
- 2 TUI: TradingChatApp, AnalysisProgress, AnalysisComplete

Alternatives considered:
- Omitting `__repr__` on utility classes → Rejected: All non-trivial classes benefit from better debugging
- Verbose multi-line repr → Rejected: Keep concise for log readability

## Supporting documentation

Fixes #430