### PR TITLE
feat: add async tool execution support

### DIFF
--- a/src/tools/base.py
+++ b/src/tools/base.py
@@ -1,5 +1,6 @@
 """Base tool interface for LLM function calling."""
 
+import asyncio
 from abc import ABC, abstractmethod
 
 from src.tools.models import ToolDefinition
@@ -44,6 +45,28 @@ class BaseTool(ABC):
         Returns:
             Tool execution result as string
         """
+
+    async def aexecute(self, **kwargs: str | int | float | bool) -> str:
+        """Execute the tool asynchronously.
+
+        Default implementation offloads sync execute() to thread pool.
+        Subclasses can override for native async implementations.
+
+        Args:
+            **kwargs: Tool-specific arguments
+
+        Returns:
+            Tool execution result as string
+
+        Examples:
+            # Default: thread offloading
+            result = await tool.aexecute(symbol="AAPL")
+
+            # Native async override in subclass:
+            async def aexecute(self, **kwargs):
+                return await self._async_operation(**kwargs)
+        """
+        return await asyncio.to_thread(self.execute, **kwargs)
 
     def __repr__(self) -> str:
         """String representation."""

--- a/src/tools/registry.py
+++ b/src/tools/registry.py
@@ -65,6 +65,27 @@ class ToolRegistry:
         logger.info(f"Executing tool: {name} with args: {args}")
         return tool.execute(**args)
 
+    async def aexecute(self, name: str, args: dict) -> str:
+        """Execute a tool asynchronously by name.
+
+        Args:
+            name: Tool name
+            args: Arguments to pass to tool
+
+        Returns:
+            Tool execution result
+
+        Raises:
+            KeyError: If tool not found
+        """
+        tool = self._tools.get(name)
+        if not tool:
+            msg = f"Tool not found: {name}"
+            raise KeyError(msg)
+
+        logger.info(f"Executing tool: {name} with args: {args}")
+        return await tool.aexecute(**args)
+
     def requires_confirmation(self, name: str) -> bool:
         """Check if tool requires user confirmation.
 

--- a/tests/test_tools/test_base.py
+++ b/tests/test_tools/test_base.py
@@ -1,5 +1,7 @@
 """Tests for BaseTool interface."""
 
+import asyncio
+
 import pytest
 
 from src.tools.base import BaseTool
@@ -36,6 +38,30 @@ class ConcreteToolWithConfirmation(ConcreteTool):
     def requires_confirmation(self) -> bool:
         """Requires confirmation."""
         return True
+
+
+class AsyncConcreteTool(BaseTool):
+    """Concrete implementation with native async execute."""
+
+    @property
+    def name(self) -> str:
+        return "async_test_tool"
+
+    def get_tool_definition(self) -> ToolDefinition:
+        return ToolDefinition(
+            function=ToolFunction(
+                name=self.name,
+                description="Async test tool",
+                parameters=ToolParametersSchema(properties={}, required=[]),
+            )
+        )
+
+    def execute(self, **kwargs: str | int | float | bool) -> str:
+        return f"sync executed with {kwargs}"
+
+    async def aexecute(self, **kwargs: str | int | float | bool) -> str:
+        await asyncio.sleep(0.01)  # Simulate async operation
+        return f"async executed with {kwargs}"
 
 
 class TestBaseTool:
@@ -86,3 +112,27 @@ class TestBaseTool:
 
         assert "ConcreteTool" in repr_str
         assert "test_tool" in repr_str
+
+    @pytest.mark.asyncio
+    async def test_aexecute_default_offloads_to_thread(self):
+        """Test that default aexecute offloads sync execute to thread."""
+        tool = ConcreteTool()
+        result = await tool.aexecute(foo="bar", num=42)
+        assert "executed with" in result
+        assert "foo" in result
+
+    @pytest.mark.asyncio
+    async def test_aexecute_can_be_overridden(self):
+        """Test that aexecute can be overridden for native async."""
+        tool = AsyncConcreteTool()
+        result = await tool.aexecute(foo="bar")
+        assert "async executed with" in result
+
+    @pytest.mark.asyncio
+    async def test_aexecute_and_execute_both_work(self):
+        """Test that both sync and async execution work on same tool."""
+        tool = AsyncConcreteTool()
+        sync_result = tool.execute(test="sync")
+        assert "sync executed with" in sync_result
+        async_result = await tool.aexecute(test="async")
+        assert "async executed with" in async_result

--- a/tests/test_tools/test_registry.py
+++ b/tests/test_tools/test_registry.py
@@ -1,5 +1,7 @@
 """Tests for ToolRegistry."""
 
+import asyncio
+
 import pytest
 
 from src.tools.base import BaseTool
@@ -175,3 +177,33 @@ class TestToolRegistry:
 
         assert "ToolRegistry" in repr_str
         assert "my_tool" in repr_str
+
+    @pytest.mark.asyncio
+    async def test_aexecute_tool(self):
+        """Test executing a tool asynchronously."""
+        registry = ToolRegistry()
+        registry.register(MockTool())
+        result = await registry.aexecute("mock_tool", {"arg1": "test_value"})
+        assert "mock result: test_value" in result
+
+    @pytest.mark.asyncio
+    async def test_aexecute_nonexistent_raises(self):
+        """Test executing nonexistent tool asynchronously raises KeyError."""
+        registry = ToolRegistry()
+        with pytest.raises(KeyError, match="Tool not found"):
+            await registry.aexecute("nonexistent", {})
+
+    @pytest.mark.asyncio
+    async def test_aexecute_with_custom_async_tool(self):
+        """Test executing tool with custom async implementation."""
+
+        class AsyncMockTool(MockTool):
+            async def aexecute(self, **kwargs: str | int | float | bool) -> str:
+                await asyncio.sleep(0.01)
+                arg1 = str(kwargs.get("arg1", "default"))
+                return f"async mock result: {arg1}"
+
+        registry = ToolRegistry()
+        registry.register(AsyncMockTool())
+        result = await registry.aexecute("mock_tool", {"arg1": "async_test"})
+        assert "async mock result: async_test" in result


### PR DESCRIPTION
## Motivation

Current tool system is sync-only. Coordinator agent needs async execution since daemon tools call async sub-agents (TradingWorkflow.analyze(), GamePlanAgent.generate()). Tools like ScreenStocksTool use anti-pattern (asyncio.run() in ThreadPoolExecutor) to bridge sync-async gap.

## Implementation information

Added async execution support while maintaining full backward compatibility:

- **BaseTool.aexecute()**: Default implementation offloads sync execute() to thread pool via asyncio.to_thread()
- **ToolRegistry.aexecute()**: Delegates to tool's async method, mirrors sync execute() signature
- **Test coverage**: Added AsyncConcreteTool test class and 6 async test methods

Subclasses can override aexecute() for native async implementations. All existing sync tools work unchanged.

**Alternatives considered:**
- Making execute() async: Breaking change for all existing tools
- Dual interface (AsyncTool/SyncTool): Added complexity, duplicated code
- Chosen approach: Backward compatible default with opt-in native async

## Supporting documentation

Implementation follows plan from async tool execution design discussion.

**Next step:** Refactor ScreenStocksTool to use native async and eliminate ThreadPoolExecutor anti-pattern.