### PR TITLE
feat(database): track order execution metrics

### DIFF
--- a/src/database/migrations/014_add_execution_metrics.sql
+++ b/src/database/migrations/014_add_execution_metrics.sql
@@ -1,0 +1,44 @@
+-- Add execution_metrics table for order execution tracking
+
+CREATE TABLE execution_metrics (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+
+    -- Core execution data
+    order_id VARCHAR(100) NOT NULL UNIQUE,
+    symbol VARCHAR(10) NOT NULL,
+    side VARCHAR(10) NOT NULL CHECK (side IN ('buy', 'sell')),
+    quantity DECIMAL(12, 4) NOT NULL CHECK (quantity > 0),
+    requested_price DECIMAL(12, 4) NOT NULL CHECK (requested_price > 0),
+    filled_price DECIMAL(12, 4) CHECK (filled_price > 0),
+
+    -- Timing
+    submitted_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    filled_at TIMESTAMP WITH TIME ZONE,
+    execution_time_ms INTEGER,
+
+    -- Slippage analysis
+    slippage_bps DECIMAL(8, 2),
+
+    -- Metadata
+    broker VARCHAR(50) NOT NULL DEFAULT 'alpaca',
+    venue VARCHAR(50),
+    status VARCHAR(20) NOT NULL,
+
+    -- Audit
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- Performance indices for common queries
+CREATE INDEX idx_execution_metrics_symbol ON execution_metrics(symbol);
+CREATE INDEX idx_execution_metrics_submitted_at ON execution_metrics(submitted_at DESC);
+CREATE INDEX idx_execution_metrics_broker ON execution_metrics(broker);
+CREATE INDEX idx_execution_metrics_status ON execution_metrics(status);
+CREATE INDEX idx_execution_metrics_symbol_broker ON execution_metrics(symbol, broker);
+
+-- Rollback instructions:
+-- DROP INDEX IF EXISTS idx_execution_metrics_symbol_broker;
+-- DROP INDEX IF EXISTS idx_execution_metrics_status;
+-- DROP INDEX IF EXISTS idx_execution_metrics_broker;
+-- DROP INDEX IF EXISTS idx_execution_metrics_submitted_at;
+-- DROP INDEX IF EXISTS idx_execution_metrics_symbol;
+-- DROP TABLE IF EXISTS execution_metrics;

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -876,3 +876,48 @@ class ActiveDiscoveryCandidateORM(Base):
     def __repr__(self) -> str:
         """Return string representation."""
         return f"ActiveDiscoveryCandidateORM(id={self.id}, symbol={self.symbol})"
+
+
+class ExecutionMetricORM(Base):
+    """Execution metric ORM model."""
+
+    __tablename__ = "execution_metrics"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("uuid_generate_v4()"),
+    )
+    order_id: Mapped[str] = mapped_column(String(100), nullable=False, unique=True)
+    symbol: Mapped[str] = mapped_column(String(10), nullable=False)
+    side: Mapped[str] = mapped_column(String(10), nullable=False)
+    quantity: Mapped[Decimal] = mapped_column(DECIMAL(12, 4), nullable=False)
+    requested_price: Mapped[Decimal] = mapped_column(DECIMAL(12, 4), nullable=False)
+    filled_price: Mapped[Decimal | None] = mapped_column(DECIMAL(12, 4), nullable=True)
+    submitted_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+    filled_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
+    execution_time_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    slippage_bps: Mapped[Decimal | None] = mapped_column(DECIMAL(8, 2), nullable=True)
+    broker: Mapped[str] = mapped_column(String(50), nullable=False, server_default="'alpaca'")
+    venue: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    status: Mapped[str] = mapped_column(String(20), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("NOW()"),
+    )
+
+    __table_args__ = (
+        Index("idx_execution_metrics_symbol", "symbol"),
+        Index("idx_execution_metrics_submitted_at", "submitted_at"),
+        Index("idx_execution_metrics_broker", "broker"),
+        Index("idx_execution_metrics_status", "status"),
+        Index("idx_execution_metrics_symbol_broker", "symbol", "broker"),
+    )
+
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return (
+            f"ExecutionMetricORM(order_id={self.order_id}, "
+            f"symbol={self.symbol}, slippage_bps={self.slippage_bps})"
+        )

--- a/src/database/repositories/execution_metric.py
+++ b/src/database/repositories/execution_metric.py
@@ -1,0 +1,160 @@
+"""Repository for execution metric persistence."""
+
+import uuid
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from loguru import logger
+from sqlalchemy import func, select
+
+from src.database.models import ExecutionMetricORM
+from src.database.repositories.base import BaseRepository
+from src.metrics.execution_metric import ExecutionMetric
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+else:
+    AsyncSession = object
+
+
+class ExecutionMetricRepository(BaseRepository[ExecutionMetric]):
+    """Repository for execution metric operations."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        """Initialize repository with database session.
+
+        Args:
+            session: SQLAlchemy async session
+        """
+        super().__init__(session)
+        logger.debug("Initialized ExecutionMetricRepository")
+
+    async def create(self, entity: ExecutionMetric) -> ExecutionMetric:
+        """Create execution metric record.
+
+        Args:
+            entity: ExecutionMetric to persist
+
+        Returns:
+            ExecutionMetric with generated ID
+        """
+        orm = ExecutionMetricORM(
+            id=uuid.uuid4(),
+            order_id=entity.order_id,
+            symbol=entity.symbol,
+            side=entity.side,
+            quantity=entity.quantity,
+            requested_price=entity.requested_price,
+            filled_price=entity.filled_price,
+            submitted_at=entity.submitted_at,
+            filled_at=entity.filled_at,
+            execution_time_ms=entity.execution_time_ms,
+            slippage_bps=entity.slippage_bps,
+            broker=entity.broker,
+            venue=entity.venue,
+            status=entity.status,
+            created_at=entity.created_at,
+        )
+        self._session.add(orm)
+        await self._session.commit()
+        logger.info(f"Created execution metric: {entity.order_id} (slippage: {entity.slippage_bps}bps)")
+        entity.id = str(orm.id)
+        return entity
+
+    async def get_by_id(self, entity_id: str) -> ExecutionMetric | None:
+        """Get execution metric by UUID.
+
+        Args:
+            entity_id: UUID string
+
+        Returns:
+            ExecutionMetric or None if not found
+        """
+        result = await self._session.execute(
+            select(ExecutionMetricORM).where(ExecutionMetricORM.id == uuid.UUID(entity_id))
+        )
+        orm = result.scalar_one_or_none()
+        return self._to_entity(orm) if orm else None
+
+    async def get_by_order_id(self, order_id: str) -> ExecutionMetric | None:
+        """Get execution metric by broker order ID.
+
+        Args:
+            order_id: Broker order ID
+
+        Returns:
+            ExecutionMetric or None if not found
+        """
+        result = await self._session.execute(
+            select(ExecutionMetricORM).where(ExecutionMetricORM.order_id == order_id)
+        )
+        orm = result.scalar_one_or_none()
+        return self._to_entity(orm) if orm else None
+
+    async def get_by_symbol(self, symbol: str, limit: int = 100) -> list[ExecutionMetric]:
+        """Get recent executions for symbol.
+
+        Args:
+            symbol: Stock ticker
+            limit: Max records to return
+
+        Returns:
+            List of ExecutionMetrics ordered by submitted_at DESC
+        """
+        result = await self._session.execute(
+            select(ExecutionMetricORM)
+            .where(ExecutionMetricORM.symbol == symbol)
+            .order_by(ExecutionMetricORM.submitted_at.desc())
+            .limit(limit)
+        )
+        return [self._to_entity(orm) for orm in result.scalars()]
+
+    async def get_avg_slippage_by_broker(self, broker: str | None = None) -> Decimal:
+        """Calculate average slippage (in bps) by broker.
+
+        Args:
+            broker: Broker name filter (None = all brokers)
+
+        Returns:
+            Average slippage in basis points
+        """
+        query = select(func.avg(ExecutionMetricORM.slippage_bps)).where(
+            ExecutionMetricORM.slippage_bps.isnot(None)
+        )
+        if broker:
+            query = query.where(ExecutionMetricORM.broker == broker)
+
+        result = await self._session.execute(query)
+        avg_slippage = result.scalar_one_or_none()
+        return Decimal(str(avg_slippage)) if avg_slippage else Decimal("0.0")
+
+    def _to_entity(self, orm: ExecutionMetricORM) -> ExecutionMetric:
+        """Convert ORM model to domain entity.
+
+        Args:
+            orm: ExecutionMetricORM instance
+
+        Returns:
+            ExecutionMetric domain model
+        """
+        return ExecutionMetric(
+            id=str(orm.id),
+            order_id=orm.order_id,
+            symbol=orm.symbol,
+            side=orm.side,
+            quantity=orm.quantity,
+            requested_price=orm.requested_price,
+            filled_price=orm.filled_price,
+            submitted_at=orm.submitted_at,
+            filled_at=orm.filled_at,
+            execution_time_ms=orm.execution_time_ms,
+            slippage_bps=orm.slippage_bps,
+            broker=orm.broker,
+            venue=orm.venue,
+            status=orm.status,
+            created_at=orm.created_at,
+        )
+
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return "ExecutionMetricRepository()"

--- a/src/di/container.py
+++ b/src/di/container.py
@@ -164,6 +164,11 @@ class AppContainer(containers.DeclarativeContainer):
         database_engine=database_engine,
     )
 
+    execution_metric_repository = providers.Factory(
+        database_providers.create_execution_metric_repository,
+        database_engine=database_engine,
+    )
+
     # Circuit breaker registry - Singleton
     circuit_breaker_registry = providers.Singleton(
         circuit_breaker_providers.create_circuit_breaker_registry,

--- a/src/di/providers/database.py
+++ b/src/di/providers/database.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from src.database.repositories.discovery import DiscoveryHistoryRepository
     from src.database.repositories.earnings_calendar import EarningsCalendarRecordRepository
     from src.database.repositories.execution_graph import ExecutionGraphRepository
+    from src.database.repositories.execution_metric import ExecutionMetricRepository
     from src.database.repositories.game_plan import GamePlanRecordRepository
     from src.database.repositories.metadata import MetadataRepository
     from src.database.repositories.monte_carlo import MonteCarloRecordRepository
@@ -451,3 +452,18 @@ def create_active_discovery_repository(database_engine: DatabaseEngine) -> Activ
 
     session = database_engine.session()
     return ActiveDiscoveryCandidateRepository(session)
+
+
+def create_execution_metric_repository(database_engine: DatabaseEngine) -> ExecutionMetricRepository:
+    """Create ExecutionMetricRepository with database session.
+
+    Args:
+        database_engine: Database engine instance
+
+    Returns:
+        ExecutionMetricRepository instance
+    """
+    from src.database.repositories.execution_metric import ExecutionMetricRepository
+
+    session = database_engine.session()
+    return ExecutionMetricRepository(session)

--- a/src/di/providers/workflows.py
+++ b/src/di/providers/workflows.py
@@ -17,6 +17,7 @@ from src.data.broker import AlpacaBroker
 from src.data.fundamental import FundamentalDataFetcher
 from src.data.market import MarketDataFetcher
 from src.data.news import NewsFetcher
+from src.database.repositories.execution_metric import ExecutionMetricRepository
 from src.database.repositories.snapshot import PortfolioSnapshotRepository
 from src.metrics.portfolio_var import PortfolioVaRCalculator
 from src.metrics.tracker import BaseMetricsTracker
@@ -48,6 +49,7 @@ class WorkflowFactoryParams:
     metrics_tracker: BaseMetricsTracker | None = None
     param_store: OptimizedParamStore | None = None
     snapshot_repository: PortfolioSnapshotRepository | None = None
+    execution_metric_repository: ExecutionMetricRepository | None = None
     notification_service: NotificationService | None = None
 
 
@@ -102,6 +104,7 @@ def create_workflow_meta(params: WorkflowFactoryParams) -> TradingWorkflow:
         broker=params.broker,
         metrics_tracker=params.metrics_tracker,
         snapshot_repository=params.snapshot_repository,
+        execution_metric_repository=params.execution_metric_repository,
         param_store=params.param_store,
         historical_cache=params.historical_cache,
         portfolio_var_calculator=params.portfolio_var_calculator,
@@ -143,6 +146,7 @@ def create_workflow_momentum(params: WorkflowFactoryParams) -> TradingWorkflow:
         broker=params.broker,
         metrics_tracker=params.metrics_tracker,
         snapshot_repository=params.snapshot_repository,
+        execution_metric_repository=params.execution_metric_repository,
         param_store=params.param_store,
         historical_cache=params.historical_cache,
         portfolio_var_calculator=params.portfolio_var_calculator,
@@ -184,6 +188,7 @@ def create_workflow_trump(params: WorkflowFactoryParams) -> TradingWorkflow:
         broker=params.broker,
         metrics_tracker=params.metrics_tracker,
         snapshot_repository=params.snapshot_repository,
+        execution_metric_repository=params.execution_metric_repository,
         param_store=params.param_store,
         historical_cache=params.historical_cache,
         portfolio_var_calculator=params.portfolio_var_calculator,

--- a/src/metrics/execution_metric.py
+++ b/src/metrics/execution_metric.py
@@ -1,0 +1,78 @@
+"""Order execution metrics for slippage analysis."""
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, Field
+
+from src.data.broker import OrderStatus
+
+
+class ExecutionMetric(BaseModel):
+    """Order execution metric for tracking slippage and timing."""
+
+    id: str | None = None
+    order_id: str = Field(description="Broker order ID")
+    symbol: str = Field(description="Stock ticker")
+    side: str = Field(description="buy or sell")
+    quantity: Decimal = Field(description="Shares ordered")
+    requested_price: Decimal = Field(description="Price at order submission (market price)")
+    filled_price: Decimal | None = Field(default=None, description="Average fill price")
+    submitted_at: datetime = Field(description="Order submission timestamp")
+    filled_at: datetime | None = Field(default=None, description="Order fill timestamp")
+    execution_time_ms: int | None = Field(default=None, description="Submission to fill latency (ms)")
+    slippage_bps: Decimal | None = Field(default=None, description="Slippage in basis points")
+    broker: str = Field(default="alpaca", description="Broker name")
+    venue: str | None = Field(default=None, description="Execution venue (if available)")
+    status: str = Field(description="Order status")
+    created_at: datetime | None = None
+
+    @classmethod
+    def from_order_status(
+        cls,
+        order: OrderStatus,
+        requested_price: Decimal,
+    ) -> ExecutionMetric:
+        """Create execution metric from OrderStatus and requested price.
+
+        Args:
+            order: OrderStatus from broker API
+            requested_price: Market price at order submission (for slippage calculation)
+
+        Returns:
+            ExecutionMetric with computed slippage and execution time
+        """
+        filled_price = Decimal(str(order.filled_avg_price)) if order.filled_avg_price else None
+        execution_time_ms = None
+        slippage_bps = None
+
+        # Compute execution time if both timestamps available
+        if order.filled_at and order.submitted_at:
+            execution_time_ms = int((order.filled_at - order.submitted_at).total_seconds() * 1000)
+
+        # Compute slippage: (filled - requested) / requested * 10000 bps
+        # Positive = paid more than expected (bad for buys)
+        # Negative = paid less than expected (good for buys)
+        if filled_price and requested_price and requested_price > 0:
+            slippage_pct = ((filled_price - requested_price) / requested_price) * 100
+            slippage_bps = Decimal(str(slippage_pct * 100))  # Convert to basis points
+
+        return cls(
+            order_id=order.order_id,
+            symbol=order.symbol,
+            side=order.side,
+            quantity=Decimal(str(order.qty)),
+            requested_price=requested_price,
+            filled_price=filled_price,
+            submitted_at=order.submitted_at,
+            filled_at=order.filled_at,
+            execution_time_ms=execution_time_ms,
+            slippage_bps=slippage_bps,
+            broker="alpaca",
+            status=order.status,
+            created_at=datetime.now(UTC),
+        )
+
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return f"ExecutionMetric(order_id={self.order_id}, slippage={self.slippage_bps}bps)"

--- a/src/workflows/config.py
+++ b/src/workflows/config.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from src.data.fundamental import FundamentalDataFetcher
     from src.data.market import MarketDataFetcher
     from src.data.news import NewsFetcher
+    from src.database.repositories.execution_metric import ExecutionMetricRepository
     from src.database.repositories.snapshot import PortfolioSnapshotRepository
     from src.di.container import AppContainer
     from src.metrics.portfolio_var import PortfolioVaRCalculator
@@ -64,6 +65,7 @@ class WorkflowComponents:
     broker: AlpacaBroker | None = None
     metrics_tracker: BaseMetricsTracker | None = None
     snapshot_repository: PortfolioSnapshotRepository | None = None
+    execution_metric_repository: ExecutionMetricRepository | None = None
     param_store: OptimizedParamStore | None = None
     historical_cache: HistoricalCache | None = None
     portfolio_var_calculator: PortfolioVaRCalculator | None = None
@@ -81,6 +83,7 @@ class WorkflowComponents:
                 self.broker is not None,
                 self.metrics_tracker is not None,
                 self.snapshot_repository is not None,
+                self.execution_metric_repository is not None,
                 self.param_store is not None,
                 self.historical_cache is not None,
                 self.portfolio_var_calculator is not None,

--- a/src/workflows/orchestrator.py
+++ b/src/workflows/orchestrator.py
@@ -52,6 +52,7 @@ class TradingWorkflow:
         self.broker = components.broker
         self.metrics_tracker = components.metrics_tracker
         self.snapshot_repository = components.snapshot_repository
+        self.execution_metric_repository = components.execution_metric_repository
         self.notification_service = components.notification_service
         self._container = components.container
         self.analysis_orchestrator_config = components.analysis_orchestrator_config
@@ -389,7 +390,12 @@ class TradingWorkflow:
             risk_assessment=state["risk_assessment"],
             trading_session=state.get("trading_session", TradingSession.REGULAR),
         )
-        execution_output = await execution.execute_trade(execution_input, self.broker)
+        execution_output = await execution.execute_trade(
+            execution_input,
+            self.broker,
+            self.market_fetcher,
+            self.execution_metric_repository,
+        )
 
         return {**state, "order_status": execution_output.order_status}
 

--- a/src/workflows/stages/execution.py
+++ b/src/workflows/stages/execution.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime
+from decimal import Decimal
 from typing import TYPE_CHECKING
 
 from loguru import logger
@@ -11,6 +12,8 @@ from loguru import logger
 if TYPE_CHECKING:
     from src.daemon.notifications import NotificationService
     from src.data.broker import AlpacaBroker
+    from src.data.market import MarketDataFetcher
+    from src.database.repositories.execution_metric import ExecutionMetricRepository
     from src.database.repositories.snapshot import PortfolioSnapshotRepository
 
 from src.agents.risk import AccountInfo, RiskAssessment
@@ -20,15 +23,96 @@ from src.strategies.session import TradingSession
 from src.workflows.models.execution import TradeExecutionInput, TradeExecutionOutput
 
 
+async def _get_current_price(
+    symbol: str,
+    market_fetcher: MarketDataFetcher,
+) -> Decimal:
+    """Get current market price for slippage calculation.
+
+    Args:
+        symbol: Stock ticker
+        market_fetcher: Market data fetcher instance
+
+    Returns:
+        Current market price as Decimal
+    """
+    try:
+        # Fetch latest close price using 1 day period
+        market_data = await asyncio.to_thread(market_fetcher.fetch_daily, symbol, 1)
+    except Exception as e:
+        logger.opt(exception=True).error(f"Failed to get current price for {symbol}: {e}")
+        raise
+
+    if market_data.data.empty:
+        msg = f"No price data available for {symbol}"
+        raise ValueError(msg)
+
+    return Decimal(str(market_data.data["Close"].iloc[-1]))
+
+
+async def _capture_requested_price(
+    symbol: str,
+    market_fetcher: MarketDataFetcher | None,
+    execution_metric_repository: ExecutionMetricRepository | None,
+) -> Decimal | None:
+    """Capture requested price for slippage tracking.
+
+    Args:
+        symbol: Stock ticker
+        market_fetcher: Market data fetcher
+        execution_metric_repository: Execution metric repository
+
+    Returns:
+        Requested price or None if capture failed
+    """
+    if not market_fetcher or not execution_metric_repository:
+        return None
+
+    try:
+        requested_price = await _get_current_price(symbol, market_fetcher)
+        logger.debug(f"Market price at submission: {requested_price}")
+        return requested_price
+    except Exception as e:
+        logger.opt(exception=True).warning(f"Failed to capture requested price: {e}")
+        return None
+
+
+async def _track_execution_metric(
+    order: OrderStatus,
+    requested_price: Decimal,
+    execution_metric_repository: ExecutionMetricRepository,
+) -> None:
+    """Track execution metric in database.
+
+    Args:
+        order: Order status from broker
+        requested_price: Requested price at submission
+        execution_metric_repository: Repository for metrics
+    """
+    try:
+        from src.metrics.execution_metric import ExecutionMetric
+
+        metric = ExecutionMetric.from_order_status(order, requested_price)
+        await execution_metric_repository.create(metric)
+        logger.info(f"Tracked execution: {order.order_id} (slippage: {metric.slippage_bps}bps)")
+    except Exception as e:
+        # Non-blocking: don't fail trade if metric write fails
+        logger.opt(exception=True).error(f"Failed to track execution metric: {e}")
+
+
 async def execute_trade(
     input_data: TradeExecutionInput,
     broker: AlpacaBroker | None,
+    market_fetcher: MarketDataFetcher | None = None,
+    execution_metric_repository: ExecutionMetricRepository | None = None,
 ) -> TradeExecutionOutput:
     """Execute trade via broker (async, thread-offloaded).
 
     Args:
         input_data: Trade execution input with decision and risk assessment
         broker: Optional Alpaca broker for trade execution
+        market_fetcher: Optional market data fetcher for current price
+        execution_metric_repository: Optional repository for metrics persistence
 
     Returns:
         TradeExecutionOutput with order status
@@ -52,6 +136,16 @@ async def execute_trade(
     if not input_data.risk_assessment.validation.approved:
         return TradeExecutionOutput(order_status=None, warnings=warnings)
 
+    # Capture requested price BEFORE order submission (for slippage tracking)
+    requested_price = await _capture_requested_price(
+        input_data.symbol,
+        market_fetcher,
+        execution_metric_repository,
+    )
+
+    # Capture broker for use in nested function (type narrowing)
+    broker_client = broker
+
     def _sync_submit_order() -> OrderStatus | None:
         """Synchronous order submission wrapper for thread execution."""
         try:
@@ -65,8 +159,7 @@ async def execute_trade(
                 if input_data.risk_assessment.position_sizing
                 else 0
             )
-            # Broker already checked for None at function level
-            order = broker.submit_order(  # type: ignore[union-attr]
+            order = broker_client.submit_order(
                 symbol=input_data.symbol,
                 qty=qty,
                 side=action.value.lower(),
@@ -92,6 +185,11 @@ async def execute_trade(
             return None
 
     order = await asyncio.to_thread(_sync_submit_order)
+
+    # Track execution metrics in postgres if repository available and order filled
+    if execution_metric_repository and order and requested_price:
+        await _track_execution_metric(order, requested_price, execution_metric_repository)
+
     return TradeExecutionOutput(order_status=order, warnings=warnings)
 
 


### PR DESCRIPTION
## Motivation

Enable slippage analysis and execution quality monitoring for broker orders. Currently, order executions are not tracked in the database, making it impossible to analyze execution performance, identify slippage patterns, or compare broker execution quality over time.

## Implementation information

Added `execution_metrics` table to track broker order executions with slippage analysis:

**Database schema:**

- New table with order_id (unique), symbol, side, quantity, requested/filled prices, timestamps
- Computed fields: execution_time_ms, slippage_bps
- Indices for common queries: symbol, broker, status, timestamp, composite (symbol, broker)

**Domain layer:**

- `ExecutionMetric` Pydantic model with `from_order_status()` factory
- Computes slippage in basis points: `((filled - requested) / requested) * 10000`
- Computes execution time: `submitted_at` to `filled_at` in milliseconds

**Repository:**

- `ExecutionMetricRepository` with async CRUD operations
- Query methods: `get_by_order_id()`, `get_by_symbol()`, `get_avg_slippage_by_broker()`

**Write path:**

- Updated `execute_trade()` to capture market price before order submission
- Tracks metrics in postgres after order filled
- Non-blocking: failures logged as warnings, trades continue
- Extracted helper functions to reduce complexity (C901)

**DI integration:**

- Wired `execution_metric_repository` through container
- Added to `WorkflowComponents` and all workflow factories
- Passed to `execute_trade()` via orchestrator

Alternative considered: Using stop_loss_price as proxy for requested price - rejected as inaccurate (stop loss ≠ entry intent). Instead, fetch current market price immediately before submission.

## Supporting documentation

Fix: #600
