### PR TITLE
fix(agents): use list for GamePlan key_levels

### DIFF
--- a/src/agents/game_plan.py
+++ b/src/agents/game_plan.py
@@ -18,7 +18,7 @@ class KeyLevel(BaseModel):
     """Price level for a symbol."""
 
     symbol: str
-    price: float
+    price: float = Field(gt=0.0)
 
 
 class GamePlanLLMResponse(BaseModel):
@@ -112,7 +112,18 @@ class GamePlanAgent:
             priority_symbols = llm_response.priority_symbols
             risk_stance = llm_response.risk_stance
             sector_focus = llm_response.sector_focus
-            key_levels = {kl.symbol: kl.price for kl in llm_response.key_levels}
+            key_levels: dict[str, float] = {}
+            seen_symbols: set[str] = set()
+            for kl in llm_response.key_levels:
+                if kl.symbol in seen_symbols:
+                    logger.warning(
+                        "Duplicate key level symbol from LLM response: {symbol}. "
+                        "Keeping last provided price {price}.",
+                        symbol=kl.symbol,
+                        price=kl.price,
+                    )
+                seen_symbols.add(kl.symbol)
+                key_levels[kl.symbol] = kl.price
             reasoning = llm_response.reasoning
             confidence = llm_response.confidence
         except StructuredOutputError as e:

--- a/tests/test_agents/test_game_plan.py
+++ b/tests/test_agents/test_game_plan.py
@@ -67,6 +67,7 @@ async def test_game_plan_agent_generate(mock_yf_ticker, test_container, mock_mar
     assert isinstance(plan, GamePlan)
     assert plan.priority_symbols == ["AAPL", "TSLA"]
     assert plan.risk_stance == "NEUTRAL"
+    assert plan.key_levels == {"AAPL": 175.0}
     assert 0.0 <= plan.confidence <= 1.0
 
 


### PR DESCRIPTION
## Motivation

GamePlanAgent structured output fails validation with google/gemini-2.5-flash:
```
ValidationError: key_levels
  Input should be an object [type=dict_type, input_value='AAPL: Resistance at 178...', input_type=str]
```

Root cause: `dict[str, float]` generates schema with `additionalProperties: {"type": "number"}`, but OpenAI strict mode overwrites with `additionalProperties: false`, breaking dict validation.

## Implementation information

- Add `KeyLevel` model with `symbol: str`, `price: float`
- Change `GamePlanLLMResponse.key_levels` from `dict[str, float] | None` to `list[KeyLevel]`
- Convert to dict in agent: `{kl.symbol: kl.price for kl in llm_response.key_levels}`
- `GamePlan.key_levels` stays `dict[str, float]` (no downstream changes)
- Update tests to use list format

Fix compatible with all LLM providers using structured output (OpenAI, Anthropic, Google).

## Supporting documentation

Related to OpenAI strict mode requirement: `additionalProperties: false` recursively