### PR TITLE
style(frontend): convert to light theme

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -5,9 +5,9 @@
 	line-height: 1.5;
 	font-weight: 400;
 
-	color-scheme: light dark;
-	color: rgba(255, 255, 255, 0.87);
-	background-color: #242424;
+	color-scheme: light;
+	color: #000000;
+	background-color: #ffffff;
 
 	font-synthesis: none;
 	text-rendering: optimizeLegibility;

--- a/frontend/src/lib/components/charts/BarChart.svelte
+++ b/frontend/src/lib/components/charts/BarChart.svelte
@@ -24,19 +24,19 @@
 	let chart: ECharts | null = null;
 
 	onMount(() => {
-		chart = echarts.init(chartContainer, 'dark');
+		chart = echarts.init(chartContainer);
 
 		const option: EChartsOption = {
 			backgroundColor: 'transparent',
 			title: title ? {
 				text: title,
-				textStyle: { color: '#e2e8f0', fontSize: 14 }
+				textStyle: { color: '#000000', fontSize: 14 }
 			} : undefined,
 			tooltip: {
 				trigger: 'axis',
-				backgroundColor: '#1e293b',
-				borderColor: '#334155',
-				textStyle: { color: '#e2e8f0' },
+				backgroundColor: '#ffffff',
+				borderColor: '#d1d5db',
+				textStyle: { color: '#000000' },
 				axisPointer: {
 					type: 'shadow'
 				}
@@ -51,17 +51,17 @@
 				type: 'category',
 				data: data.map(d => d.label),
 				name: xAxisLabel,
-				nameTextStyle: { color: '#94a3b8' },
-				axisLine: { lineStyle: { color: '#334155' } },
-				axisLabel: { color: '#94a3b8', rotate: 45 }
+				nameTextStyle: { color: '#4b5563' },
+				axisLine: { lineStyle: { color: '#d1d5db' } },
+				axisLabel: { color: '#4b5563', rotate: 45 }
 			},
 			yAxis: {
 				type: 'value',
 				name: yAxisLabel,
-				nameTextStyle: { color: '#94a3b8' },
-				axisLine: { lineStyle: { color: '#334155' } },
-				axisLabel: { color: '#94a3b8' },
-				splitLine: { lineStyle: { color: '#334155' } }
+				nameTextStyle: { color: '#4b5563' },
+				axisLine: { lineStyle: { color: '#d1d5db' } },
+				axisLabel: { color: '#4b5563' },
+				splitLine: { lineStyle: { color: '#e5e7eb' } }
 			},
 			series: [
 				{

--- a/frontend/src/lib/components/charts/CandlestickChart.svelte
+++ b/frontend/src/lib/components/charts/CandlestickChart.svelte
@@ -26,11 +26,11 @@
 		const chartInstance = createChart(chartContainer, {
 			layout: {
 				background: { type: ColorType.Solid, color: 'transparent' },
-				textColor: '#94a3b8'
+				textColor: '#4b5563'
 			},
 			grid: {
-				vertLines: { color: '#334155' },
-				horzLines: { color: '#334155' }
+				vertLines: { color: '#e5e7eb' },
+				horzLines: { color: '#e5e7eb' }
 			},
 			width: chartContainer.clientWidth,
 			height,
@@ -42,10 +42,10 @@
 		chart = chartInstance;
 
 		candlestickSeries = (chartInstance as any).addCandlestickSeries({
-			upColor: '#10b981',
+			upColor: '#059669',
 			downColor: '#ef4444',
 			borderVisible: false,
-			wickUpColor: '#10b981',
+			wickUpColor: '#059669',
 			wickDownColor: '#ef4444'
 		});
 
@@ -80,7 +80,7 @@
 
 <div class="w-full">
 	{#if symbol}
-		<div class="mb-2 text-sm font-medium text-slate-300">{symbol}</div>
+		<div class="mb-2 text-sm font-medium text-gray-700">{symbol}</div>
 	{/if}
-	<div bind:this={chartContainer} class="rounded-lg overflow-hidden bg-slate-900"></div>
+	<div bind:this={chartContainer} class="rounded-lg overflow-hidden bg-white"></div>
 </div>

--- a/frontend/src/lib/components/charts/GaugeChart.svelte
+++ b/frontend/src/lib/components/charts/GaugeChart.svelte
@@ -24,7 +24,7 @@
 	let chart: ECharts | null = null;
 
 	onMount(() => {
-		chart = echarts.init(chartContainer, 'dark');
+		chart = echarts.init(chartContainer);
 
 		const option: EChartsOption = {
 			backgroundColor: 'transparent',
@@ -42,7 +42,7 @@
 						lineStyle: {
 							width: 20,
 							color: [
-								[thresholds.low / max, '#10b981'],
+								[thresholds.low / max, '#059669'],
 								[thresholds.medium / max, '#f59e0b'],
 								[1, '#ef4444']
 							]
@@ -50,7 +50,7 @@
 					},
 					pointer: {
 						itemStyle: {
-							color: '#e2e8f0'
+							color: '#374151'
 						},
 						width: 5,
 						length: '60%'
@@ -59,7 +59,7 @@
 						distance: -20,
 						length: 6,
 						lineStyle: {
-							color: '#334155',
+							color: '#d1d5db',
 							width: 1
 						}
 					},
@@ -67,12 +67,12 @@
 						distance: -20,
 						length: 12,
 						lineStyle: {
-							color: '#334155',
+							color: '#d1d5db',
 							width: 2
 						}
 					},
 					axisLabel: {
-						color: '#94a3b8',
+						color: '#4b5563',
 						distance: 20,
 						fontSize: 11,
 						formatter: (value: number) => value.toFixed(0)
@@ -80,7 +80,7 @@
 					title: {
 						offsetCenter: [0, '85%'],
 						fontSize: 14,
-						color: '#e2e8f0'
+						color: '#000000'
 					},
 					detail: {
 						fontSize: 22,
@@ -91,11 +91,11 @@
 							value: {
 								fontSize: 24,
 								fontWeight: 'bold',
-								color: '#e2e8f0'
+								color: '#000000'
 							},
 							unit: {
 								fontSize: 16,
-								color: '#94a3b8',
+								color: '#4b5563',
 								padding: [0, 0, 0, 4]
 							}
 						}

--- a/frontend/src/lib/components/charts/HeatmapChart.svelte
+++ b/frontend/src/lib/components/charts/HeatmapChart.svelte
@@ -30,7 +30,7 @@
 			backgroundColor: 'transparent',
 			title: {
 				text: title,
-				textStyle: { color: '#e2e8f0', fontSize: 16 }
+				textStyle: { color: '#000000', fontSize: 16 }
 			},
 			tooltip: {
 				position: 'top',
@@ -49,13 +49,13 @@
 				type: 'category',
 				data: symbols,
 				splitArea: { show: true },
-				axisLabel: { color: '#94a3b8' }
+				axisLabel: { color: '#4b5563' }
 			},
 			yAxis: {
 				type: 'category',
 				data: symbols,
 				splitArea: { show: true },
-				axisLabel: { color: '#94a3b8' }
+				axisLabel: { color: '#4b5563' }
 			},
 			visualMap: {
 				min: -1,
@@ -65,9 +65,9 @@
 				left: 'center',
 				bottom: '5%',
 				inRange: {
-					color: ['#ef4444', '#f59e0b', '#10b981']
+					color: ['#ef4444', '#f59e0b', '#059669']
 				},
-				textStyle: { color: '#94a3b8' }
+				textStyle: { color: '#4b5563' }
 			},
 			series: [
 				{
@@ -77,7 +77,7 @@
 					label: {
 						show: true,
 						formatter: (params: any) => params.data[2].toFixed(2),
-						color: '#e2e8f0'
+						color: '#000000'
 					},
 					emphasis: {
 						itemStyle: {
@@ -93,7 +93,7 @@
 	}
 
 	onMount(() => {
-		chart = echarts.init(chartContainer, 'dark');
+		chart = echarts.init(chartContainer);
 		updateChart();
 
 		const resizeObserver = new ResizeObserver(() => {

--- a/frontend/src/lib/components/charts/LineChart.svelte
+++ b/frontend/src/lib/components/charts/LineChart.svelte
@@ -22,19 +22,19 @@
 	let chart: ECharts | null = null;
 
 	onMount(() => {
-		chart = echarts.init(chartContainer, 'dark');
+		chart = echarts.init(chartContainer);
 
 		const option: EChartsOption = {
 			backgroundColor: 'transparent',
 			title: title ? {
 				text: title,
-				textStyle: { color: '#e2e8f0', fontSize: 14 }
+				textStyle: { color: '#000000', fontSize: 14 }
 			} : undefined,
 			tooltip: {
 				trigger: 'axis',
-				backgroundColor: '#1e293b',
-				borderColor: '#334155',
-				textStyle: { color: '#e2e8f0' }
+				backgroundColor: '#ffffff',
+				borderColor: '#d1d5db',
+				textStyle: { color: '#000000' }
 			},
 			grid: {
 				left: '3%',
@@ -46,16 +46,16 @@
 				type: 'category',
 				boundaryGap: false,
 				data: data.map(d => typeof d.time === 'string' ? d.time : d.time.toLocaleString()),
-				axisLine: { lineStyle: { color: '#334155' } },
-				axisLabel: { color: '#94a3b8' }
+				axisLine: { lineStyle: { color: '#d1d5db' } },
+				axisLabel: { color: '#4b5563' }
 			},
 			yAxis: {
 				type: 'value',
 				name: yAxisLabel,
-				nameTextStyle: { color: '#94a3b8' },
-				axisLine: { lineStyle: { color: '#334155' } },
-				axisLabel: { color: '#94a3b8' },
-				splitLine: { lineStyle: { color: '#334155' } }
+				nameTextStyle: { color: '#4b5563' },
+				axisLine: { lineStyle: { color: '#d1d5db' } },
+				axisLabel: { color: '#4b5563' },
+				splitLine: { lineStyle: { color: '#e5e7eb' } }
 			},
 			series: [
 				{

--- a/frontend/src/lib/components/charts/RebalanceChart.svelte
+++ b/frontend/src/lib/components/charts/RebalanceChart.svelte
@@ -24,14 +24,14 @@
 
 		// Color-code current bars: green for underweight, red for overweight
 		const barColors = deltas.map(d =>
-			d < 0 ? '#10b981' : d > 0 ? '#ef4444' : '#6b7280'
+			d < 0 ? '#059669' : d > 0 ? '#ef4444' : '#6b7280'
 		);
 
 		const option: EChartsOption = {
 			backgroundColor: 'transparent',
 			title: {
 				subtext: 'Green = Underweight, Red = Overweight',
-				subtextStyle: { color: '#94a3b8', fontSize: 12 }
+				subtextStyle: { color: '#4b5563', fontSize: 12 }
 			},
 			tooltip: {
 				trigger: 'axis',
@@ -55,21 +55,21 @@
 			},
 			legend: {
 				data: ['Target', 'Current'],
-				textStyle: { color: '#e2e8f0' }
+				textStyle: { color: '#000000' }
 			},
 			xAxis: {
 				type: 'category',
 				data: symbols,
-				axisLabel: { color: '#e2e8f0' },
-				axisLine: { lineStyle: { color: '#475569' } }
+				axisLabel: { color: '#000000' },
+				axisLine: { lineStyle: { color: '#9ca3af' } }
 			},
 			yAxis: {
 				type: 'value',
 				name: 'Weight (%)',
-				nameTextStyle: { color: '#e2e8f0' },
-				axisLabel: { color: '#e2e8f0' },
-				axisLine: { lineStyle: { color: '#475569' } },
-				splitLine: { lineStyle: { color: '#334155' } }
+				nameTextStyle: { color: '#000000' },
+				axisLabel: { color: '#000000' },
+				axisLine: { lineStyle: { color: '#9ca3af' } },
+				splitLine: { lineStyle: { color: '#e5e7eb' } }
 			},
 			series: [
 				{
@@ -94,7 +94,7 @@
 
 	onMount(() => {
 		if (chartContainer) {
-			chart = echarts.init(chartContainer, 'dark');
+			chart = echarts.init(chartContainer);
 			updateChart();
 
 			const resizeObserver = new ResizeObserver(() => {

--- a/frontend/src/lib/components/charts/SectorRotationHeatmap.svelte
+++ b/frontend/src/lib/components/charts/SectorRotationHeatmap.svelte
@@ -64,14 +64,14 @@
 			backgroundColor: 'transparent',
 			title: {
 				text: chartTitle,
-				textStyle: { color: '#e2e8f0', fontSize: 14 },
+				textStyle: { color: '#000000', fontSize: 14 },
 				left: 'center'
 			},
 			tooltip: {
 				position: 'top',
-				backgroundColor: '#1e293b',
-				borderColor: '#334155',
-				textStyle: { color: '#e2e8f0' },
+				backgroundColor: '#ffffff',
+				borderColor: '#d1d5db',
+				textStyle: { color: '#000000' },
 				formatter: (params: any) => {
 					const sectorIdx = params.data[1];
 					const ticker = sortedSectors[sectorIdx];
@@ -96,13 +96,13 @@
 				type: 'category',
 				data: ['Relative Strength'],
 				splitArea: { show: false },
-				axisLabel: { color: '#94a3b8', fontSize: 12 }
+				axisLabel: { color: '#4b5563', fontSize: 12 }
 			},
 			yAxis: {
 				type: 'category',
 				data: yAxisLabels,
 				splitArea: { show: true },
-				axisLabel: { color: '#94a3b8', fontSize: 11 }
+				axisLabel: { color: '#4b5563', fontSize: 11 }
 			},
 			visualMap: {
 				min: 0,
@@ -112,9 +112,9 @@
 				left: 'center',
 				bottom: '3%',
 				inRange: {
-					color: ['#ef4444', '#f59e0b', '#84cc16', '#10b981']
+					color: ['#ef4444', '#f59e0b', '#84cc16', '#059669']
 				},
-				textStyle: { color: '#94a3b8' },
+				textStyle: { color: '#4b5563' },
 				formatter: '{value}%' as any
 			},
 			series: [
@@ -125,14 +125,14 @@
 					label: {
 						show: true,
 						formatter: (params: any) => `${params.data[2].toFixed(1)}%`,
-						color: '#e2e8f0',
+						color: '#000000',
 						fontSize: 11
 					},
 					emphasis: {
 						itemStyle: {
 							shadowBlur: 10,
 							shadowColor: 'rgba(0, 0, 0, 0.5)',
-							borderColor: '#e2e8f0',
+							borderColor: '#000000',
 							borderWidth: 2
 						}
 					},
@@ -140,7 +140,7 @@
 						borderColor: ((params: any) => {
 							const sectorIdx = params.data[1];
 							const ticker = sortedSectors[sectorIdx];
-							return (leadingSectors?.includes(ticker) ?? false) ? '#fbbf24' : '#334155';
+							return (leadingSectors?.includes(ticker) ?? false) ? '#fbbf24' : '#d1d5db';
 						}) as any,
 						borderWidth: ((params: any) => {
 							const sectorIdx = params.data[1];
@@ -156,7 +156,7 @@
 	}
 
 	onMount(() => {
-		chart = echarts.init(chartContainer, 'dark');
+		chart = echarts.init(chartContainer);
 		updateChart();
 
 		const resizeObserver = new ResizeObserver(() => {

--- a/frontend/src/lib/components/charts/TreemapChart.svelte
+++ b/frontend/src/lib/components/charts/TreemapChart.svelte
@@ -24,9 +24,10 @@
 
 		const option: EChartsOption = {
 			backgroundColor: 'transparent',
+			color: ['#e5e7eb', '#d1d5db', '#9ca3af', '#6b7280', '#4b5563'],
 			title: {
 				text: title,
-				textStyle: { color: '#e2e8f0', fontSize: 16 }
+				textStyle: { color: '#000000', fontSize: 16 }
 			},
 			tooltip: {
 				formatter: (params: any) => {
@@ -44,10 +45,10 @@
 						formatter: (params: any) => {
 							return `${params.name}\n$${params.value.toLocaleString()}`;
 						},
-						color: '#e2e8f0'
+						color: '#000000'
 					},
 					itemStyle: {
-						borderColor: '#1e293b',
+						borderColor: '#ffffff',
 						borderWidth: 2
 					},
 					levels: [
@@ -61,7 +62,7 @@
 							itemStyle: {
 								gapWidth: 1
 							},
-							colorSaturation: [0.35, 0.5]
+							colorSaturation: [0.15, 0.25]
 						}
 					],
 					visualDimension: 0,
@@ -75,7 +76,7 @@
 	}
 
 	onMount(() => {
-		chart = echarts.init(chartContainer, 'dark');
+		chart = echarts.init(chartContainer);
 		updateChart();
 
 		const resizeObserver = new ResizeObserver(() => {

--- a/frontend/src/lib/components/ui/Accordion.svelte
+++ b/frontend/src/lib/components/ui/Accordion.svelte
@@ -43,17 +43,17 @@
 
 <div class="space-y-3">
 	{#each items as item}
-		<div class="border border-slate-700 rounded-lg bg-slate-800 overflow-hidden">
+		<div class="border border-gray-300 rounded-lg bg-white overflow-hidden">
 			<button
 				type="button"
-				class="w-full px-6 py-4 text-left flex items-center justify-between hover:bg-slate-700/50 transition-colors"
+				class="w-full px-6 py-4 text-left flex items-center justify-between hover:bg-gray-50 transition-colors"
 				onclick={() => toggle(item.id)}
 				aria-expanded={isOpen(item.id)}
 				aria-controls={`accordion-content-${item.id}`}
 			>
-				<h3 class="text-lg font-semibold text-slate-100">{item.title}</h3>
+				<h3 class="text-lg font-semibold text-black">{item.title}</h3>
 				<svg
-					class="w-5 h-5 text-slate-400 transition-transform duration-200"
+					class="w-5 h-5 text-gray-600 transition-transform duration-200"
 					class:rotate-180={isOpen(item.id)}
 					fill="none"
 					stroke="currentColor"
@@ -66,7 +66,7 @@
 			{#if isOpen(item.id)}
 				<div
 					id={`accordion-content-${item.id}`}
-					class="px-6 pb-6 border-t border-slate-700 animate-fadeIn"
+					class="px-6 pb-6 border-t border-gray-300 animate-fadeIn"
 				>
 					{#if content}
 						{@render content(item.content())}

--- a/frontend/src/lib/components/ui/Badge.svelte
+++ b/frontend/src/lib/components/ui/Badge.svelte
@@ -10,14 +10,14 @@
 	let { variant, children }: Props = $props();
 
 	const variantStyles: Record<string, string> = {
-		BUY: 'bg-green-500/10 text-green-400 border-green-500/20',
-		SELL: 'bg-red-500/10 text-red-400 border-red-500/20',
-		HOLD: 'bg-slate-500/10 text-slate-400 border-slate-500/20',
-		success: 'bg-green-500/10 text-green-400 border-green-500/20',
-		error: 'bg-red-500/10 text-red-400 border-red-500/20',
-		warning: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
-		info: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
-		neutral: 'bg-slate-500/10 text-slate-400 border-slate-500/20'
+		BUY: 'bg-green-50 text-green-700 border-green-300',
+		SELL: 'bg-red-50 text-red-700 border-red-300',
+		HOLD: 'bg-gray-50 text-gray-700 border-gray-300',
+		success: 'bg-green-50 text-green-700 border-green-300',
+		error: 'bg-red-50 text-red-700 border-red-300',
+		warning: 'bg-yellow-50 text-yellow-700 border-yellow-300',
+		info: 'bg-blue-50 text-blue-700 border-blue-300',
+		neutral: 'bg-gray-50 text-gray-700 border-gray-300'
 	};
 
 	const classes = $derived(variantStyles[variant] || variantStyles.neutral);

--- a/frontend/src/lib/components/ui/Card.svelte
+++ b/frontend/src/lib/components/ui/Card.svelte
@@ -10,10 +10,10 @@
 	let { title, class: className, children }: Props = $props();
 </script>
 
-<div class="bg-slate-800 rounded-lg border border-slate-700 {className}">
+<div class="bg-white rounded-lg border border-gray-300 {className}">
 	{#if title}
-		<div class="px-6 py-4 border-b border-slate-700">
-			<h3 class="text-lg font-semibold text-slate-100">{title}</h3>
+		<div class="px-6 py-4 border-b border-gray-300">
+			<h3 class="text-lg font-semibold text-black">{title}</h3>
 		</div>
 	{/if}
 	<div class="p-6">

--- a/frontend/src/lib/components/ui/DataTable.svelte
+++ b/frontend/src/lib/components/ui/DataTable.svelte
@@ -16,23 +16,23 @@
 </script>
 
 <div class="overflow-x-auto {className}">
-	<table class="min-w-full divide-y divide-slate-700">
-		<thead class="bg-slate-800/50">
+	<table class="min-w-full divide-y divide-gray-300">
+		<thead class="bg-gray-50">
 			<tr>
 				{#each columns as column}
-					<th 
-						class="px-6 py-3 text-left text-xs font-medium text-slate-400 uppercase tracking-wider {column.class || ''}"
+					<th
+						class="px-6 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider {column.class || ''}"
 					>
 						{column.label}
 					</th>
 				{/each}
 			</tr>
 		</thead>
-		<tbody class="bg-slate-800 divide-y divide-slate-700">
+		<tbody class="bg-white divide-y divide-gray-300">
 			{#each data as row}
-				<tr class="hover:bg-slate-700/50 transition-colors">
+				<tr class="hover:bg-gray-50 transition-colors">
 					{#each columns as column}
-						<td class="px-6 py-4 whitespace-nowrap text-sm text-slate-300">
+						<td class="px-6 py-4 whitespace-nowrap text-sm text-black">
 							{#if column.format}
 								{column.format(row[column.key], row)}
 							{:else}
@@ -45,7 +45,7 @@
 		</tbody>
 	</table>
 	{#if data.length === 0}
-		<div class="text-center py-12 text-slate-400">
+		<div class="text-center py-12 text-gray-600">
 			No data available
 		</div>
 	{/if}

--- a/frontend/src/lib/components/ui/DegradationAlert.svelte
+++ b/frontend/src/lib/components/ui/DegradationAlert.svelte
@@ -17,14 +17,14 @@
 
 {#if shouldShow && degradation}
 	<div
-		class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border-l-4 border-yellow-400 dark:border-yellow-600"
+		class="bg-white rounded-lg shadow p-4 border-l-4 border-yellow-600"
 		role="alert"
 	>
 		<div class="flex items-start gap-3">
 			<span class="text-2xl">⚠️</span>
 			<div class="flex-1">
 				<div class="flex items-center gap-3 mb-2">
-					<h3 class="text-lg font-semibold text-gray-900 dark:text-white">Service Degradation</h3>
+					<h3 class="text-lg font-semibold text-black">Service Degradation</h3>
 					<span class="px-3 py-1 rounded-full border text-sm font-medium {tierClass}">
 						{degradation.tier}
 					</span>
@@ -32,7 +32,7 @@
 
 				<!-- Confidence Adjustment -->
 				<div class="mb-2">
-					<span class="text-sm font-medium text-gray-700 dark:text-gray-300">
+					<span class="text-sm font-medium text-gray-700">
 						Confidence Adjustment: {(degradation.confidence_adjustment * 100).toFixed(0)}%
 					</span>
 				</div>
@@ -40,12 +40,12 @@
 				<!-- Unavailable Services -->
 				{#if degradation.unavailable_services.length > 0}
 					<div class="mb-2">
-						<span class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+						<span class="text-xs font-medium text-gray-600 uppercase">
 							Unavailable Services
 						</span>
 						<div class="flex flex-wrap gap-2 mt-1">
 							{#each degradation.unavailable_services as service}
-								<span class="px-2 py-1 bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200 text-xs rounded">
+								<span class="px-2 py-1 bg-red-100 text-red-800 text-xs rounded">
 									{service}
 								</span>
 							{/each}
@@ -55,11 +55,11 @@
 
 				<!-- Halt Reason -->
 				{#if degradation.halt_reason}
-					<div class="mt-2 p-2 bg-red-50 dark:bg-red-900/20 rounded">
-						<span class="text-xs font-medium text-red-700 dark:text-red-300 uppercase">
+					<div class="mt-2 p-2 bg-red-50 rounded">
+						<span class="text-xs font-medium text-red-700 uppercase">
 							Trading Halted
 						</span>
-						<p class="text-sm text-red-600 dark:text-red-400 mt-1">
+						<p class="text-sm text-red-700 mt-1">
 							{degradation.halt_reason}
 						</p>
 					</div>

--- a/frontend/src/lib/components/ui/GamePlanCard.svelte
+++ b/frontend/src/lib/components/ui/GamePlanCard.svelte
@@ -13,8 +13,8 @@
 	$: riskClass = plan ? riskColors[plan.risk_stance] || riskColors.MODERATE : '';
 </script>
 
-<div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border border-gray-200 dark:border-gray-700">
-	<h3 class="text-lg font-semibold mb-3 text-gray-900 dark:text-white">Game Plan</h3>
+<div class="bg-white rounded-lg shadow p-4 border border-gray-300">
+	<h3 class="text-lg font-semibold mb-3 text-black">Game Plan</h3>
 
 	{#if plan}
 		<div class="space-y-3">
@@ -23,7 +23,7 @@
 				<span class="px-3 py-1 rounded-full border text-sm font-medium {riskClass}">
 					{plan.risk_stance}
 				</span>
-				<span class="text-sm text-gray-600 dark:text-gray-400">
+				<span class="text-sm text-gray-600">
 					Confidence: {(plan.confidence * 100).toFixed(1)}%
 				</span>
 			</div>
@@ -31,13 +31,13 @@
 			<!-- Priority Symbols -->
 			{#if plan.priority_symbols.length > 0}
 				<div>
-					<span class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+					<span class="text-xs font-medium text-gray-600 uppercase">
 						Priority Symbols
 					</span>
 					<div class="flex flex-wrap gap-2 mt-1">
 						{#each plan.priority_symbols as symbol}
 							<span
-								class="px-2 py-1 bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 text-xs font-mono rounded"
+								class="px-2 py-1 bg-blue-100 text-blue-800 text-xs font-mono rounded"
 							>
 								{symbol}
 							</span>
@@ -49,12 +49,12 @@
 			<!-- Sector Focus -->
 			{#if plan.sector_focus.length > 0}
 				<div>
-					<span class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+					<span class="text-xs font-medium text-gray-600 uppercase">
 						Sector Focus
 					</span>
 					<div class="flex flex-wrap gap-2 mt-1">
 						{#each plan.sector_focus as sector}
-							<span class="px-2 py-1 bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-200 text-xs rounded">
+							<span class="px-2 py-1 bg-purple-100 text-purple-800 text-xs rounded">
 								{sector}
 							</span>
 						{/each}
@@ -64,17 +64,17 @@
 
 			<!-- Reasoning -->
 			<div>
-				<span class="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Reasoning</span>
-				<p class="text-sm text-gray-700 dark:text-gray-300 mt-1">{plan.reasoning}</p>
+				<span class="text-xs font-medium text-gray-600 uppercase">Reasoning</span>
+				<p class="text-sm text-gray-700 mt-1">{plan.reasoning}</p>
 			</div>
 
 			<!-- Metadata -->
-			<div class="text-xs text-gray-500 dark:text-gray-400 pt-2 border-t border-gray-200 dark:border-gray-700">
+			<div class="text-xs text-gray-600 pt-2 border-t border-gray-300">
 				Generated: {new Date(plan.generated_at).toLocaleString()}
 			</div>
 		</div>
 	{:else}
-		<p class="text-sm text-gray-500 dark:text-gray-400">
+		<p class="text-sm text-gray-600">
 			No game plan available. Enable in daemon config.
 		</p>
 	{/if}

--- a/frontend/src/lib/components/ui/MetricCard.svelte
+++ b/frontend/src/lib/components/ui/MetricCard.svelte
@@ -10,31 +10,31 @@
 	let { title, value, subtitle, trend, icon }: Props = $props();
 </script>
 
-<div class="bg-slate-800 rounded-lg border border-slate-700 p-6">
+<div class="bg-white rounded-lg border border-gray-300 p-6">
 	<div class="flex items-start justify-between">
 		<div class="flex-1">
-			<p class="text-sm font-medium text-slate-400">{title}</p>
-			<p class="mt-2 text-3xl font-bold text-slate-100">{value}</p>
+			<p class="text-sm font-medium text-gray-600">{title}</p>
+			<p class="mt-2 text-3xl font-bold text-black">{value}</p>
 			{#if subtitle}
-				<p class="mt-1 text-sm text-slate-400">{subtitle}</p>
+				<p class="mt-1 text-sm text-gray-600">{subtitle}</p>
 			{/if}
 		</div>
 		{#if icon}
-			<div class="ml-4 text-2xl text-slate-400">{icon}</div>
+			<div class="ml-4 text-2xl text-gray-600">{icon}</div>
 		{/if}
 	</div>
 	{#if trend}
 		<div class="mt-4">
 			{#if trend === 'up'}
-				<span class="inline-flex items-center text-sm font-medium text-green-400">
+				<span class="inline-flex items-center text-sm font-medium text-green-600">
 					↑ Increasing
 				</span>
 			{:else if trend === 'down'}
-				<span class="inline-flex items-center text-sm font-medium text-red-400">
+				<span class="inline-flex items-center text-sm font-medium text-red-600">
 					↓ Decreasing
 				</span>
 			{:else}
-				<span class="inline-flex items-center text-sm font-medium text-slate-400">
+				<span class="inline-flex items-center text-sm font-medium text-gray-600">
 					→ Stable
 				</span>
 			{/if}

--- a/frontend/src/lib/components/ui/RiskStatusBadge.svelte
+++ b/frontend/src/lib/components/ui/RiskStatusBadge.svelte
@@ -33,9 +33,9 @@
 	};
 
 	const colorClasses = {
-		green: 'bg-green-900 text-green-200 border-green-700',
-		yellow: 'bg-yellow-900 text-yellow-200 border-yellow-700',
-		red: 'bg-red-900 text-red-200 border-red-700'
+		green: 'bg-green-100 text-green-800 border-green-300',
+		yellow: 'bg-yellow-100 text-yellow-800 border-yellow-300',
+		red: 'bg-red-100 text-red-800 border-red-300'
 	};
 </script>
 

--- a/frontend/src/lib/components/ui/Tabs.svelte
+++ b/frontend/src/lib/components/ui/Tabs.svelte
@@ -13,15 +13,15 @@
 	let { tabs, activeTab }: Props = $props();
 </script>
 
-<div class="border-b border-slate-700">
+<div class="border-b border-gray-300">
 	<nav class="-mb-px flex space-x-8" aria-label="Tabs">
 		{#each tabs as tab}
 			<a
 				href={tab.href}
 				class="
 					{tab.id === activeTab
-						? 'border-blue-500 text-blue-400'
-						: 'border-transparent text-slate-400 hover:text-slate-300 hover:border-slate-300'}
+						? 'border-black text-black'
+						: 'border-transparent text-gray-600 hover:text-black hover:border-gray-400'}
 					whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm transition-colors
 				"
 				aria-current={tab.id === activeTab ? 'page' : undefined}

--- a/frontend/src/lib/components/ui/WatchlistBreakdown.svelte
+++ b/frontend/src/lib/components/ui/WatchlistBreakdown.svelte
@@ -12,33 +12,33 @@
 	$: hasSymbols = watchlist && watchlist.count > 0;
 </script>
 
-<div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 border border-gray-200 dark:border-gray-700">
-	<h3 class="text-lg font-semibold mb-3 text-gray-900 dark:text-white">Watchlist</h3>
+<div class="bg-white rounded-lg shadow p-4 border border-gray-300">
+	<h3 class="text-lg font-semibold mb-3 text-black">Watchlist</h3>
 
 	{#if hasSymbols && watchlist}
 		<div class="space-y-3">
 			<!-- Total Count -->
-			<div class="text-2xl font-bold text-gray-900 dark:text-white">
+			<div class="text-2xl font-bold text-black">
 				{watchlist.count} {watchlist.count === 1 ? 'Symbol' : 'Symbols'}
 			</div>
 
 			<!-- Source Breakdown -->
 			<div class="grid grid-cols-3 gap-2">
-				<div class="bg-blue-50 dark:bg-blue-900/20 rounded p-2">
-					<div class="text-xs text-gray-600 dark:text-gray-400">Config</div>
-					<div class="text-lg font-semibold text-blue-600 dark:text-blue-400">
+				<div class="bg-blue-50 rounded p-2">
+					<div class="text-xs text-gray-600">Config</div>
+					<div class="text-lg font-semibold text-blue-700">
 						{watchlist.sources.config || 0}
 					</div>
 				</div>
-				<div class="bg-green-50 dark:bg-green-900/20 rounded p-2">
-					<div class="text-xs text-gray-600 dark:text-gray-400">Broker</div>
-					<div class="text-lg font-semibold text-green-600 dark:text-green-400">
+				<div class="bg-green-50 rounded p-2">
+					<div class="text-xs text-gray-600">Broker</div>
+					<div class="text-lg font-semibold text-green-700">
 						{watchlist.sources.broker || 0}
 					</div>
 				</div>
-				<div class="bg-purple-50 dark:bg-purple-900/20 rounded p-2">
-					<div class="text-xs text-gray-600 dark:text-gray-400">Screening</div>
-					<div class="text-lg font-semibold text-purple-600 dark:text-purple-400">
+				<div class="bg-purple-50 rounded p-2">
+					<div class="text-xs text-gray-600">Screening</div>
+					<div class="text-lg font-semibold text-purple-700">
 						{watchlist.sources.screening || 0}
 					</div>
 				</div>
@@ -48,7 +48,7 @@
 			{#if watchlist.symbols.length > 0}
 				<button
 					on:click={toggleExpanded}
-					class="w-full text-left text-sm text-blue-600 dark:text-blue-400 hover:underline"
+					class="w-full text-left text-sm text-blue-700 hover:underline"
 					aria-expanded={expanded}
 					aria-controls="watchlist-symbols"
 				>
@@ -58,10 +58,10 @@
 				{#if expanded}
 					<div
 						id="watchlist-symbols"
-						class="flex flex-wrap gap-2 max-h-40 overflow-y-auto p-2 bg-gray-50 dark:bg-gray-900/50 rounded"
+						class="flex flex-wrap gap-2 max-h-40 overflow-y-auto p-2 bg-gray-50 rounded"
 					>
 						{#each watchlist.symbols as symbol}
-							<span class="px-2 py-1 bg-white dark:bg-gray-800 text-xs font-mono rounded border border-gray-200 dark:border-gray-700">
+							<span class="px-2 py-1 bg-white text-xs font-mono rounded border border-gray-300">
 								{symbol}
 							</span>
 						{/each}
@@ -70,6 +70,6 @@
 			{/if}
 		</div>
 	{:else}
-		<p class="text-sm text-gray-500 dark:text-gray-400">No watchlist data available</p>
+		<p class="text-sm text-gray-600">No watchlist data available</p>
 	{/if}
 </div>

--- a/frontend/src/lib/components/workflow/AgentBreakdownChart.svelte
+++ b/frontend/src/lib/components/workflow/AgentBreakdownChart.svelte
@@ -14,7 +14,7 @@
 	let chart: ECharts | null = null;
 
 	onMount(() => {
-		chart = echarts.init(chartContainer, 'dark');
+		chart = echarts.init(chartContainer);
 
 		const resizeObserver = new ResizeObserver(() => {
 			chart?.resize();
@@ -33,16 +33,16 @@
 				backgroundColor: 'transparent',
 				tooltip: {
 					trigger: 'axis',
-					backgroundColor: '#1e293b',
-					borderColor: '#334155',
-					textStyle: { color: '#e2e8f0' },
+					backgroundColor: '#ffffff',
+					borderColor: '#e5e7eb',
+					textStyle: { color: '#374151' },
 					axisPointer: {
 						type: 'cross'
 					}
 				},
 				legend: {
 					data: ['Latency (ms)', 'LLM Calls'],
-					textStyle: { color: '#94a3b8' },
+					textStyle: { color: '#6b7280' },
 					top: 0
 				},
 				grid: {
@@ -55,24 +55,24 @@
 				xAxis: {
 					type: 'category',
 					data: data.map(a => a.agent_name),
-					axisLine: { lineStyle: { color: '#334155' } },
-					axisLabel: { color: '#94a3b8', rotate: 45 }
+					axisLine: { lineStyle: { color: '#d1d5db' } },
+					axisLabel: { color: '#6b7280', rotate: 45 }
 				},
 				yAxis: [
 					{
 						type: 'value',
 						name: 'Latency (ms)',
-						nameTextStyle: { color: '#94a3b8' },
-						axisLine: { lineStyle: { color: '#334155' } },
-						axisLabel: { color: '#94a3b8' },
-						splitLine: { lineStyle: { color: '#334155' } }
+						nameTextStyle: { color: '#6b7280' },
+						axisLine: { lineStyle: { color: '#d1d5db' } },
+						axisLabel: { color: '#6b7280' },
+						splitLine: { lineStyle: { color: '#e5e7eb' } }
 					},
 					{
 						type: 'value',
 						name: 'LLM Calls',
-						nameTextStyle: { color: '#94a3b8' },
-						axisLine: { lineStyle: { color: '#334155' } },
-						axisLabel: { color: '#94a3b8' },
+						nameTextStyle: { color: '#6b7280' },
+						axisLine: { lineStyle: { color: '#d1d5db' } },
+						axisLabel: { color: '#6b7280' },
 						splitLine: { show: false }
 					}
 				],
@@ -88,8 +88,8 @@
 						name: 'LLM Calls',
 						type: 'line',
 						data: data.map(a => a.llm_calls),
-						itemStyle: { color: '#10b981' },
-						lineStyle: { color: '#10b981', width: 2 },
+						itemStyle: { color: '#059669' },
+						lineStyle: { color: '#059669', width: 2 },
 						yAxisIndex: 1
 					}
 				]

--- a/frontend/src/lib/components/workflow/GanttChart.svelte
+++ b/frontend/src/lib/components/workflow/GanttChart.svelte
@@ -14,7 +14,7 @@
 	let chart: ECharts | null = null;
 
 	onMount(() => {
-		chart = echarts.init(chartContainer, 'dark');
+		chart = echarts.init(chartContainer);
 
 		const resizeObserver = new ResizeObserver(() => {
 			chart?.resize();
@@ -48,9 +48,9 @@
 				backgroundColor: 'transparent',
 				tooltip: {
 					trigger: 'item',
-					backgroundColor: '#1e293b',
-					borderColor: '#334155',
-					textStyle: { color: '#e2e8f0' },
+					backgroundColor: '#ffffff',
+					borderColor: '#e5e7eb',
+					textStyle: { color: '#374151' },
 					formatter: (params: any) => {
 						const duration = (params.value[3] / 1000).toFixed(2);
 						return `${params.name}<br/>Duration: ${duration}s`;
@@ -66,16 +66,16 @@
 				xAxis: {
 					type: 'value',
 					name: 'Time (ms)',
-					nameTextStyle: { color: '#94a3b8' },
-					axisLine: { lineStyle: { color: '#334155' } },
-					axisLabel: { color: '#94a3b8' },
-					splitLine: { lineStyle: { color: '#334155' } }
+					nameTextStyle: { color: '#6b7280' },
+					axisLine: { lineStyle: { color: '#d1d5db' } },
+					axisLabel: { color: '#6b7280' },
+					splitLine: { lineStyle: { color: '#e5e7eb' } }
 				},
 				yAxis: {
 					type: 'category',
 					data: data.map(s => s.stage),
-					axisLine: { lineStyle: { color: '#334155' } },
-					axisLabel: { color: '#94a3b8' }
+					axisLine: { lineStyle: { color: '#d1d5db' } },
+					axisLabel: { color: '#6b7280' }
 				},
 				series: [
 					{

--- a/frontend/src/lib/components/workflow/HistoricalAnalysisTab.svelte
+++ b/frontend/src/lib/components/workflow/HistoricalAnalysisTab.svelte
@@ -44,7 +44,7 @@
 		<label for="workflow-selector" class="sr-only">Select workflow execution</label>
 		<select
 			id="workflow-selector"
-			class="w-full bg-slate-700 text-slate-100 border border-slate-600 rounded px-4 py-2"
+			class="w-full bg-gray-100 text-black border border-gray-300 rounded px-4 py-2"
 			bind:value={selectedWorkflowId}
 			onchange={() => handleWorkflowSelection(selectedWorkflowId)}
 		>
@@ -56,7 +56,7 @@
 			{/each}
 		</select>
 		{#if metricsList.length === 0}
-			<p class="text-slate-400 text-sm mt-2">No workflow executions found</p>
+			<p class="text-gray-600 text-sm mt-2">No workflow executions found</p>
 		{/if}
 	</Card>
 
@@ -64,16 +64,16 @@
 	{#if selectedMetrics && !loading}
 		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
 			<Card title="Total Time">
-				<p class="text-3xl font-bold text-blue-400">{totalTime}s</p>
+				<p class="text-3xl font-bold text-blue-600">{totalTime}s</p>
 			</Card>
 			<Card title="LLM Calls">
-				<p class="text-3xl font-bold text-green-400">{llmCalls}</p>
+				<p class="text-3xl font-bold text-green-600">{llmCalls}</p>
 			</Card>
 			<Card title="Tokens">
 				<p class="text-3xl font-bold text-purple-400">{totalTokens}k</p>
 			</Card>
 			<Card title="Cost">
-				<p class="text-3xl font-bold text-yellow-400">${totalCost}</p>
+				<p class="text-3xl font-bold text-yellow-600">${totalCost}</p>
 			</Card>
 		</div>
 
@@ -96,11 +96,11 @@
 		</Card>
 	{:else if loading}
 		<Card>
-			<p class="text-slate-400 text-center py-8">Loading metrics...</p>
+			<p class="text-gray-600 text-center py-8">Loading metrics...</p>
 		</Card>
 	{:else}
 		<Card>
-			<p class="text-slate-400 text-center py-8">Select a workflow execution to view details</p>
+			<p class="text-gray-600 text-center py-8">Select a workflow execution to view details</p>
 		</Card>
 	{/if}
 </div>

--- a/frontend/src/lib/components/workflow/LLMCallsTable.svelte
+++ b/frontend/src/lib/components/workflow/LLMCallsTable.svelte
@@ -25,8 +25,8 @@
 
 <div class="overflow-x-auto">
 	{#if data && data.length > 0}
-		<table class="w-full text-sm text-left text-slate-300">
-			<thead class="text-xs text-slate-400 uppercase bg-slate-700">
+		<table class="w-full text-sm text-left text-gray-700">
+			<thead class="text-xs text-gray-600 uppercase bg-gray-100">
 				<tr>
 					<th class="px-4 py-3">Time</th>
 					<th class="px-4 py-3">Agent</th>
@@ -41,7 +41,7 @@
 			</thead>
 			<tbody>
 				{#each data as call}
-					<tr class="border-b border-slate-700 hover:bg-slate-700/50">
+					<tr class="border-b border-gray-300 hover:bg-gray-100/50">
 						<td class="px-4 py-3 whitespace-nowrap">{formatTimestamp(call.timestamp)}</td>
 						<td class="px-4 py-3">{call.agent_name}</td>
 						<td class="px-4 py-3">{call.method}</td>
@@ -52,9 +52,9 @@
 						<td class="px-4 py-3 text-right">{formatCost(call.estimated_cost_usd)}</td>
 						<td class="px-4 py-3 text-center">
 							{#if call.success}
-								<span class="text-green-400">✓</span>
+								<span class="text-green-600">✓</span>
 							{:else}
-								<span class="text-red-400" title={call.error || 'Unknown error'}>✗</span>
+								<span class="text-red-600" title={call.error || 'Unknown error'}>✗</span>
 							{/if}
 						</td>
 					</tr>
@@ -62,6 +62,6 @@
 			</tbody>
 		</table>
 	{:else}
-		<p class="text-slate-400 text-center py-8">No LLM calls recorded</p>
+		<p class="text-gray-600 text-center py-8">No LLM calls recorded</p>
 	{/if}
 </div>

--- a/frontend/src/lib/components/workflow/LiveStatusTab.svelte
+++ b/frontend/src/lib/components/workflow/LiveStatusTab.svelte
@@ -61,10 +61,10 @@
 					{latestEvent.event_type}
 				</Badge>
 				<div class="flex-1">
-					<p class="text-slate-300">
+					<p class="text-gray-700">
 						{latestEvent.data.message || JSON.stringify(latestEvent.data)}
 					</p>
-					<p class="text-sm text-slate-500 mt-1">
+					<p class="text-sm text-gray-600 mt-1">
 						{formatRelativeTime(latestEvent.timestamp)}
 					</p>
 				</div>
@@ -77,17 +77,17 @@
 		{#if eventsList.length > 0}
 			<div class="space-y-3">
 				{#each eventsList as event}
-					<div class="flex items-start gap-4 py-2 border-b border-slate-700 last:border-b-0">
+					<div class="flex items-start gap-4 py-2 border-b border-gray-300 last:border-b-0">
 						<div class="flex-shrink-0">
 							<Badge variant={getBadgeVariant(event.event_type)}>
 								{event.event_type}
 							</Badge>
 						</div>
 						<div class="flex-1 min-w-0">
-							<p class="text-sm text-slate-300 truncate">
+							<p class="text-sm text-gray-700 truncate">
 								{event.data.message || event.data.symbol || JSON.stringify(event.data)}
 							</p>
-							<p class="text-xs text-slate-500 mt-1">
+							<p class="text-xs text-gray-600 mt-1">
 								{formatRelativeTime(event.timestamp)}
 							</p>
 						</div>
@@ -95,7 +95,7 @@
 				{/each}
 			</div>
 		{:else}
-			<p class="text-slate-400 text-center py-8">No recent events</p>
+			<p class="text-gray-600 text-center py-8">No recent events</p>
 		{/if}
 	</Card>
 </div>

--- a/frontend/src/lib/components/workflow/WaterfallChart.svelte
+++ b/frontend/src/lib/components/workflow/WaterfallChart.svelte
@@ -14,7 +14,7 @@
 	let chart: ECharts | null = null;
 
 	onMount(() => {
-		chart = echarts.init(chartContainer, 'dark');
+		chart = echarts.init(chartContainer);
 
 		const resizeObserver = new ResizeObserver(() => {
 			chart?.resize();
@@ -36,9 +36,9 @@
 				backgroundColor: 'transparent',
 				tooltip: {
 					trigger: 'axis',
-					backgroundColor: '#1e293b',
-					borderColor: '#334155',
-					textStyle: { color: '#e2e8f0' },
+					backgroundColor: '#ffffff',
+					borderColor: '#e5e7eb',
+					textStyle: { color: '#374151' },
 					axisPointer: {
 						type: 'shadow'
 					},
@@ -57,16 +57,16 @@
 				xAxis: {
 					type: 'value',
 					name: 'Latency (s)',
-					nameTextStyle: { color: '#94a3b8' },
-					axisLine: { lineStyle: { color: '#334155' } },
-					axisLabel: { color: '#94a3b8' },
-					splitLine: { lineStyle: { color: '#334155' } }
+					nameTextStyle: { color: '#6b7280' },
+					axisLine: { lineStyle: { color: '#d1d5db' } },
+					axisLabel: { color: '#6b7280' },
+					splitLine: { lineStyle: { color: '#e5e7eb' } }
 				},
 				yAxis: {
 					type: 'category',
 					data: sorted.map(a => a.agent_name),
-					axisLine: { lineStyle: { color: '#334155' } },
-					axisLabel: { color: '#94a3b8' }
+					axisLine: { lineStyle: { color: '#d1d5db' } },
+					axisLabel: { color: '#6b7280' }
 				},
 				series: [
 					{

--- a/frontend/src/lib/utils/config.ts
+++ b/frontend/src/lib/utils/config.ts
@@ -13,7 +13,7 @@ export function formatConfigValue(value: unknown): FormattedValue {
 		return {
 			type: 'null',
 			display: 'None',
-			color: 'text-slate-500'
+			color: 'text-gray-500'
 		};
 	}
 
@@ -21,7 +21,7 @@ export function formatConfigValue(value: unknown): FormattedValue {
 		return {
 			type: 'boolean',
 			display: value ? '✓' : '✗',
-			color: value ? 'text-green-400' : 'text-red-400'
+			color: value ? 'text-green-600' : 'text-red-600'
 		};
 	}
 
@@ -30,7 +30,7 @@ export function formatConfigValue(value: unknown): FormattedValue {
 			return {
 				type: 'list',
 				display: '[]',
-				color: 'text-slate-500'
+				color: 'text-gray-500'
 			};
 		}
 		return {
@@ -44,7 +44,7 @@ export function formatConfigValue(value: unknown): FormattedValue {
 		return {
 			type: 'dict',
 			display: `${keys.length} items`,
-			color: 'text-slate-500'
+			color: 'text-gray-500'
 		};
 	}
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -25,25 +25,25 @@
 		: 'overview';
 
 	$: daemonStatus = $health?.daemon_running ? 'Running' : 'Stopped';
-	$: statusColor = $health?.daemon_running ? 'text-green-400' : 'text-red-400';
+	$: statusColor = $health?.daemon_running ? 'text-green-600' : 'text-red-600';
 </script>
 
-<div class="min-h-screen bg-slate-900">
+<div class="min-h-screen bg-white">
 	<!-- Header -->
-	<header class="bg-slate-800 border-b border-slate-700">
+	<header class="bg-gray-50 border-b border-gray-300">
 		<div class="container mx-auto px-6 py-4">
 			<div class="flex items-center justify-between">
 				<div>
-					<h1 class="text-2xl font-bold text-slate-100">AI Casino</h1>
-					<p class="text-sm text-slate-400">Multi-Agent Trading System</p>
+					<h1 class="text-2xl font-bold text-black">AI Casino</h1>
+					<p class="text-sm text-gray-600">Multi-Agent Trading System</p>
 				</div>
 				<div class="flex items-center gap-4">
 					<div class="text-sm">
-						<span class="text-slate-400">Daemon:</span>
+						<span class="text-gray-600">Daemon:</span>
 						<span class="ml-2 font-medium {statusColor}">{daemonStatus}</span>
 					</div>
 					{#if $health?.uptime_seconds}
-						<div class="text-sm text-slate-400">
+						<div class="text-sm text-gray-600">
 							Uptime: {Math.floor($health.uptime_seconds / 3600)}h {Math.floor(($health.uptime_seconds % 3600) / 60)}m
 						</div>
 					{/if}
@@ -53,7 +53,7 @@
 	</header>
 
 	<!-- Navigation -->
-	<div class="bg-slate-800 border-b border-slate-700">
+	<div class="bg-gray-50 border-b border-gray-300">
 		<div class="container mx-auto px-6">
 			<Tabs {tabs} {activeTab} />
 		</div>
@@ -65,8 +65,8 @@
 	</main>
 
 	<!-- Footer -->
-	<footer class="bg-slate-800 border-t border-slate-700 mt-12">
-		<div class="container mx-auto px-6 py-4 text-center text-sm text-slate-400">
+	<footer class="bg-gray-50 border-t border-gray-300 mt-12">
+		<div class="container mx-auto px-6 py-4 text-center text-sm text-gray-600">
 			SvelteKit + TypeScript + ECharts + Lightweight Charts
 		</div>
 	</footer>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -148,7 +148,7 @@
 				yAxisLabel="Confidence"
 			/>
 		{:else}
-			<div class="text-center py-12 text-slate-400">
+			<div class="text-center py-12 text-gray-600">
 				No analysis data available
 			</div>
 		{/if}
@@ -165,7 +165,7 @@
 				xAxisLabel="Hour"
 			/>
 		{:else}
-			<div class="text-center py-12 text-slate-400">
+			<div class="text-center py-12 text-gray-600">
 				No analysis data available
 			</div>
 		{/if}
@@ -176,7 +176,7 @@
 		{#if recentAnalyses.length > 0}
 			<DataTable data={recentAnalyses.slice(0, 10)} columns={analysisColumns} />
 		{:else}
-			<div class="text-center py-12 text-slate-400">
+			<div class="text-center py-12 text-gray-600">
 				No analyses yet. Daemon may be stopped or no trading cycles completed.
 			</div>
 		{/if}
@@ -187,12 +187,12 @@
 		<Card title="System Status">
 			<dl class="grid grid-cols-2 gap-4 text-sm">
 				<div>
-					<dt class="text-slate-400">Total Trades</dt>
-					<dd class="mt-1 text-lg font-semibold text-slate-100">{summary.total_trades}</dd>
+					<dt class="text-gray-600">Total Trades</dt>
+					<dd class="mt-1 text-lg font-semibold text-black">{summary.total_trades}</dd>
 				</div>
 				<div>
-					<dt class="text-slate-400">Errors</dt>
-					<dd class="mt-1 text-lg font-semibold text-slate-100">{summary.error_count}</dd>
+					<dt class="text-gray-600">Errors</dt>
+					<dd class="mt-1 text-lg font-semibold text-black">{summary.error_count}</dd>
 				</div>
 			</dl>
 		</Card>

--- a/frontend/src/routes/config/+page.svelte
+++ b/frontend/src/routes/config/+page.svelte
@@ -98,14 +98,14 @@
 
 <div class="space-y-8">
 	<div>
-		<h1 class="text-3xl font-bold text-slate-100">Configuration</h1>
-		<p class="mt-2 text-slate-400">View daemon configuration (auto-refreshes every 5 seconds)</p>
+		<h1 class="text-3xl font-bold text-black">Configuration</h1>
+		<p class="mt-2 text-gray-600">View daemon configuration (auto-refreshes every 5 seconds)</p>
 	</div>
 
 	{#if !cfg}
 		<div class="text-center py-12">
-			<div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-slate-400"></div>
-			<p class="mt-4 text-slate-400">Loading configuration...</p>
+			<div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-gray-600"></div>
+			<p class="mt-4 text-gray-600">Loading configuration...</p>
 		</div>
 	{:else}
 		<!-- Summary Cards -->
@@ -118,23 +118,23 @@
 						{/each}
 					</div>
 				{:else}
-					<p class="text-slate-500">No symbols</p>
+					<p class="text-gray-600">No symbols</p>
 				{/if}
 			</Card>
 
 			<Card title="Interval">
-				<div class="text-3xl font-bold text-slate-100">
+				<div class="text-3xl font-bold text-black">
 					{cfg.interval_minutes}
-					<span class="text-lg text-slate-400 ml-2">min</span>
+					<span class="text-lg text-gray-600 ml-2">min</span>
 				</div>
 			</Card>
 
 			<Card title="Market Hours Only">
 				<div class="text-3xl">
 					{#if cfg.market_hours_only}
-						<span class="text-green-400">✓</span>
+						<span class="text-green-600">✓</span>
 					{:else}
-						<span class="text-red-400">✗</span>
+						<span class="text-red-600">✗</span>
 					{/if}
 				</div>
 			</Card>
@@ -142,15 +142,15 @@
 			<Card title="Auto Trade">
 				<div class="text-3xl">
 					{#if cfg.auto_trade}
-						<span class="text-green-400">✓</span>
+						<span class="text-green-600">✓</span>
 					{:else}
-						<span class="text-red-400">✗</span>
+						<span class="text-red-600">✗</span>
 					{/if}
 				</div>
 			</Card>
 
 			<Card title="Trading Mode">
-				<div class="text-2xl font-bold text-slate-100 uppercase">
+				<div class="text-2xl font-bold text-black uppercase">
 					{cfg.trading_mode || 'UNKNOWN'}
 				</div>
 			</Card>
@@ -158,9 +158,9 @@
 			<Card title="Pre-Market">
 				<div class="text-3xl">
 					{#if cfg.schedule && typeof cfg.schedule === 'object' && 'enable_pre_market' in cfg.schedule && cfg.schedule.enable_pre_market}
-						<span class="text-green-400">✓</span>
+						<span class="text-green-600">✓</span>
 					{:else}
-						<span class="text-red-400">✗</span>
+						<span class="text-red-600">✗</span>
 					{/if}
 				</div>
 			</Card>
@@ -168,7 +168,7 @@
 
 		<!-- Configuration Sections -->
 		<div>
-			<h2 class="text-2xl font-bold text-slate-100 mb-4">Configuration Sections</h2>
+			<h2 class="text-2xl font-bold text-black mb-4">Configuration Sections</h2>
 			<Accordion items={accordionItems} defaultOpen={['trading-&-execution']}>
 				{#snippet content(rawData)}
 					{@const data = rawData as AccordionContentData}
@@ -178,24 +178,24 @@
 							{@const sectionDataRecord = typeof sectionData === 'object' && sectionData !== null && !Array.isArray(sectionData) ? sectionData as Record<string, unknown> : {}}
 							{@const enabled = getSectionEnabled(sectionDataRecord)}
 							{@const sortedEntries = sortConfigKeys(sectionDataRecord)}
-							{@const borderColor = enabled ? 'border-l-green-500' : 'border-l-slate-600'}
+							{@const borderColor = enabled ? 'border-l-green-700' : 'border-l-gray-300'}
 
-							<div class="bg-slate-800/50 rounded-lg border border-slate-700 border-l-4 {borderColor} overflow-hidden">
-								<div class="px-4 py-3 border-b border-slate-700 flex items-center justify-between">
-									<h4 class="font-semibold text-slate-100">{section.title}</h4>
+							<div class="bg-gray-50 rounded-lg border border-gray-300 border-l-4 {borderColor} overflow-hidden">
+								<div class="px-4 py-3 border-b border-gray-300 flex items-center justify-between">
+									<h4 class="font-semibold text-black">{section.title}</h4>
 									<Badge variant={enabled ? 'success' : 'neutral'}>
 										{enabled ? 'Enabled' : 'Disabled'}
 									</Badge>
 								</div>
 								<div class="overflow-x-auto">
-									<table class="min-w-full divide-y divide-slate-700">
-										<tbody class="divide-y divide-slate-700">
+									<table class="min-w-full divide-y divide-gray-200">
+										<tbody class="divide-y divide-gray-200">
 											{#each sortedEntries as [key, value]}
 												{@const formatted = formatConfigValue(value)}
-												{@const colorClass = formatted.color || 'text-slate-300'}
+												{@const colorClass = formatted.color || 'text-gray-700'}
 
-												<tr class="hover:bg-slate-700/30">
-													<td class="px-4 py-3 text-sm text-slate-400 w-1/3">{key}</td>
+												<tr class="hover:bg-gray-50">
+													<td class="px-4 py-3 text-sm text-gray-600 w-1/3">{key}</td>
 													<td class="px-4 py-3 text-sm {colorClass}">
 														{#if formatted.type === 'list' && Array.isArray(value) && value.length > 0}
 															<div class="flex flex-wrap gap-1">

--- a/frontend/src/routes/events/+page.svelte
+++ b/frontend/src/routes/events/+page.svelte
@@ -181,7 +181,7 @@
 			case 'INFO':
 				return { color: '#3b82f6', icon: '🔵' };
 			case 'TRADE':
-				return { color: '#22c55e', icon: '🟢' };
+				return { color: '#16a34a', icon: '🟢' };
 			case 'SYSTEM':
 			default:
 				return { color: '#6b7280', icon: '⚪' };
@@ -249,7 +249,7 @@
 	// Initialize degradation chart reactively when container becomes available
 	$effect(() => {
 		if (degradationChartContainer && !degradationChart) {
-			degradationChart = echarts.init(degradationChartContainer, 'dark');
+			degradationChart = echarts.init(degradationChartContainer);
 			if ($degradationHistory) {
 				updateDegradationChart();
 			}
@@ -269,7 +269,7 @@
 
 		const tierOrder = ['FULL', 'DEGRADED', 'MINIMAL', 'HALTED'];
 		const tierColors: Record<string, string> = {
-			FULL: '#22c55e',
+			FULL: '#16a34a',
 			DEGRADED: '#fbbf24',
 			MINIMAL: '#f97316',
 			HALTED: '#ef4444'
@@ -284,13 +284,13 @@
 			backgroundColor: 'transparent',
 			title: {
 				text: 'API Degradation Timeline',
-				textStyle: { color: '#e2e8f0', fontSize: 14 }
+				textStyle: { color: '#374151', fontSize: 14 }
 			},
 			tooltip: {
 				trigger: 'axis',
-				backgroundColor: '#1e293b',
-				borderColor: '#334155',
-				textStyle: { color: '#e2e8f0' },
+				backgroundColor: '#ffffff',
+				borderColor: '#e5e7eb',
+				textStyle: { color: '#374151' },
 				formatter: (params: any) => {
 					const p = Array.isArray(params) ? params[0] : params;
 					return `<b>${p.value}</b><br/>${p.name}<br/>${services[p.dataIndex]}`;
@@ -305,14 +305,14 @@
 			xAxis: {
 				type: 'category',
 				data: timestamps,
-				axisLine: { lineStyle: { color: '#334155' } },
-				axisLabel: { color: '#94a3b8', rotate: 45 }
+				axisLine: { lineStyle: { color: '#d1d5db' } },
+				axisLabel: { color: '#6b7280', rotate: 45 }
 			},
 			yAxis: {
 				type: 'category',
 				data: tierOrder,
-				axisLine: { lineStyle: { color: '#334155' } },
-				axisLabel: { color: '#94a3b8' }
+				axisLine: { lineStyle: { color: '#d1d5db' } },
+				axisLabel: { color: '#6b7280' }
 			},
 			series: [
 				{
@@ -341,14 +341,14 @@
 	<!-- Warnings Banner -->
 	{#if warnings.length > 0}
 		<div class="space-y-2">
-			<h2 class="text-xl font-semibold text-slate-100">⚠️ Active Warnings</h2>
+			<h2 class="text-xl font-semibold text-black">⚠️ Active Warnings</h2>
 			{#each warnings as warning}
-				<div class="{warning.severity === 'danger' ? 'bg-red-900/20 border-red-700' : 'bg-yellow-900/20 border-yellow-700'} border rounded-lg p-4">
+				<div class="{warning.severity === 'danger' ? 'bg-red-50 border-red-300' : 'bg-yellow-50 border-yellow-300'} border rounded-lg p-4">
 					<div class="flex items-start gap-3">
 						<span class="text-2xl">{warning.icon}</span>
 						<div>
-							<p class="font-semibold text-slate-100">{warning.message}</p>
-							<p class="text-sm text-slate-400 mt-1">{warning.details}</p>
+							<p class="font-semibold text-black">{warning.message}</p>
+							<p class="text-sm text-gray-600 mt-1">{warning.details}</p>
 						</div>
 					</div>
 				</div>
@@ -368,44 +368,44 @@
 		<div class="space-y-4">
 			<div>
 				<!-- svelte-ignore a11y_label_has_associated_control -->
-				<label class="block text-sm font-medium text-slate-400 mb-2">
+				<label class="block text-sm font-medium text-gray-600 mb-2">
 					Event Types
 				</label>
 				<div class="flex flex-wrap gap-2">
 					{#each availableCategories as category}
-						<label class="flex items-center gap-2 px-3 py-2 bg-slate-700 rounded-lg cursor-pointer hover:bg-slate-600 transition-colors">
+						<label class="flex items-center gap-2 px-3 py-2 bg-gray-100 rounded-lg cursor-pointer hover:bg-gray-50 transition-colors">
 							<input
 								type="checkbox"
 								bind:group={selectedCategories}
 								value={category}
-								class="rounded border-slate-500 text-blue-500 focus:ring-blue-500"
+								class="rounded border-gray-400 text-blue-700 focus:ring-blue-700"
 							/>
-							<span class="text-sm text-slate-200">{category}</span>
+							<span class="text-sm text-gray-800">{category}</span>
 						</label>
 					{/each}
 				</div>
 			</div>
 			<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
 				<div>
-					<label for="start-date" class="block text-sm font-medium text-slate-400 mb-2">
+					<label for="start-date" class="block text-sm font-medium text-gray-600 mb-2">
 						Start Date
 					</label>
 					<input
 						id="start-date"
 						type="date"
 						bind:value={startDate}
-						class="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-lg text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+						class="w-full px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg text-black focus:outline-none focus:ring-2 focus:ring-blue-700"
 					/>
 				</div>
 				<div>
-					<label for="end-date" class="block text-sm font-medium text-slate-400 mb-2">
+					<label for="end-date" class="block text-sm font-medium text-gray-600 mb-2">
 						End Date
 					</label>
 					<input
 						id="end-date"
 						type="date"
 						bind:value={endDate}
-						class="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-lg text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+						class="w-full px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg text-black focus:outline-none focus:ring-2 focus:ring-blue-700"
 					/>
 				</div>
 			</div>
@@ -417,18 +417,18 @@
 		{#if filteredEvents.length > 0}
 			<div class="overflow-x-auto">
 				<table class="w-full text-sm">
-					<thead class="border-b border-slate-700">
+					<thead class="border-b border-gray-300">
 						<tr>
-							<th class="text-left py-3 px-4 font-medium text-slate-400">Timestamp</th>
-							<th class="text-left py-3 px-4 font-medium text-slate-400">Type</th>
-							<th class="text-left py-3 px-4 font-medium text-slate-400">Category</th>
-							<th class="text-left py-3 px-4 font-medium text-slate-400">Details</th>
+							<th class="text-left py-3 px-4 font-medium text-gray-600">Timestamp</th>
+							<th class="text-left py-3 px-4 font-medium text-gray-600">Type</th>
+							<th class="text-left py-3 px-4 font-medium text-gray-600">Category</th>
+							<th class="text-left py-3 px-4 font-medium text-gray-600">Details</th>
 						</tr>
 					</thead>
 					<tbody>
 						{#each filteredEvents.slice(0, 100) as event}
-							<tr class="border-b border-slate-800 hover:bg-slate-800/50">
-								<td class="py-3 px-4 font-mono text-xs text-slate-300">
+							<tr class="border-b border-gray-200 hover:bg-gray-50">
+								<td class="py-3 px-4 font-mono text-xs text-gray-700">
 									{formatDate(event.timestamp)}
 								</td>
 								<td class="py-3 px-4">
@@ -439,10 +439,10 @@
 										</span>
 									</div>
 								</td>
-								<td class="py-3 px-4 text-xs text-slate-400">
+								<td class="py-3 px-4 text-xs text-gray-600">
 									{event.category}
 								</td>
-								<td class="py-3 px-4 text-xs text-slate-300">
+								<td class="py-3 px-4 text-xs text-gray-700">
 									{truncate(event.details)}
 								</td>
 							</tr>
@@ -451,7 +451,7 @@
 				</table>
 			</div>
 		{:else}
-			<div class="text-center py-12 text-slate-400">
+			<div class="text-center py-12 text-gray-600">
 				No events match the selected filters.
 			</div>
 		{/if}

--- a/frontend/src/routes/portfolio/+page.svelte
+++ b/frontend/src/routes/portfolio/+page.svelte
@@ -208,13 +208,13 @@
 				<LineChart 
 					data={equityData} 
 					height={300}
-					color="#10b981"
+					color="#059669"
 					yAxisLabel="Portfolio Value ($)"
 				/>
 			{:else if loading}
-				<div class="text-center py-12 text-slate-400">Loading...</div>
+				<div class="text-center py-12 text-gray-600">Loading...</div>
 			{:else}
-				<div class="text-center py-12 text-slate-400">No historical data</div>
+				<div class="text-center py-12 text-gray-600">No historical data</div>
 			{/if}
 		</Card>
 
@@ -223,7 +223,7 @@
 			{#if treemapData.length > 0}
 				<TreemapChart data={treemapData} height={300} title="" />
 			{:else}
-				<div class="text-center py-12 text-slate-400">No positions</div>
+				<div class="text-center py-12 text-gray-600">No positions</div>
 			{/if}
 		</Card>
 	</div>
@@ -233,9 +233,9 @@
 		{#if rebalance && rebalance.allocations.length > 0}
 			<RebalanceChart allocations={rebalance.allocations} height={350} />
 		{:else if loading}
-			<div class="text-center py-12 text-slate-400">Loading...</div>
+			<div class="text-center py-12 text-gray-600">Loading...</div>
 		{:else}
-			<div class="text-center py-12 text-slate-400">
+			<div class="text-center py-12 text-gray-600">
 				No rebalancing data available
 			</div>
 		{/if}
@@ -246,7 +246,7 @@
 		{#if positionsList.length > 0}
 			<DataTable data={positionsList} columns={positionColumns} />
 		{:else}
-			<div class="text-center py-12 text-slate-400">
+			<div class="text-center py-12 text-gray-600">
 				No active positions. Start trading to see positions here.
 			</div>
 		{/if}

--- a/frontend/src/routes/risk/+page.svelte
+++ b/frontend/src/routes/risk/+page.svelte
@@ -153,7 +153,7 @@
 				flaggedPositions={sectorRotationData.flagged_positions}
 			/>
 		{:else}
-			<div class="text-center py-12 text-slate-400">
+			<div class="text-center py-12 text-gray-600">
 				Sector rotation not enabled or no data available.
 			</div>
 		{/if}
@@ -165,38 +165,38 @@
 			<div class="overflow-x-auto">
 				<table class="w-full text-sm">
 					<thead>
-						<tr class="border-b border-slate-700">
-							<th class="text-left py-3 px-4 text-slate-300 font-medium">Metric</th>
-							<th class="text-right py-3 px-4 text-slate-300 font-medium">Value</th>
+						<tr class="border-b border-gray-300">
+							<th class="text-left py-3 px-4 text-gray-700 font-medium">Metric</th>
+							<th class="text-right py-3 px-4 text-gray-700 font-medium">Value</th>
 						</tr>
 					</thead>
-					<tbody class="divide-y divide-slate-800">
-						<tr class="hover:bg-slate-800/50">
-							<td class="py-3 px-4 text-slate-400">VaR 95%</td>
-							<td class="py-3 px-4 text-right text-slate-200 font-mono">{formatPercent(riskReport.var_95)}</td>
+					<tbody class="divide-y divide-gray-200">
+						<tr class="hover:bg-gray-50">
+							<td class="py-3 px-4 text-gray-600">VaR 95%</td>
+							<td class="py-3 px-4 text-right text-gray-800 font-mono">{formatPercent(riskReport.var_95)}</td>
 						</tr>
-						<tr class="hover:bg-slate-800/50">
-							<td class="py-3 px-4 text-slate-400">VaR 99%</td>
-							<td class="py-3 px-4 text-right text-slate-200 font-mono">{formatPercent(riskReport.var_99)}</td>
+						<tr class="hover:bg-gray-50">
+							<td class="py-3 px-4 text-gray-600">VaR 99%</td>
+							<td class="py-3 px-4 text-right text-gray-800 font-mono">{formatPercent(riskReport.var_99)}</td>
 						</tr>
-						<tr class="hover:bg-slate-800/50">
-							<td class="py-3 px-4 text-slate-400">CVaR 95%</td>
-							<td class="py-3 px-4 text-right text-slate-200 font-mono">{formatPercent(riskReport.cvar_95)}</td>
+						<tr class="hover:bg-gray-50">
+							<td class="py-3 px-4 text-gray-600">CVaR 95%</td>
+							<td class="py-3 px-4 text-right text-gray-800 font-mono">{formatPercent(riskReport.cvar_95)}</td>
 						</tr>
-						<tr class="hover:bg-slate-800/50">
-							<td class="py-3 px-4 text-slate-400">CVaR 99%</td>
-							<td class="py-3 px-4 text-right text-slate-200 font-mono">{formatPercent(riskReport.cvar_99)}</td>
+						<tr class="hover:bg-gray-50">
+							<td class="py-3 px-4 text-gray-600">CVaR 99%</td>
+							<td class="py-3 px-4 text-right text-gray-800 font-mono">{formatPercent(riskReport.cvar_99)}</td>
 						</tr>
-						<tr class="hover:bg-slate-800/50">
-							<td class="py-3 px-4 text-slate-400">CDaR 95%</td>
-							<td class="py-3 px-4 text-right text-slate-200 font-mono">{formatPercent(riskReport.cdar_95)}</td>
+						<tr class="hover:bg-gray-50">
+							<td class="py-3 px-4 text-gray-600">CDaR 95%</td>
+							<td class="py-3 px-4 text-right text-gray-800 font-mono">{formatPercent(riskReport.cdar_95)}</td>
 						</tr>
-						<tr class="hover:bg-slate-800/50">
-							<td class="py-3 px-4 text-slate-400">Max Drawdown</td>
-							<td class="py-3 px-4 text-right text-slate-200 font-mono">{formatPercent(riskReport.max_drawdown)}</td>
+						<tr class="hover:bg-gray-50">
+							<td class="py-3 px-4 text-gray-600">Max Drawdown</td>
+							<td class="py-3 px-4 text-right text-gray-800 font-mono">{formatPercent(riskReport.max_drawdown)}</td>
 						</tr>
-						<tr class="hover:bg-slate-800/50">
-							<td class="py-3 px-4 text-slate-400">Risk Status</td>
+						<tr class="hover:bg-gray-50">
+							<td class="py-3 px-4 text-gray-600">Risk Status</td>
 							<td class="py-3 px-4 text-right">
 								<div class="flex justify-end">
 									<RiskStatusBadge status={riskReport.risk_status} size="sm" />
@@ -220,9 +220,9 @@
 					yAxisLabel="Sharpe Ratio"
 				/>
 			{:else if loading}
-				<div class="text-center py-12 text-slate-400">Loading...</div>
+				<div class="text-center py-12 text-gray-600">Loading...</div>
 			{:else}
-				<div class="text-center py-12 text-slate-400">No risk history</div>
+				<div class="text-center py-12 text-gray-600">No risk history</div>
 			{/if}
 		</Card>
 
@@ -235,9 +235,9 @@
 					yAxisLabel="Volatility"
 				/>
 			{:else if loading}
-				<div class="text-center py-12 text-slate-400">Loading...</div>
+				<div class="text-center py-12 text-gray-600">Loading...</div>
 			{:else}
-				<div class="text-center py-12 text-slate-400">No volatility data</div>
+				<div class="text-center py-12 text-gray-600">No volatility data</div>
 			{/if}
 		</Card>
 	</div>
@@ -252,7 +252,7 @@
 				title=""
 			/>
 		{:else}
-			<div class="text-center py-12 text-slate-400">
+			<div class="text-center py-12 text-gray-600">
 				No correlation data available. Requires multiple positions.
 			</div>
 		{/if}
@@ -262,26 +262,26 @@
 	<Card title="Risk Metrics Explained">
 		<dl class="space-y-4 text-sm">
 			<div>
-				<dt class="font-medium text-slate-300">Sharpe Ratio</dt>
-				<dd class="mt-1 text-slate-400">
+				<dt class="font-medium text-gray-700">Sharpe Ratio</dt>
+				<dd class="mt-1 text-gray-600">
 					Measures risk-adjusted returns. Higher is better. &gt;1 is good, &gt;2 is excellent.
 				</dd>
 			</div>
 			<div>
-				<dt class="font-medium text-slate-300">Volatility</dt>
-				<dd class="mt-1 text-slate-400">
+				<dt class="font-medium text-gray-700">Volatility</dt>
+				<dd class="mt-1 text-gray-600">
 					Standard deviation of returns. Lower means more stable portfolio.
 				</dd>
 			</div>
 			<div>
-				<dt class="font-medium text-slate-300">Max Drawdown</dt>
-				<dd class="mt-1 text-slate-400">
+				<dt class="font-medium text-gray-700">Max Drawdown</dt>
+				<dd class="mt-1 text-gray-600">
 					Largest peak-to-trough decline. Shows worst-case historical loss.
 				</dd>
 			</div>
 			<div>
-				<dt class="font-medium text-slate-300">Value at Risk (VaR 95%)</dt>
-				<dd class="mt-1 text-slate-400">
+				<dt class="font-medium text-gray-700">Value at Risk (VaR 95%)</dt>
+				<dd class="mt-1 text-gray-600">
 					Maximum expected loss over a time period at 95% confidence level.
 				</dd>
 			</div>

--- a/frontend/src/routes/signals/+page.svelte
+++ b/frontend/src/routes/signals/+page.svelte
@@ -128,31 +128,31 @@
 		<div class="space-y-4">
 			<!-- Quick Presets -->
 			<div>
-				<label class="block text-sm font-medium text-slate-400 mb-2">
+				<label class="block text-sm font-medium text-gray-600 mb-2">
 					Quick Presets
 				</label>
 				<div class="flex gap-2">
 					<button
 						on:click={() => setDatePreset('today')}
-						class="px-4 py-2 bg-slate-700 hover:bg-slate-600 border border-slate-600 rounded-lg text-slate-100 text-sm transition-colors"
+						class="px-4 py-2 bg-gray-100 hover:bg-gray-50 border border-gray-300 rounded-lg text-black text-sm transition-colors"
 					>
 						Today
 					</button>
 					<button
 						on:click={() => setDatePreset('7days')}
-						class="px-4 py-2 bg-slate-700 hover:bg-slate-600 border border-slate-600 rounded-lg text-slate-100 text-sm transition-colors"
+						class="px-4 py-2 bg-gray-100 hover:bg-gray-50 border border-gray-300 rounded-lg text-black text-sm transition-colors"
 					>
 						Last 7 days
 					</button>
 					<button
 						on:click={() => setDatePreset('30days')}
-						class="px-4 py-2 bg-slate-700 hover:bg-slate-600 border border-slate-600 rounded-lg text-slate-100 text-sm transition-colors"
+						class="px-4 py-2 bg-gray-100 hover:bg-gray-50 border border-gray-300 rounded-lg text-black text-sm transition-colors"
 					>
 						Last 30 days
 					</button>
 					<button
 						on:click={() => setDatePreset('all')}
-						class="px-4 py-2 bg-slate-700 hover:bg-slate-600 border border-slate-600 rounded-lg text-slate-100 text-sm transition-colors"
+						class="px-4 py-2 bg-gray-100 hover:bg-gray-50 border border-gray-300 rounded-lg text-black text-sm transition-colors"
 					>
 						All time
 					</button>
@@ -162,25 +162,25 @@
 			<!-- Date Range -->
 			<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
 				<div>
-					<label for="start-date" class="block text-sm font-medium text-slate-400 mb-2">
+					<label for="start-date" class="block text-sm font-medium text-gray-600 mb-2">
 						Start Date
 					</label>
 					<input
 						id="start-date"
 						type="date"
 						bind:value={startDate}
-						class="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-lg text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+						class="w-full px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg text-black focus:outline-none focus:ring-2 focus:ring-blue-700"
 					/>
 				</div>
 				<div>
-					<label for="end-date" class="block text-sm font-medium text-slate-400 mb-2">
+					<label for="end-date" class="block text-sm font-medium text-gray-600 mb-2">
 						End Date
 					</label>
 					<input
 						id="end-date"
 						type="date"
 						bind:value={endDate}
-						class="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-lg text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+						class="w-full px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg text-black focus:outline-none focus:ring-2 focus:ring-blue-700"
 					/>
 				</div>
 			</div>
@@ -188,13 +188,13 @@
 			<!-- Symbol and Signal Filters -->
 			<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
 				<div>
-					<label for="symbol-filter" class="block text-sm font-medium text-slate-400 mb-2">
+					<label for="symbol-filter" class="block text-sm font-medium text-gray-600 mb-2">
 						Symbol
 					</label>
 					<select
 						id="symbol-filter"
 						bind:value={selectedSymbol}
-						class="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-lg text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+						class="w-full px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg text-black focus:outline-none focus:ring-2 focus:ring-blue-700"
 					>
 						<option value="">All Symbols</option>
 						{#each symbols as symbol}
@@ -203,13 +203,13 @@
 					</select>
 				</div>
 				<div>
-					<label for="signal-filter" class="block text-sm font-medium text-slate-400 mb-2">
+					<label for="signal-filter" class="block text-sm font-medium text-gray-600 mb-2">
 						Signal
 					</label>
 					<select
 						id="signal-filter"
 						bind:value={selectedSignal}
-						class="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-lg text-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+						class="w-full px-3 py-2 bg-gray-100 border border-gray-300 rounded-lg text-black focus:outline-none focus:ring-2 focus:ring-blue-700"
 					>
 						<option value="">All Signals</option>
 						<option value="BUY">BUY</option>
@@ -223,7 +223,7 @@
 			<div>
 				<button
 					on:click={clearFilters}
-					class="px-4 py-2 bg-red-900 hover:bg-red-800 border border-red-700 rounded-lg text-slate-100 text-sm transition-colors"
+					class="px-4 py-2 bg-red-100 hover:bg-red-200 border border-red-300 rounded-lg text-red-800 text-sm transition-colors"
 				>
 					Clear All Filters
 				</button>
@@ -235,17 +235,17 @@
 	<div class="grid grid-cols-1 md:grid-cols-4 gap-4">
 		{#each (['BUY', 'SELL', 'HOLD'] as const) as signal}
 			{@const count = filteredAnalyses.filter(a => a.signal === signal).length}
-			<div class="bg-slate-800 rounded-lg border border-slate-700 p-4">
+			<div class="bg-white rounded-lg border border-gray-300 p-4">
 				<div class="flex items-center justify-between">
 					<Badge variant={signal}>{signal}</Badge>
-					<span class="text-2xl font-bold text-slate-100">{count}</span>
+					<span class="text-2xl font-bold text-black">{count}</span>
 				</div>
 			</div>
 		{/each}
-		<div class="bg-slate-800 rounded-lg border border-slate-700 p-4">
+		<div class="bg-white rounded-lg border border-gray-300 p-4">
 			<div class="flex items-center justify-between">
-				<span class="text-sm font-medium text-slate-400">Total</span>
-				<span class="text-2xl font-bold text-slate-100">{filteredAnalyses.length}</span>
+				<span class="text-sm font-medium text-gray-600">Total</span>
+				<span class="text-2xl font-bold text-black">{filteredAnalyses.length}</span>
 			</div>
 		</div>
 	</div>
@@ -255,7 +255,7 @@
 		{#if filteredAnalyses.length > 0}
 			<DataTable data={filteredAnalyses} columns={columns} />
 		{:else}
-			<div class="text-center py-12 text-slate-400">
+			<div class="text-center py-12 text-gray-600">
 				No signals match the selected filters.
 			</div>
 		{/if}

--- a/frontend/src/routes/workflow/+page.svelte
+++ b/frontend/src/routes/workflow/+page.svelte
@@ -6,22 +6,22 @@
 </script>
 
 <div class="space-y-6">
-	<h2 class="text-2xl font-bold text-slate-100">Workflow Execution</h2>
+	<h2 class="text-2xl font-bold text-black">Workflow Execution</h2>
 
 	<!-- Sub-tab buttons -->
-	<div class="flex gap-4 border-b border-slate-700">
+	<div class="flex gap-4 border-b border-gray-300">
 		<button
 			class="px-4 py-2 text-sm font-medium transition-colors {activeSubTab === 'live'
-				? 'text-blue-400 border-b-2 border-blue-400'
-				: 'text-slate-400 hover:text-slate-300'}"
+				? 'text-blue-600 border-b-2 border-blue-600'
+				: 'text-gray-600 hover:text-gray-700'}"
 			onclick={() => activeSubTab = 'live'}
 		>
 			Live Status
 		</button>
 		<button
 			class="px-4 py-2 text-sm font-medium transition-colors {activeSubTab === 'historical'
-				? 'text-blue-400 border-b-2 border-blue-400'
-				: 'text-slate-400 hover:text-slate-300'}"
+				? 'text-blue-600 border-b-2 border-blue-600'
+				: 'text-gray-600 hover:text-gray-700'}"
 			onclick={() => activeSubTab = 'historical'}
 		>
 			Historical Analysis


### PR DESCRIPTION
## Motivation

Replace dark theme with professional black and white light theme for better readability and cleaner appearance.

## Implementation information

Converted entire Svelte frontend from dark to light theme:

**Core changes:**

- app.css: white background, black text, light color scheme
- Layout: gray-50 headers/footers, gray-300 borders
- Components (Card, Badge, Tabs, etc.): white backgrounds, black text, gray accents
- Tables: white with gray-50 hover states, gray-300 borders
- All dark mode classes removed (dark:* modifiers)

**Charts (ECharts):**

- Removed dark theme initialization
- Grayscale palette: gray-200 to gray-600
- Black text, light gray borders/grids
- Muted semantic colors (green-700 for positive, red-500 for negative)

**Files updated:** 34 frontend files including all components, routes, and charts

## Supporting documentation

Addresses user request for black/white light theme.
