### PR TITLE
feat(risk): migrate reports to PostgreSQL

### DIFF
--- a/src/daemon/state/models.py
+++ b/src/daemon/state/models.py
@@ -161,6 +161,11 @@ class RiskReportRecord(BaseModel):
     cvar_99: float
     cdar_95: float
     max_drawdown: float
+    portfolio_volatility: float
+    current_exposure_percent: float
+    num_positions: int
+    var_limit_breached: bool
+    cvar_limit_breached: bool
     risk_status: str
 
 

--- a/src/daemon/tasks/reporting_tasks.py
+++ b/src/daemon/tasks/reporting_tasks.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-import json
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from loguru import logger
@@ -177,18 +175,7 @@ class RiskReportTask(TaskExecutor):
             lookback_days=self.components.config.risk_limits.lookback_days,
         )
 
-        # Persist to JSON file
-        def _write_report() -> Path:
-            report_dir = Path(self.components.config.risk_limits.report_dir).expanduser()
-            report_dir.mkdir(parents=True, exist_ok=True)
-            report_path = report_dir / f"risk-report-{report.date}.json"
-            with report_path.open("w") as f:
-                json.dump(report.model_dump(), f, indent=2)
-            return report_path
-
-        report_path = await asyncio.to_thread(_write_report)
-
-        # Record in state
+        # Record in database
         await self.components.state.record_risk_report(
             RiskReportRecord(
                 timestamp=datetime.now(UTC),
@@ -198,6 +185,11 @@ class RiskReportTask(TaskExecutor):
                 cvar_99=report.cvar_99,
                 cdar_95=report.cdar_95,
                 max_drawdown=report.max_drawdown,
+                portfolio_volatility=report.portfolio_volatility,
+                current_exposure_percent=report.current_exposure_percent,
+                num_positions=report.num_positions,
+                var_limit_breached=report.var_limit_breached,
+                cvar_limit_breached=report.cvar_limit_breached,
                 risk_status=report.risk_status,
             )
         )
@@ -207,7 +199,6 @@ class RiskReportTask(TaskExecutor):
         )
         console.print(f"[{status_color}]Risk status: {report.risk_status}[/{status_color}]")
         console.print(f"[dim]VaR95={report.var_95:.4f}, CVaR99={report.cvar_99:.4f}[/dim]")
-        console.print(f"[dim]Report saved: {report_path}[/dim]")
         logger.info(f"Risk report generated: {report.risk_status}")
 
         # Send notification if VaR limits breached

--- a/src/database/migrations/016_expand_risk_report_fields.sql
+++ b/src/database/migrations/016_expand_risk_report_fields.sql
@@ -1,0 +1,21 @@
+-- Add missing fields to risk_report_records table
+
+ALTER TABLE risk_report_records
+ADD COLUMN IF NOT EXISTS portfolio_volatility DECIMAL(12, 4) NOT NULL DEFAULT 0,
+ADD COLUMN IF NOT EXISTS current_exposure_percent DECIMAL(5, 4) NOT NULL DEFAULT 0,
+ADD COLUMN IF NOT EXISTS num_positions INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN IF NOT EXISTS var_limit_breached BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN IF NOT EXISTS cvar_limit_breached BOOLEAN NOT NULL DEFAULT false;
+
+-- Add index for breach queries
+CREATE INDEX IF NOT EXISTS idx_risk_report_records_breaches
+ON risk_report_records (timestamp DESC)
+WHERE var_limit_breached = true OR cvar_limit_breached = true;
+
+-- Rollback instructions:
+-- DROP INDEX IF EXISTS idx_risk_report_records_breaches;
+-- ALTER TABLE risk_report_records DROP COLUMN IF EXISTS cvar_limit_breached;
+-- ALTER TABLE risk_report_records DROP COLUMN IF EXISTS var_limit_breached;
+-- ALTER TABLE risk_report_records DROP COLUMN IF EXISTS num_positions;
+-- ALTER TABLE risk_report_records DROP COLUMN IF EXISTS current_exposure_percent;
+-- ALTER TABLE risk_report_records DROP COLUMN IF EXISTS portfolio_volatility;

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -601,6 +601,11 @@ class RiskReportRecordORM(Base):
     cvar_99: Mapped[Decimal] = mapped_column(DECIMAL(12, 4), nullable=False)
     cdar_95: Mapped[Decimal] = mapped_column(DECIMAL(12, 4), nullable=False)
     max_drawdown: Mapped[Decimal] = mapped_column(DECIMAL(8, 4), nullable=False)
+    portfolio_volatility: Mapped[Decimal] = mapped_column(DECIMAL(12, 4), nullable=False)
+    current_exposure_percent: Mapped[Decimal] = mapped_column(DECIMAL(5, 4), nullable=False)
+    num_positions: Mapped[int] = mapped_column(nullable=False)
+    var_limit_breached: Mapped[bool] = mapped_column(nullable=False)
+    cvar_limit_breached: Mapped[bool] = mapped_column(nullable=False)
     risk_status: Mapped[str] = mapped_column(String(20), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True),

--- a/src/database/repositories/risk_report.py
+++ b/src/database/repositories/risk_report.py
@@ -48,6 +48,11 @@ class RiskReportRecordRepository(BaseRepository[RiskReportRecord]):
             cvar_99=Decimal(str(entity.cvar_99)),
             cdar_95=Decimal(str(entity.cdar_95)),
             max_drawdown=Decimal(str(entity.max_drawdown)),
+            portfolio_volatility=Decimal(str(entity.portfolio_volatility)),
+            current_exposure_percent=Decimal(str(entity.current_exposure_percent)),
+            num_positions=entity.num_positions,
+            var_limit_breached=entity.var_limit_breached,
+            cvar_limit_breached=entity.cvar_limit_breached,
             risk_status=entity.risk_status,
             created_at=datetime.now(UTC),
         )
@@ -102,6 +107,11 @@ class RiskReportRecordRepository(BaseRepository[RiskReportRecord]):
             cvar_99=float(orm.cvar_99),
             cdar_95=float(orm.cdar_95),
             max_drawdown=float(orm.max_drawdown),
+            portfolio_volatility=float(orm.portfolio_volatility),
+            current_exposure_percent=float(orm.current_exposure_percent),
+            num_positions=orm.num_positions,
+            var_limit_breached=orm.var_limit_breached,
+            cvar_limit_breached=orm.cvar_limit_breached,
             risk_status=orm.risk_status,
         )
 


### PR DESCRIPTION
## Motivation

Risk reports were persisted to both JSON files and PostgreSQL (dual
persistence). This was inconsistent with the audit logs migration in
PR 628, which fully migrated to PostgreSQL. JSON file storage created
unnecessary complexity and didn't align with the database-first
architecture.

## Implementation information

Added missing fields to RiskReportRecordORM and RiskReportRecord:
portfolio_volatility, current_exposure_percent, num_positions,
var_limit_breached, cvar_limit_breached.

Created migration 016_expand_risk_report_fields.sql with new columns
and partial index for breach queries.

Updated RiskReportRecordRepository create/read methods to handle new
fields.

Removed JSON file persistence from RiskReportTask (lines 180-189).
Removed unused imports (json, Path).

Single source of truth: PostgreSQL.

## Supporting documentation

Related: PR 628 (audit logs migration to PostgreSQL)
