### PR TITLE
fix: abort stop-loss update if cancellation fails

### DIFF
--- a/src/daemon/positions.py
+++ b/src/daemon/positions.py
@@ -678,7 +678,8 @@ class PositionManager:
                 self.broker.cancel_order(position.stop_loss_order_id)
                 logger.info(f"Cancelled old stop-loss order: {position.stop_loss_order_id}")
             except Exception as e:
-                logger.warning(f"Failed to cancel old stop-loss order: {e}")
+                logger.error(f"Failed to cancel old stop-loss order {position.stop_loss_order_id}: {e}")
+                return None
 
         # Verify position still exists and get current price
         broker_info = self.broker.get_account_info()


### PR DESCRIPTION
## Motivation

Trailing stop-loss updates were failing with Alpaca API error `insufficient qty available for order` because the code attempted to submit new stop-loss orders while old orders still held all shares.

## Implementation information

Changed `PositionManager._update_stop_loss()` to return `None` immediately when order cancellation fails, instead of catching the exception and continuing execution.

**Before:** Exception was caught, logged as warning, and execution continued → new order submitted → broker rejected due to double allocation.

**After:** Exception caught, logged as error, returns `None` → no duplicate order submission.

**File:** `src/daemon/positions.py:680-682`

**Alternatives considered:**
- Retry cancellation with backoff: Added complexity, doesn't address root issue of continuing on failure
- Verify cancellation succeeded: Additional API call overhead, still doesn't prevent the core problem
- Wait delay after cancellation: Band-aid solution, unreliable

**Chosen approach:** Fail-fast on cancellation error - simplest and safest solution.

## Supporting documentation

Fixes #471