### PR TITLE
fix(data): swap NASDAQ100 columns for Wikipedia

### DIFF
--- a/src/data/universe.py
+++ b/src/data/universe.py
@@ -445,8 +445,8 @@ class StockUniverseFetcher:
             for row in table.find_all("tr")[1:]:  # Skip header
                 cols = row.find_all("td")
                 if len(cols) >= 3:
-                    raw_name = cols[0].get_text(strip=True)
-                    raw_symbol = cols[1].get_text(strip=True)
+                    raw_symbol = cols[0].get_text(strip=True)
+                    raw_name = cols[1].get_text(strip=True)
                     symbol = raw_symbol.replace(".", "-")
                     name = raw_name
                     sector = cols[2].get_text(strip=True)
@@ -455,7 +455,7 @@ class StockUniverseFetcher:
                     # Validate: symbol should not contain spaces and should be short
                     if " " in symbol or len(symbol) > 6:
                         logger.warning(
-                            f"NASDAQ100 INVALID: col0='{raw_name}' col1='{raw_symbol}' -> "
+                            f"NASDAQ100 INVALID: col0='{raw_symbol}' col1='{raw_name}' -> "
                             f"symbol='{symbol}' name='{name}'"
                         )
                         continue

--- a/tests/test_data/test_universe.py
+++ b/tests/test_data/test_universe.py
@@ -26,9 +26,9 @@ def mock_nasdaq100_html():
     """Mock NASDAQ 100 Wikipedia HTML."""
     return """
     <table id="constituents">
-        <tr><th>Company</th><th>Ticker</th><th>GICS Sector</th><th>GICS Sub-Industry</th></tr>
-        <tr><td>Apple Inc.</td><td>AAPL</td><td>Information Technology</td><td>Technology Hardware</td></tr>
-        <tr><td>NVIDIA Corp</td><td>NVDA</td><td>Information Technology</td><td>Semiconductors</td></tr>
+        <tr><th>Ticker</th><th>Company</th><th>GICS Sector</th><th>GICS Sub-Industry</th></tr>
+        <tr><td>AAPL</td><td>Apple Inc.</td><td>Information Technology</td><td>Technology Hardware</td></tr>
+        <tr><td>NVDA</td><td>NVIDIA Corp</td><td>Information Technology</td><td>Semiconductors</td></tr>
     </table>
     """
 
@@ -277,10 +277,10 @@ class TestStockUniverseFetcher:
         """Test NASDAQ 100 scraper filters symbols with spaces or length > 6."""
         mock_html = """
         <table id="constituents">
-            <tr><th>Company</th><th>Ticker</th><th>GICS Sector</th><th>GICS Sub-Industry</th></tr>
-            <tr><td>Apple Inc.</td><td>AAPL</td><td>Tech</td><td>Hardware</td></tr>
-            <tr><td>Bad Co</td><td>BAD TICK</td><td>Tech</td><td>Software</td></tr>
-            <tr><td>Too Long Inc</td><td>TOOLONG</td><td>Tech</td><td>Services</td></tr>
+            <tr><th>Ticker</th><th>Company</th><th>GICS Sector</th><th>GICS Sub-Industry</th></tr>
+            <tr><td>AAPL</td><td>Apple Inc.</td><td>Tech</td><td>Hardware</td></tr>
+            <tr><td>BAD TICK</td><td>Bad Co</td><td>Tech</td><td>Software</td></tr>
+            <tr><td>TOOLONG</td><td>Too Long Inc</td><td>Tech</td><td>Services</td></tr>
         </table>
         """
         mock_response = MagicMock()


### PR DESCRIPTION
## Motivation

Wikipedia changed NASDAQ 100 table structure. Parser was reading col0 as company name and col1 as ticker, but current Wikipedia table has col0=ticker and col1=company. This caused all NASDAQ100 stocks to be filtered out with warnings showing swapped symbol/name assignments.

## Implementation information

- Swapped cols[0] and cols[1] assignments in _scrape_nasdaq100() to match current Wikipedia structure
- Updated test fixtures to reflect new table format (Ticker, Company instead of Company, Ticker)
- Verified all 1831 tests pass

## Supporting documentation

See warning logs showing: symbol='Adobe Inc-' name='ADBE' (backwards)
