### PR TITLE
feat(frontend): add analyses per-hour histogram

### DIFF
--- a/frontend/src/lib/components/charts/BarChart.svelte
+++ b/frontend/src/lib/components/charts/BarChart.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import * as echarts from 'echarts';
+	import type { ECharts, EChartsOption } from 'echarts';
+
+	interface DataPoint {
+		label: string;
+		value: number;
+		color?: string;
+	}
+
+	interface Props {
+		data: DataPoint[];
+		title?: string;
+		height?: number;
+		defaultColor?: string;
+		yAxisLabel?: string;
+		xAxisLabel?: string;
+	}
+
+	let { data, title, height = 300, defaultColor = '#3b82f6', yAxisLabel, xAxisLabel }: Props = $props();
+
+	let chartContainer = null as unknown as HTMLElement;
+	let chart: ECharts | null = null;
+
+	onMount(() => {
+		chart = echarts.init(chartContainer, 'dark');
+
+		const option: EChartsOption = {
+			backgroundColor: 'transparent',
+			title: title ? {
+				text: title,
+				textStyle: { color: '#e2e8f0', fontSize: 14 }
+			} : undefined,
+			tooltip: {
+				trigger: 'axis',
+				backgroundColor: '#1e293b',
+				borderColor: '#334155',
+				textStyle: { color: '#e2e8f0' },
+				axisPointer: {
+					type: 'shadow'
+				}
+			},
+			grid: {
+				left: '3%',
+				right: '4%',
+				bottom: '3%',
+				containLabel: true
+			},
+			xAxis: {
+				type: 'category',
+				data: data.map(d => d.label),
+				name: xAxisLabel,
+				nameTextStyle: { color: '#94a3b8' },
+				axisLine: { lineStyle: { color: '#334155' } },
+				axisLabel: { color: '#94a3b8', rotate: 45 }
+			},
+			yAxis: {
+				type: 'value',
+				name: yAxisLabel,
+				nameTextStyle: { color: '#94a3b8' },
+				axisLine: { lineStyle: { color: '#334155' } },
+				axisLabel: { color: '#94a3b8' },
+				splitLine: { lineStyle: { color: '#334155' } }
+			},
+			series: [
+				{
+					data: data.map(d => ({
+						value: d.value,
+						itemStyle: { color: d.color || defaultColor }
+					})),
+					type: 'bar',
+					barWidth: '60%'
+				}
+			]
+		};
+
+		chart.setOption(option);
+
+		const resizeObserver = new ResizeObserver(() => {
+			chart?.resize();
+		});
+		resizeObserver.observe(chartContainer);
+
+		return () => {
+			resizeObserver.disconnect();
+			chart?.dispose();
+		};
+	});
+
+	$effect(() => {
+		if (chart && data) {
+			chart.setOption({
+				xAxis: {
+					data: data.map(d => d.label)
+				},
+				series: [{
+					data: data.map(d => ({
+						value: d.value,
+						itemStyle: { color: d.color || defaultColor }
+					}))
+				}]
+			});
+		}
+	});
+</script>
+
+<div bind:this={chartContainer} style="width: 100%; height: {height}px;"></div>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -3,6 +3,7 @@
 	import Card from '$lib/components/ui/Card.svelte';
 	import DataTable from '$lib/components/ui/DataTable.svelte';
 	import LineChart from '$lib/components/charts/LineChart.svelte';
+	import BarChart from '$lib/components/charts/BarChart.svelte';
 	import ServiceHealthBadge from '$lib/components/ui/ServiceHealthBadge.svelte';
 	import GamePlanCard from '$lib/components/ui/GamePlanCard.svelte';
 	import WatchlistBreakdown from '$lib/components/ui/WatchlistBreakdown.svelte';
@@ -15,7 +16,7 @@
 		degradation
 	} from '$lib/stores/dashboard';
 	import { formatPercent, formatDateShort } from '$lib/utils/format';
-	import type { AnalysisRecordResponse } from '$lib/types/api';
+	import type { AnalysisRecordResponse, Signal } from '$lib/types/api';
 
 	$: summary = $stateSummary;
 	$: services = $serviceHealth;
@@ -32,6 +33,39 @@
 			time: formatDateShort(a.timestamp),
 			value: a.confidence
 		}));
+
+	// Histogram: analyses per hour (last 24 hours)
+	$: analysesPerHour = (() => {
+		const now = new Date();
+		const hourBuckets: Record<string, { count: number; bySignal: Record<Signal, number> }> = {};
+
+		// Initialize 24 hour buckets
+		for (let i = 23; i >= 0; i--) {
+			const hourDate = new Date(now.getTime() - i * 60 * 60 * 1000);
+			const hourLabel = `${hourDate.getHours().toString().padStart(2, '0')}:00`;
+			hourBuckets[hourLabel] = { count: 0, bySignal: { BUY: 0, SELL: 0, HOLD: 0 } };
+		}
+
+		// Count analyses per hour
+		recentAnalyses.forEach(analysis => {
+			const analysisDate = new Date(analysis.timestamp);
+			const hoursSince = Math.floor((now.getTime() - analysisDate.getTime()) / (60 * 60 * 1000));
+			if (hoursSince < 24 && hoursSince >= 0) {
+				const hourLabel = `${analysisDate.getHours().toString().padStart(2, '0')}:00`;
+				if (hourBuckets[hourLabel]) {
+					hourBuckets[hourLabel].count++;
+					hourBuckets[hourLabel].bySignal[analysis.signal]++;
+				}
+			}
+		});
+
+		// Convert to array format for chart
+		return Object.entries(hourBuckets).map(([label, data]) => ({
+			label,
+			value: data.count,
+			color: data.count > 0 ? '#3b82f6' : '#334155'
+		}));
+	})();
 
 	const analysisColumns = [
 		{
@@ -112,6 +146,23 @@
 				height={300}
 				color="#3b82f6"
 				yAxisLabel="Confidence"
+			/>
+		{:else}
+			<div class="text-center py-12 text-slate-400">
+				No analysis data available
+			</div>
+		{/if}
+	</Card>
+
+	<!-- Analyses Per Hour Histogram -->
+	<Card title="Analyses Per Hour (Last 24h)">
+		{#if analysesPerHour.length > 0}
+			<BarChart
+				data={analysesPerHour}
+				height={300}
+				defaultColor="#3b82f6"
+				yAxisLabel="Count"
+				xAxisLabel="Hour"
 			/>
 		{:else}
 			<div class="text-center py-12 text-slate-400">


### PR DESCRIPTION
## Motivation

Adds visibility into system activity patterns by showing when analyses are occurring throughout the day. Helps with capacity planning and identifying peak activity periods.

## Implementation information

- Created reusable BarChart component using Apache ECharts
- Added histogram visualization on Overview page showing analyses per hour for last 24 hours
- Automatically groups analyses into hourly buckets based on timestamp
- Visual coding: blue bars for hours with data, gray bars for empty hours
- Interactive tooltips show exact counts
- Integrates with existing dashboard auto-refresh (5s interval)

## Supporting documentation

Fixes #485
