### PR TITLE
feat: add async tool executor support to LLMClient

### DIFF
--- a/src/models/llm.py
+++ b/src/models/llm.py
@@ -525,8 +525,8 @@ class LLMClient:
             sync_executor = cast("Callable[[str, dict], str]", executor)
             result = await asyncio.to_thread(sync_executor, tool_call.name, tool_call.arguments)
 
-            # Handle edge case: sync function returns awaitable
-            if inspect.iscoroutine(result):
+            # Handle edge case: sync function returns awaitable (e.g., coroutine, Future, Task)
+            if inspect.isawaitable(result):
                 return await result
 
             return result

--- a/tests/test_models/test_llm.py
+++ b/tests/test_models/test_llm.py
@@ -504,7 +504,7 @@ class TestAsyncToolExecutor:
             await asyncio.sleep(0.01)
             return f"Wrapped result: {symbol}"
 
-        def sync_returning_awaitable(name: str, args: dict) -> str:
+        def sync_returning_awaitable(name: str, args: dict):
             return inner_async(args.get("symbol", "N/A"))
 
         tool_call = ToolCall(id="call_xyz", name="analyze", arguments={"symbol": "AMZN"})


### PR DESCRIPTION
## Motivation

Issue #439: `LLMClient.acomplete_with_tools()` currently only accepts sync `tool_executor` functions. The coordinator workflow needs to pass async executors that call async sub-agents (technical analyst, sentiment analyst, etc.). Without async support, tool execution blocks the event loop, preventing concurrent operations and forcing the coordinator to use workarounds.

This change enables the coordinator to directly pass async executors, allowing proper async sub-agent orchestration without blocking the event loop.

## Implementation information

**Approach:** Hybrid executor support with runtime type detection

Added `_execute_tool_async()` method that accepts both sync and async callables using union type `Callable[[str, dict], str] | Callable[[str, dict], Awaitable[str]]`. The method performs runtime detection to handle each case appropriately:

- **Async executors:** Detected via `inspect.iscoroutinefunction()`, awaited directly
- **Sync executors:** Offloaded to thread pool via `asyncio.to_thread()` to prevent blocking event loop (matches `BaseTool.aexecute()` pattern)
- **Edge case:** Sync functions returning awaitables detected with `inspect.iscoroutine()` and awaited

**Type safety:** Used explicit `cast()` with quoted type expressions to satisfy type checker's inability to narrow union types across runtime checks.

**Deprecation fix:** Used `inspect.iscoroutinefunction()` instead of deprecated `asyncio.iscoroutinefunction()` (deprecated in Python 3.16).

**Alternatives considered:**
- Separate methods (`acomplete_with_tools_async`): Rejected - duplicates code, worse API
- Always offload to threads: Rejected - unnecessary overhead for async executors
- Remove sync support: Rejected - breaks existing code (WebResearchAgent, TUI app)

**Backward compatibility:** Original `_execute_tool()` method preserved. All existing sync executors (WebResearchAgent lambda, TUI registry) continue working without modification.

## Supporting documentation

Fixes #439

**Testing:**
- 7 new comprehensive tests in `TestAsyncToolExecutor`
- All 31 existing LLM tests pass
- Full test suite: 1730 passed

**Quality gates:**
- ✓ Format (ruff)
- ✓ Lint (ruff)  
- ✓ Typecheck (pyrefly)
- ✓ Tests (pytest)