### PR TITLE
fix(api): use NONE tier for healthy state

### DIFF
--- a/src/daemon/api/routers/health.py
+++ b/src/daemon/api/routers/health.py
@@ -22,7 +22,7 @@ async def health(request: Request) -> HealthResponse:
     uptime = (datetime.now(UTC) - request.app.state.start_time).total_seconds()
 
     # Determine health status from degradation tier
-    degradation_tier = "FULL"
+    degradation_tier = "NONE"
     last_run = None
 
     try:

--- a/src/daemon/api/routers/state.py
+++ b/src/daemon/api/routers/state.py
@@ -22,7 +22,7 @@ async def state_summary(request: Request) -> StateSummaryResponse:
 
     try:
         # Get current degradation tier
-        degradation_tier = "FULL"
+        degradation_tier = "NONE"
         degradation_history = await components.state.get_degradation_history(limit=1)
         if degradation_history:
             degradation_tier = degradation_history[-1].tier
@@ -66,7 +66,7 @@ async def state_summary(request: Request) -> StateSummaryResponse:
             positions_count=0,
             win_rate=None,
             error_count=0,
-            degradation_tier="FULL",
+            degradation_tier="NONE",
             trading_mode=components.config.trading_mode.value,
         )
 
@@ -79,7 +79,7 @@ async def get_degradation(request: Request) -> DegradationResponse:
     degradation_history = await components.state.get_degradation_history(limit=1)
     if not degradation_history:
         return DegradationResponse(
-            tier="FULL",
+            tier="NONE",
             unavailable_services=[],
             confidence_adjustment=1.0,
             halt_reason=None,

--- a/tests/test_daemon/test_api.py
+++ b/tests/test_daemon/test_api.py
@@ -153,7 +153,7 @@ def mock_runner(
         degradation_history=[
             DegradationRecord(
                 timestamp=datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC),
-                tier="FULL",
+                tier="NONE",
                 unavailable_services=[],
                 confidence_adjustment=1.0,
             )
@@ -546,7 +546,7 @@ class TestDegradationEndpoint:
     """Tests for /degradation endpoint."""
 
     def test_get_degradation_full(self, client: TestClient) -> None:
-        """Test degradation endpoint with FULL tier."""
+        """Test degradation endpoint with NONE tier."""
         response = client.get("/degradation")
         assert response.status_code == 200
 
@@ -577,7 +577,7 @@ class TestDegradationEndpoint:
         assert data["confidence_adjustment"] == 0.9
 
     def test_get_degradation_no_history(self, client: TestClient, mock_runner: Mock) -> None:
-        """Test degradation endpoint defaults to FULL."""
+        """Test degradation endpoint defaults to NONE."""
         mock_runner.state.degradation_history = []
 
         response = client.get("/degradation")

--- a/tests/test_daemon/test_degradation.py
+++ b/tests/test_daemon/test_degradation.py
@@ -22,7 +22,7 @@ def policy(daemon_config):
 
 
 def test_full_mode_all_services_healthy(policy):
-    """Verify FULL tier when all services healthy."""
+    """Verify NONE tier when all services healthy."""
     health_report = HealthReport(
         timestamp=datetime.now(UTC),
         overall_status=ServiceStatus.HEALTHY,
@@ -288,7 +288,7 @@ def test_confidence_penalty_capped_at_50_percent(policy):
 
 
 def test_no_health_report_defaults_to_full(policy):
-    """Verify FULL tier when no health report available."""
+    """Verify NONE tier when no health report available."""
     context = policy.evaluate_degradation(None)
 
     assert context.tier == DegradationTier.NONE

--- a/tests/test_daemon/test_runner_degradation.py
+++ b/tests/test_daemon/test_runner_degradation.py
@@ -286,8 +286,8 @@ async def test_no_degradation_when_all_healthy(daemon_config_with_health, temp_h
 
         assert sleep_time == daemon_config_with_health.interval_minutes * 60
 
-        # Verify no degradation recorded (or FULL tier recorded)
-        # Note: Implementation may or may not record FULL tier
+        # Verify no degradation recorded (or NONE tier recorded)
+        # Note: Implementation may or may not record NONE tier
         if runner.state.degradation_history:
             assert runner.state.degradation_history[-1].tier == DegradationTier.NONE.value
 


### PR DESCRIPTION
## Motivation

API routers defaulted to invalid `FULL` tier instead of `DegradationTier.NONE` when no degradation history exists. Frontend shows degradation alert when `tier !== "NONE"`, so `FULL` triggered a false "Service Degradation" warning with 100% confidence adjustment on healthy systems.

## Implementation information

Replaced all hardcoded `"FULL"` defaults with `"NONE"` in:
- `src/daemon/api/routers/state.py` — state summary and degradation endpoints
- `src/daemon/api/routers/health.py` — health endpoint

Updated test fixtures and docstrings to match.