### PR TITLE
ci(mise): add --remove-orphans to compose tasks

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -51,11 +51,11 @@ run = "pgrep -f 'ollama serve' && echo 'Ollama is running' || echo 'Ollama is no
 
 [tasks.dev]
 description = "Run dev environment (cloud LLM, uses ~/.ai-casino/daemon-production.yaml)"
-run = "docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build"
+run = "docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build --remove-orphans"
 
 [tasks."dev:ollama"]
 description = "Run dev environment with Ollama (uses ~/.ai-casino/daemon-dev.yaml)"
-run = "docker compose -f docker-compose.yml -f docker-compose.dev-ollama.yml up --build"
+run = "docker compose -f docker-compose.yml -f docker-compose.dev-ollama.yml up --build --remove-orphans"
 
 [tasks."dev:down"]
 description = "Stop dev environment"
@@ -112,7 +112,7 @@ run = "docker exec -it ai-casino-db psql -U postgres -d ai_casino"
 
 [tasks.prod]
 description = "Run production daemon with Docker Compose"
-run = "docker compose up --build"
+run = "docker compose up --build --remove-orphans"
 
 [tasks."prod:down"]
 description = "Stop production daemon"


### PR DESCRIPTION
## Motivation

`mise dev` fails with container name conflicts when stopped containers exist. Also shows orphan container warnings.

## Implementation information

Added `--remove-orphans` flag to docker compose commands in:

- `mise dev`
- `mise dev:ollama`
- `mise prod`

Flag auto-cleans orphan containers on startup.

## Supporting documentation

Fix: #615
