### PR TITLE
docs(docs): require # prefix for issue numbers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,11 +151,12 @@ Never skip/disable on failure - fix properly, re-run until clean.
 <!-- Explain how this was done and potentially alternatives considered and discarded -->
 
 ## Supporting documentation
-Fix: #{issue_number}
+Fix: #123
 <!-- Include MADR or related PRs if applicable -->
 ```
 
 **ALWAYS link an issue** - create one if needed before PR
+**ALWAYS prefix issue numbers with `#`** - Use `Fix: #123` not `Fix: 123`
 
 ---
 


### PR DESCRIPTION
## Motivation

CLAUDE.md PR format example showed #{issue_number} but lacked explicit instruction to always use # prefix. This can lead to inconsistent PR descriptions.

## Implementation information

Updated CLAUDE.md Pull Requests section to:

- Change example from #{issue_number} to #123 (concrete example)
- Add explicit rule: "ALWAYS prefix issue numbers with #" with example showing correct vs incorrect format

## Supporting documentation

Fix: #611
