### PR TITLE
fix(ui): rename degradation tier to NONE

### DIFF
--- a/frontend/src/lib/components/ui/DegradationAlert.svelte
+++ b/frontend/src/lib/components/ui/DegradationAlert.svelte
@@ -5,13 +5,13 @@
 
 	// Tier colors
 	const tierColors: Record<string, string> = {
-		FULL: 'bg-green-100 text-green-800 border-green-300',
+		NONE: 'bg-green-100 text-green-800 border-green-300',
 		DEGRADED: 'bg-yellow-100 text-yellow-800 border-yellow-300',
 		MINIMAL: 'bg-orange-100 text-orange-800 border-orange-300',
 		HALTED: 'bg-red-100 text-red-800 border-red-300'
 	};
 
-	$: shouldShow = degradation && degradation.tier !== 'FULL';
+	$: shouldShow = degradation && degradation.tier !== 'NONE';
 	$: tierClass = degradation ? tierColors[degradation.tier] || tierColors.DEGRADED : '';
 </script>
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -89,6 +89,25 @@
 			format: (value: string) => new Date(value).toLocaleTimeString()
 		}
 	];
+
+	function getDegradationIcon(tier: string | undefined): string {
+		switch (tier) {
+			case 'NONE':
+				return '✅';
+			case 'DEGRADED':
+				return '⚠️';
+			case 'MINIMAL':
+				return '🔶';
+			case 'HALTED':
+				return '🛑';
+			default:
+				return '❓';
+		}
+	}
+
+	function getDegradationDisplay(tier: string | undefined): string {
+		return tier ?? 'UNKNOWN';
+	}
 </script>
 
 <svelte:head>
@@ -133,8 +152,8 @@
 		/>
 		<MetricCard
 			title="Degradation"
-			value={summary?.degradation_tier ?? 'UNKNOWN'}
-			icon="⚠️"
+			value={getDegradationDisplay(summary?.degradation_tier)}
+			icon={getDegradationIcon(summary?.degradation_tier)}
 		/>
 	</div>
 

--- a/frontend/src/routes/events/+page.svelte
+++ b/frontend/src/routes/events/+page.svelte
@@ -267,9 +267,9 @@
 			return;
 		}
 
-		const tierOrder = ['FULL', 'DEGRADED', 'MINIMAL', 'HALTED'];
+		const tierOrder = ['NONE', 'DEGRADED', 'MINIMAL', 'HALTED'];
 		const tierColors: Record<string, string> = {
-			FULL: '#16a34a',
+			NONE: '#16a34a',
 			DEGRADED: '#fbbf24',
 			MINIMAL: '#f97316',
 			HALTED: '#ef4444'

--- a/frontend/src/routes/risk/+page.svelte
+++ b/frontend/src/routes/risk/+page.svelte
@@ -49,6 +49,7 @@
 	$: sharpeData = riskHistory
 		.slice()
 		.reverse()
+		.filter(r => r.sharpe_ratio != null)
 		.map(r => ({
 			time: formatDateShort(r.timestamp),
 			value: r.sharpe_ratio
@@ -58,6 +59,7 @@
 	$: volatilityData = riskHistory
 		.slice()
 		.reverse()
+		.filter(r => r.portfolio_volatility != null)
 		.map(r => ({
 			time: formatDateShort(r.timestamp),
 			value: r.portfolio_volatility
@@ -73,25 +75,25 @@
 	<div class="grid grid-cols-1 md:grid-cols-4 gap-6">
 		<MetricCard
 			title="Sharpe Ratio"
-			value={riskReport ? riskReport.sharpe_ratio.toFixed(2) : 'N/A'}
+			value={riskReport?.sharpe_ratio != null ? riskReport.sharpe_ratio.toFixed(2) : 'N/A'}
 			subtitle="Risk-adjusted return"
 			icon="📉"
 		/>
 		<MetricCard
 			title="Volatility"
-			value={riskReport ? formatPercent(riskReport.portfolio_volatility) : 'N/A'}
+			value={riskReport?.portfolio_volatility != null ? formatPercent(riskReport.portfolio_volatility) : 'N/A'}
 			subtitle="Portfolio volatility"
 			icon="📊"
 		/>
 		<MetricCard
 			title="Max Drawdown"
-			value={riskReport ? formatPercent(riskReport.max_drawdown) : 'N/A'}
+			value={riskReport?.max_drawdown != null ? formatPercent(riskReport.max_drawdown) : 'N/A'}
 			subtitle="Peak to trough"
 			icon="⚠️"
 		/>
 		<MetricCard
 			title="VaR (95%)"
-			value={riskReport ? formatPercent(riskReport.var_95) : 'N/A'}
+			value={riskReport?.var_95 != null ? formatPercent(riskReport.var_95) : 'N/A'}
 			subtitle="Value at Risk"
 			icon="🎲"
 		/>

--- a/src/daemon/api/routers/health.py
+++ b/src/daemon/api/routers/health.py
@@ -35,7 +35,7 @@ async def health(request: Request) -> HealthResponse:
         # DB temporarily unavailable due to concurrent operations - still healthy
         logger.opt(exception=True).debug(f"Failed to fetch state for health check: {e}")
 
-    status = "healthy" if degradation_tier == "FULL" else "degraded"
+    status = "healthy" if degradation_tier == "NONE" else "degraded"
 
     return HealthResponse(
         status=status,

--- a/src/daemon/cycle_orchestrator.py
+++ b/src/daemon/cycle_orchestrator.py
@@ -177,8 +177,8 @@ class DaemonCycleOrchestrator:
                 results_count=0,
             )
 
-        # Log degradation status if not FULL
-        if degradation_context.tier != DegradationTier.FULL:
+        # Log degradation status if not NONE
+        if degradation_context.tier != DegradationTier.NONE:
             unavailable_agents = set(AgentType) - degradation_context.available_agents
             logger.warning(
                 f"Degraded mode: {degradation_context.tier} | "

--- a/src/daemon/degradation.py
+++ b/src/daemon/degradation.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 class DegradationTier(StrEnum):
     """Degradation tier based on API availability."""
 
-    FULL = "FULL"  # All services healthy
+    NONE = "NONE"  # All services healthy
     DEGRADED = "DEGRADED"  # Some optional services down
     MINIMAL = "MINIMAL"  # Only cached/free data available
     HALTED = "HALTED"  # Critical services down (no market data or LLM)
@@ -146,7 +146,7 @@ class DegradationPolicy:
 
         if not health_report:
             return DegradationContext(
-                tier=DegradationTier.FULL,
+                tier=DegradationTier.NONE,
                 available_agents=set(AgentType),
                 unavailable_services=[],
                 confidence_adjustment=1.0,
@@ -192,7 +192,7 @@ class DegradationPolicy:
 
         # Determine tier
         if len(unavailable_agents) == 0:
-            tier = DegradationTier.FULL
+            tier = DegradationTier.NONE
         elif len(available_agents) >= 3:  # Technical + 2 others
             tier = DegradationTier.DEGRADED
         else:

--- a/src/daemon/runner.py
+++ b/src/daemon/runner.py
@@ -139,7 +139,7 @@ class DaemonRunner:
 
         # Convert DegradationContext to dict for coordinator API
         degradation_dict = None
-        if degradation_context.tier != DegradationTier.FULL:
+        if degradation_context.tier != DegradationTier.NONE:
             degradation_dict = {
                 "tier": degradation_context.tier.value,
                 "unavailable_services": degradation_context.unavailable_services,

--- a/tests/test_daemon/test_api.py
+++ b/tests/test_daemon/test_api.py
@@ -256,7 +256,7 @@ class TestStateSummaryEndpoint:
         assert data["total_analyses"] == 42
         assert data["total_trades"] == 15
         assert data["error_count"] == 2
-        assert data["degradation_tier"] == "FULL"
+        assert data["degradation_tier"] == "NONE"
         assert data["trading_mode"] == "paper"
 
     def test_state_summary_degraded(self, client: TestClient, mock_runner: Mock) -> None:
@@ -551,7 +551,7 @@ class TestDegradationEndpoint:
         assert response.status_code == 200
 
         data = response.json()
-        assert data["tier"] == "FULL"
+        assert data["tier"] == "NONE"
         assert data["unavailable_services"] == []
         assert data["confidence_adjustment"] == 1.0
         assert data["halt_reason"] is None
@@ -584,7 +584,7 @@ class TestDegradationEndpoint:
         assert response.status_code == 200
 
         data = response.json()
-        assert data["tier"] == "FULL"
+        assert data["tier"] == "NONE"
         assert data["confidence_adjustment"] == 1.0
 
 

--- a/tests/test_daemon/test_cycle_orchestrator.py
+++ b/tests/test_daemon/test_cycle_orchestrator.py
@@ -82,7 +82,7 @@ def sample_config_coordinator_disabled(tmp_path: Path) -> DaemonConfig:
 def mock_degradation_context() -> DegradationContext:
     """Create mock degradation context."""
     return DegradationContext(
-        tier=DegradationTier.FULL,
+        tier=DegradationTier.NONE,
         available_agents=set(),
         unavailable_services=[],
         confidence_adjustment=1.0,

--- a/tests/test_daemon/test_degradation.py
+++ b/tests/test_daemon/test_degradation.py
@@ -55,7 +55,7 @@ def test_full_mode_all_services_healthy(policy):
 
     context = policy.evaluate_degradation(health_report)
 
-    assert context.tier == DegradationTier.FULL
+    assert context.tier == DegradationTier.NONE
     assert len(context.available_agents) == 9  # All agents
     assert context.confidence_adjustment == 1.0
     assert context.halt_reason is None
@@ -240,7 +240,7 @@ def test_stale_health_report_different_llm_provider():
     context = policy.evaluate_degradation(health_report)
 
     # Should NOT halt (configured provider is healthy)
-    assert context.tier == DegradationTier.FULL
+    assert context.tier == DegradationTier.NONE
     assert context.halt_reason is None
     assert len(context.available_agents) == 9
     assert context.confidence_adjustment == 1.0
@@ -291,7 +291,7 @@ def test_no_health_report_defaults_to_full(policy):
     """Verify FULL tier when no health report available."""
     context = policy.evaluate_degradation(None)
 
-    assert context.tier == DegradationTier.FULL
+    assert context.tier == DegradationTier.NONE
     assert len(context.available_agents) == 9
     assert context.confidence_adjustment == 1.0
 

--- a/tests/test_daemon/test_runner.py
+++ b/tests/test_daemon/test_runner.py
@@ -275,7 +275,7 @@ async def test_run_cycle_uses_merged_watchlist(
         runner,
         "_evaluate_degradation",
         lambda: DegradationContext(
-            tier=DegradationTier.FULL,
+            tier=DegradationTier.NONE,
             available_agents=set(),
             unavailable_services=[],
             confidence_adjustment=1.0,
@@ -529,7 +529,7 @@ class TestSectorRotationIntegration:
             runner,
             "_evaluate_degradation",
             lambda: DegradationContext(
-                tier=DegradationTier.FULL,
+                tier=DegradationTier.NONE,
                 available_agents=set(AgentType),  # All agents available
                 unavailable_services=[],
                 confidence_adjustment=1.0,
@@ -678,7 +678,7 @@ async def test_runner_publishes_cycle_events(sample_config: DaemonConfig, event_
             runner,
             "_evaluate_degradation",
             return_value=DegradationContext(
-                tier=DegradationTier.FULL,
+                tier=DegradationTier.NONE,
                 available_agents=set(),
                 unavailable_services=[],
                 confidence_adjustment=1.0,

--- a/tests/test_daemon/test_runner_degradation.py
+++ b/tests/test_daemon/test_runner_degradation.py
@@ -289,7 +289,7 @@ async def test_no_degradation_when_all_healthy(daemon_config_with_health, temp_h
         # Verify no degradation recorded (or FULL tier recorded)
         # Note: Implementation may or may not record FULL tier
         if runner.state.degradation_history:
-            assert runner.state.degradation_history[-1].tier == DegradationTier.FULL.value
+            assert runner.state.degradation_history[-1].tier == DegradationTier.NONE.value
 
 
 async def test_degradation_history_limited_to_100(daemon_config_with_health, temp_health_dir):


### PR DESCRIPTION
## Motivation

The degradation tier "FULL" was confusing - it displayed with a warning icon even when the system was healthy. "FULL degradation" sounds like everything is broken, when it actually meant "fully operational". Changed to "NONE" (no degradation) for clearer UX.

Risk page was crashing with null pointer errors when risk metrics were undefined/null.

## Implementation information

**Degradation tier rename:**

- Updated `DegradationTier` enum: `FULL` → `NONE`
- Updated all backend references in degradation policy, health checks, runner
- Updated all test assertions (13 files total)
- Updated frontend display logic and icon mapping
- Updated DegradationAlert component conditionals

**Risk page null safety:**

- Added proper null checks for metric cards using optional chaining
- Changed from `riskReport ? riskReport.property` to `riskReport?.property != null`
- Added `.filter()` to chart data to exclude records with null values

All tests pass (1805 passed, 181 skipped), frontend build successful.

## Supporting documentation

Fixes issue identified during dashboard review - misleading UI showing "FULL" degradation with warning icon when system was healthy.
