### PR TITLE
fix: resolve event loop lifecycle issue in PositionManager

### DIFF
--- a/src/daemon/factory.py
+++ b/src/daemon/factory.py
@@ -356,25 +356,22 @@ class DaemonFactory:
 
         from src.daemon.positions import PositionManager
 
-        # Get repositories from container if database is available
-        position_repository = None
-        position_action_repository = None
+        # Get database engine and trade repository from container if database is available
+        database_engine = None
         trade_repository = None
 
         if os.getenv("DATABASE_URL") or self.config.database.database_url:
             try:
-                position_repository = self._container.position_repository()
-                position_action_repository = self._container.position_action_repository()
+                database_engine = self._container.database_engine()
                 trade_repository = self._container.trade_repository()
-                logger.debug("Position manager initialized with database repositories")
+                logger.debug("Position manager initialized with database engine")
             except Exception as e:
-                logger.warning(f"Failed to initialize position manager repositories: {e}")
+                logger.warning(f"Failed to initialize position manager database: {e}")
 
         position_manager = PositionManager(
             broker,
             self.config.position_management,
-            position_repository=position_repository,
-            position_action_repository=position_action_repository,
+            database_engine=database_engine,
             trade_repository=trade_repository,
         )
         logger.info("Position management enabled")

--- a/src/daemon/positions.py
+++ b/src/daemon/positions.py
@@ -14,8 +14,7 @@ from src.data.broker import AlpacaBroker, BrokerPosition
 from src.workflows.types import TradingWorkflowResult
 
 if TYPE_CHECKING:
-    from src.database.repositories.position import PositionRecordRepository
-    from src.database.repositories.position_action import PositionManagementActionRepository
+    from src.database.engine import DatabaseEngine
     from src.database.repositories.trade import TradeRepository
 
 
@@ -100,8 +99,7 @@ class PositionManager:
         self,
         broker: AlpacaBroker,
         config: PositionManagementConfig,
-        position_repository: PositionRecordRepository | None = None,
-        position_action_repository: PositionManagementActionRepository | None = None,
+        database_engine: DatabaseEngine | None = None,
         trade_repository: TradeRepository | None = None,
     ) -> None:
         """Initialize position manager.
@@ -109,14 +107,12 @@ class PositionManager:
         Args:
             broker: Alpaca broker for order execution
             config: Position management configuration
-            position_repository: Optional position record repository
-            position_action_repository: Optional position action repository
+            database_engine: Optional database engine for creating per-task sessions
             trade_repository: Optional trade repository for loading entry metadata
         """
         self.broker = broker
         self.config = config
-        self._position_repository = position_repository
-        self._position_action_repository = position_action_repository
+        self._database_engine = database_engine
         self._trade_repository = trade_repository
         logger.info(f"PositionManager initialized: {config}")
 
@@ -185,33 +181,66 @@ class PositionManager:
 
     def _persist_position_create(self, position: PositionRecord) -> None:
         """Persist new position to database."""
-        if self._position_repository:
+        if self._database_engine:
             try:
-                task = asyncio.create_task(self._position_repository.create(position))  # type: ignore[bad-argument-type]
+                task = asyncio.create_task(self._async_persist_position_create(position))
                 task.add_done_callback(_log_task_exception)
             except Exception as e:
                 logger.error(f"Failed to persist new position to database: {e}")
                 raise
 
+    async def _async_persist_position_create(self, position: PositionRecord) -> None:
+        """Async helper to persist position with fresh session."""
+        from src.database.repositories.position import PositionRecordRepository
+
+        session = self._database_engine.session()  # type: ignore[missing-attribute]
+        try:
+            repository = PositionRecordRepository(session)
+            await repository.create(position)  # type: ignore[bad-argument-type]
+        finally:
+            await session.close()
+
     def _persist_position_update(self, position: PositionRecord) -> None:
         """Persist position update to database."""
-        if self._position_repository:
+        if self._database_engine:
             try:
-                task = asyncio.create_task(self._position_repository.update(position))  # type: ignore[bad-argument-type]
+                task = asyncio.create_task(self._async_persist_position_update(position))
                 task.add_done_callback(_log_task_exception)
             except Exception as e:
                 logger.error(f"Failed to update position in database: {e}")
                 raise
 
+    async def _async_persist_position_update(self, position: PositionRecord) -> None:
+        """Async helper to persist position update with fresh session."""
+        from src.database.repositories.position import PositionRecordRepository
+
+        session = self._database_engine.session()  # type: ignore[missing-attribute]
+        try:
+            repository = PositionRecordRepository(session)
+            await repository.update(position)  # type: ignore[bad-argument-type]
+        finally:
+            await session.close()
+
     def _persist_position_delete(self, symbol: str) -> None:
         """Delete position from database."""
-        if self._position_repository:
+        if self._database_engine:
             try:
-                task = asyncio.create_task(self._position_repository.delete_by_symbol(symbol))
+                task = asyncio.create_task(self._async_persist_position_delete(symbol))
                 task.add_done_callback(_log_task_exception)
             except Exception as e:
                 logger.error(f"Failed to delete position from database: {e}")
                 raise
+
+    async def _async_persist_position_delete(self, symbol: str) -> None:
+        """Async helper to delete position with fresh session."""
+        from src.database.repositories.position import PositionRecordRepository
+
+        session = self._database_engine.session()  # type: ignore[missing-attribute]
+        try:
+            repository = PositionRecordRepository(session)
+            await repository.delete_by_symbol(symbol)
+        finally:
+            await session.close()
 
     def _create_position_from_broker(self, symbol: str, broker_pos: BrokerPosition) -> PositionRecord:
         """Create PositionRecord from broker position.
@@ -356,12 +385,10 @@ class PositionManager:
             elif action.action_type in ("PARTIAL_PROFIT", "TIME_EXIT", "CONVICTION_SCALE"):
                 self._execute_sell_action(position, action)
 
-            # Persist action to database if repository available
-            if self._position_action_repository:
+            # Persist action to database if database engine available
+            if self._database_engine:
                 try:
-                    import asyncio
-
-                    task = asyncio.create_task(self._position_action_repository.create(action))  # type: ignore[bad-argument-type]
+                    task = asyncio.create_task(self._async_persist_action(action))
                     task.add_done_callback(_log_task_exception)
                     logger.debug(
                         f"Persisted position action to database: {action.symbol} {action.action_type}"
@@ -369,6 +396,17 @@ class PositionManager:
                 except Exception as e:
                     logger.error(f"Failed to persist position action to database: {e}")
                     raise  # Fail fast per user requirement
+
+    async def _async_persist_action(self, action: PositionManagementAction) -> None:
+        """Async helper to persist action with fresh session."""
+        from src.database.repositories.position_action import PositionManagementActionRepository
+
+        session = self._database_engine.session()  # type: ignore[missing-attribute]
+        try:
+            repository = PositionManagementActionRepository(session)
+            await repository.create(action)  # type: ignore[bad-argument-type]
+        finally:
+            await session.close()
 
     def review_position(
         self,


### PR DESCRIPTION
## Motivation

The daemon was encountering `RuntimeError: Event loop is closed` and `Future attached to a different loop` errors during position synchronization and action persistence. These errors occurred when background tasks attempted to use SQLAlchemy AsyncSession objects that were created on a different event loop.

SQLAlchemy AsyncSession objects are bound to the event loop active when they're created. The previous implementation created repositories with sessions in the DI container (on loop A), then used those repositories from fire-and-forget tasks (on loop B or after loop A closed).

## Implementation information

**Changed PositionManager to use DatabaseEngine instead of pre-created repositories:**
- Constructor now accepts `database_engine: DatabaseEngine | None` instead of individual repository instances
- Removed direct repository instance variables

**Added async helper methods for database operations:**
- `_async_persist_position_create()` - Creates fresh session, persists position, closes session
- `_async_persist_position_update()` - Creates fresh session, updates position, closes session
- `_async_persist_position_delete()` - Creates fresh session, deletes position, closes session
- `_async_persist_action()` - Creates fresh session, persists action, closes session

**Each helper follows the pattern:**
1. Create new session on current event loop: `session = self._database_engine.session()`
2. Instantiate repository with fresh session
3. Perform database operation
4. Close session in finally block

**Updated factory.py:**
- Pass `database_engine` singleton instead of repository factory instances
- Simplified initialization logic

**Alternatives considered:**
- Making PositionManager fully async: Rejected - would require extensive refactoring of sync broker API integration
- Using asyncio.run() inside tasks: Rejected - creates nested event loops (the original problem we're removing nest_asyncio for)
- Session pooling/reuse: Rejected - sessions cannot safely cross event loop boundaries

## Supporting documentation

Related to ongoing effort to remove nest_asyncio dependency and fix async/sync boundary issues.

**Test coverage:**
- All 1747 existing tests pass
- Type checking passes (pyrefly)
- Linting passes (ruff)