### PR TITLE
docs(database): session management patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -837,6 +837,169 @@ Inheritance is acceptable ONLY for:
 
 **Never use inheritance for code reuse** - always extract and compose instead.
 
+### Database Session Management (MANDATORY)
+
+**Core principle:** Sessions are per-request, never singletons. Engines are singletons.
+
+#### Pattern 1: FastAPI API Endpoints (Dependency Injection)
+
+```python
+# In API endpoint
+@app.get("/positions")
+async def get_positions(
+    session: AsyncSession = Depends(get_db_session)
+):
+    repo = PositionRecordRepository(session)
+    return await repo.get_all_active()
+```
+
+**Use for:** All FastAPI endpoints, any request-scoped operations
+
+#### Pattern 2: Background Tasks (Inline Creation)
+
+```python
+# In background task
+async def scheduled_task():
+    async with get_db_engine().session() as session:
+        repo = AnalysisRepository(session)
+        await repo.create(analysis)
+```
+
+**Use for:** Daemon lifecycle tasks, scheduled jobs, event watchers
+
+#### Pattern 3: Repository Pattern
+
+```python
+class PositionRecordRepository:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get_all_active(self) -> list[PositionRecord]:
+        result = await self.session.execute(
+            select(PositionRecord).where(PositionRecord.closed == False)
+        )
+        return list(result.scalars().all())
+```
+
+**Rules:**
+
+- ✅ Repositories receive sessions in `__init__`
+- ✅ Repository instances can be reused
+- ❌ Never store sessions in long-lived objects
+- ❌ Never create sessions inside repositories
+
+#### State Manager Pattern
+
+```python
+class PositionStateManager:
+    # API methods (called from endpoints)
+    async def get_all_positions(self, session: AsyncSession) -> list[PositionRecord]:
+        repo = PositionRecordRepository(session)
+        return await repo.get_all_active()
+
+    # Background task methods (daemon lifecycle)
+    async def sync_from_broker(self):
+        async with get_db_engine().session() as session:
+            repo = PositionRecordRepository(session)
+            # sync logic
+```
+
+**Rules:**
+
+- ✅ API-facing methods accept `session: AsyncSession` parameter
+- ✅ Background task methods create sessions inline
+- ❌ Never store `_database_engine` or `_session` as instance variables
+
+#### Common Anti-Patterns
+
+❌ **DON'T: Store sessions in state**
+
+```python
+class BadManager:
+    def __init__(self, session: AsyncSession):
+        self._session = session  # ❌ Session shared across requests
+```
+
+❌ **DON'T: Use scoped sessions**
+
+```python
+scoped_session = scoped_session(session_factory)  # ❌ Not recommended for async
+```
+
+❌ **DON'T: Create sessions inside repositories**
+
+```python
+class BadRepository:
+    async def get_all(self):
+        async with get_db_engine().session() as session:  # ❌ Should receive session
+            ...
+```
+
+✅ **DO: Pass sessions explicitly**
+
+```python
+# FastAPI endpoint
+async def endpoint(session: AsyncSession = Depends(get_db_session)):
+    result = await service.process(session, data)
+
+# Service layer
+async def process(session: AsyncSession, data: Data):
+    repo = DataRepository(session)
+    return await repo.create(data)
+```
+
+#### Configuration
+
+```python
+# Engine: Singleton (thread-safe, connection pool)
+engine = create_async_engine(database_url, pool_size=5, max_overflow=10)
+
+# Session factory: Configured once
+async_session_maker = async_sessionmaker(
+    engine,
+    class_=AsyncSession,
+    expire_on_commit=False,  # Required for async
+    autoflush=False,  # Explicit control
+)
+```
+
+#### Exception Handling
+
+```python
+async def get_db_session() -> AsyncGenerator[AsyncSession, None]:
+    async with async_session_maker() as session:
+        try:
+            yield session
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await session.close()
+```
+
+#### Troubleshooting
+
+**Error: "This session is provisioning a new connection; concurrent operations are not permitted"**
+
+- **Cause:** Shared session used by concurrent requests
+- **Fix:** Ensure each request gets fresh session via dependency injection
+
+**Error: "greenlet_spawn has not been called"**
+
+- **Cause:** `expire_on_commit=True` with async sessions
+- **Fix:** Set `expire_on_commit=False` in session factory
+
+**Error: Deadlock or hanging requests**
+
+- **Cause:** Session not closed, connection pool exhausted
+- **Fix:** Always use `async with` context manager for sessions
+
+#### References
+
+- [SQLAlchemy Async Documentation](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html)
+- [FastAPI Dependencies with Yield](https://fastapi.tiangolo.com/tutorial/dependencies/dependencies-with-yield/)
+- [Session Management Best Practices](https://deepwiki.com/fastapi-practices/fastapi_best_architecture/7.6-database-session-management)
+
 ### LLM Abstraction (Custom Provider Pattern)
 
 **Architecture:** Custom provider abstraction using native SDKs (Anthropic, OpenAI) and direct HTTP for Ollama.

--- a/docs/decisions/0003-session-management-pattern.md
+++ b/docs/decisions/0003-session-management-pattern.md
@@ -1,0 +1,107 @@
+# ADR 0003: SQLAlchemy Async Session Management Pattern
+
+## Status
+
+Accepted
+
+## Context
+
+SQLAlchemy async sessions are mutable, stateful objects representing single database transactions. They are NOT thread-safe or task-safe for concurrent operations.
+
+Key characteristics:
+
+- Sessions maintain connection state and transaction context
+- Sessions should not be shared across concurrent requests/tasks
+- Connection pools are managed by the engine (singleton), not sessions
+- Async sessions require `expire_on_commit=False` to prevent lazy-loading issues
+- Sessions must be properly closed to return connections to the pool
+
+## Decision
+
+We will use two distinct patterns for session management:
+
+### Pattern 1: Session-per-request (FastAPI endpoints)
+
+All API endpoints receive sessions via dependency injection using FastAPI's `Depends()`:
+
+```python
+@app.get("/positions")
+async def get_positions(session: AsyncSession = Depends(get_db_session)):
+    repo = PositionRecordRepository(session)
+    return await repo.get_all_active()
+```
+
+**Rationale:** FastAPI's dependency injection system automatically creates and closes sessions per request, preventing session sharing across concurrent requests.
+
+### Pattern 2: Inline session creation (background tasks)
+
+Background tasks and daemon lifecycle methods create sessions inline using context managers:
+
+```python
+async def scheduled_task():
+    async with get_db_engine().session() as session:
+        repo = AnalysisRepository(session)
+        await repo.create(analysis)
+```
+
+**Rationale:** Background tasks don't have request-scoped lifecycle, so they must manage sessions explicitly with context managers.
+
+### Supporting patterns
+
+**Repository Pattern:**
+
+- Repositories receive sessions via `__init__` parameter
+- Repository instances can be reused, but sessions cannot
+- Never create sessions inside repositories
+
+**State Manager Pattern:**
+
+- API-facing methods accept `session: AsyncSession` parameter
+- Background task methods create sessions inline
+- Never store sessions or engines as instance variables
+
+## Consequences
+
+### Positive
+
+- **Prevents concurrency errors:** Each request/task gets isolated session
+- **Follows SQLAlchemy best practices:** Official documentation recommends session-per-request
+- **Clear separation of concerns:** API pattern vs background task pattern explicit
+- **Testability:** Easy to mock sessions in unit tests
+- **Connection pooling:** Engine singleton manages pool efficiently
+
+### Negative
+
+- **Slightly more verbose:** Explicit session passing requires additional parameter
+- **Learning curve:** Developers must understand when to use each pattern
+- **Boilerplate:** Dependency injection setup requires initial configuration
+
+### Neutral
+
+- **Migration effort:** Existing code using stored sessions must be refactored
+- **Documentation overhead:** Team must maintain clear guidelines
+
+## Alternatives Considered
+
+### Alternative 1: Scoped sessions
+
+**Rejected:** `scoped_session()` uses thread-local storage, which doesn't work reliably with asyncio tasks. Not recommended for async contexts.
+
+### Alternative 2: Singleton session
+
+**Rejected:** Would cause "concurrent operations not permitted" errors when handling parallel requests.
+
+### Alternative 3: Session middleware
+
+**Rejected:** While possible, FastAPI's dependency injection is more explicit and type-safe.
+
+## References
+
+- [SQLAlchemy Async Documentation](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html)
+- [FastAPI Dependencies with Yield](https://fastapi.tiangolo.com/tutorial/dependencies/dependencies-with-yield/)
+- [Database Session Management Best Practices](https://deepwiki.com/fastapi-practices/fastapi_best_architecture/7.6-database-session-management)
+- Related PRs: #620, #621
+
+## Date
+
+2026-02-14


### PR DESCRIPTION
## Motivation

After refactoring session management (620, 621), we need clear documentation for developers on when to use dependency injection vs inline session creation and common pitfalls to avoid.

## Implementation information

Added comprehensive session management documentation:

- CLAUDE.md section under Architecture Patterns covering 4 patterns (FastAPI DI, background tasks, repository, state manager)
- Common anti-patterns with explanations
- Configuration and exception handling examples
- Troubleshooting guide for common errors
- ADR 0003 documenting architectural decision with rationale and alternatives considered

## Supporting documentation

Fix: 622
