### PR TITLE
refactor(di): remove service locator from tools

### DIFF
--- a/src/agents/web_researcher.py
+++ b/src/agents/web_researcher.py
@@ -61,15 +61,15 @@ QUERY_TEMPLATES = {
 class WebResearchAgent:
     """Agent for gathering web-based research on stocks."""
 
-    def __init__(self, llm_client: LLMClient, search_tool: WebSearchTool | None = None) -> None:
+    def __init__(self, llm_client: LLMClient, search_tool: WebSearchTool) -> None:
         """Initialize web research agent.
 
         Args:
             llm_client: LLM client for analysis
-            search_tool: Web search tool. Creates default if not provided.
+            search_tool: Web search tool for data fetching
         """
         self.llm = llm_client
-        self.search_tool = search_tool or WebSearchTool()
+        self.search_tool = search_tool
         self._prompts = PromptLoader("web_researcher")
         logger.info(f"Initialized WebResearchAgent (tools_enabled={llm_client.supports_tools})")
 

--- a/src/di/container.py
+++ b/src/di/container.py
@@ -179,7 +179,7 @@ class AppContainer(containers.DeclarativeContainer):
 
     web_search_tool = providers.Singleton(
         model_providers.create_web_search_tool,
-        container=providers.Self(),
+        websearch_fetcher=websearch_fetcher,
     )
 
     market_regime_detector = providers.Singleton(

--- a/src/di/providers/models.py
+++ b/src/di/providers/models.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from src.data.market import MarketDataFetcher
     from src.data.news import NewsFetcher
     from src.data.universe import StockUniverseFetcher
+    from src.data.websearch import WebSearchFetcher
     from src.database.repositories.trade import TradeRepository
     from src.di.container import AppContainer
     from src.metrics.execution import ExecutionMetricsCollector
@@ -129,18 +130,18 @@ def create_portfolio_var_calculator(
     return PortfolioVaRCalculator(risk_calculator, market_fetcher)
 
 
-def create_web_search_tool(container: AppContainer) -> WebSearchTool:
-    """Create WebSearchTool with DI container.
+def create_web_search_tool(websearch_fetcher: WebSearchFetcher) -> WebSearchTool:
+    """Create WebSearchTool with websearch fetcher.
 
     Args:
-        container: DI container for dependency resolution
+        websearch_fetcher: WebSearchFetcher for executing searches
 
     Returns:
         WebSearchTool instance
     """
     from src.tools.websearch import WebSearchTool
 
-    return WebSearchTool(container)
+    return WebSearchTool(websearch_fetcher)
 
 
 def create_market_regime_detector() -> MarketRegimeDetector:

--- a/src/di/providers/workers.py
+++ b/src/di/providers/workers.py
@@ -90,14 +90,12 @@ def create_comparative_worker(
     return ComparativeWorker(llm_client, comparative_fetcher)
 
 
-def create_web_research_worker(
-    llm_client: LLMClient, search_tool: WebSearchTool | None = None
-) -> WebResearchWorker:
+def create_web_research_worker(llm_client: LLMClient, search_tool: WebSearchTool) -> WebResearchWorker:
     """Create WebResearchWorker.
 
     Args:
         llm_client: LLM client
-        search_tool: Web search tool (creates default if not provided)
+        search_tool: Web search tool for data fetching
 
     Returns:
         WebResearchWorker instance

--- a/src/tools/analyze_stock.py
+++ b/src/tools/analyze_stock.py
@@ -17,15 +17,13 @@ if TYPE_CHECKING:
 class AnalyzeStockTool(BaseTool):
     """Tool to run full trading analysis workflow."""
 
-    def __init__(self, container: AppContainer | None = None) -> None:
-        """Initialize tool with optional container.
+    def __init__(self, container: AppContainer) -> None:
+        """Initialize tool with DI container.
 
         Args:
-            container: DI container (auto-created if not provided)
+            container: DI container for dependency resolution
         """
-        from src.di.container import create_container
-
-        self._container = container or create_container()
+        self._container = container
 
     @property
     def name(self) -> str:

--- a/src/tools/backtest.py
+++ b/src/tools/backtest.py
@@ -15,15 +15,13 @@ if TYPE_CHECKING:
 class RunBacktestTool(BaseTool):
     """Tool to run backtest on a stock with momentum strategy."""
 
-    def __init__(self, container: AppContainer | None = None) -> None:
-        """Initialize tool with optional container.
+    def __init__(self, container: AppContainer) -> None:
+        """Initialize tool with DI container.
 
         Args:
-            container: DI container (auto-created if not provided)
+            container: DI container for dependency resolution
         """
-        from src.di.container import create_container
-
-        self._container = container or create_container()
+        self._container = container
 
     @property
     def name(self) -> str:

--- a/src/tools/market_data.py
+++ b/src/tools/market_data.py
@@ -15,15 +15,13 @@ if TYPE_CHECKING:
 class GetMarketDataTool(BaseTool):
     """Tool to fetch current market data for a stock."""
 
-    def __init__(self, container: AppContainer | None = None) -> None:
-        """Initialize tool with optional container.
+    def __init__(self, container: AppContainer) -> None:
+        """Initialize tool with DI container.
 
         Args:
-            container: DI container (auto-created if not provided)
+            container: DI container for dependency resolution
         """
-        from src.di.container import create_container
-
-        self._container = container or create_container()
+        self._container = container
 
     @property
     def name(self) -> str:

--- a/src/tools/news.py
+++ b/src/tools/news.py
@@ -17,15 +17,13 @@ DESCRIPTION_TRUNCATE_LENGTH = 300
 class GetNewsTool(BaseTool):
     """Tool to fetch recent news for a stock."""
 
-    def __init__(self, container: AppContainer | None = None) -> None:
-        """Initialize tool with optional container.
+    def __init__(self, container: AppContainer) -> None:
+        """Initialize tool with DI container.
 
         Args:
-            container: DI container (auto-created if not provided)
+            container: DI container for dependency resolution
         """
-        from src.di.container import create_container
-
-        self._container = container or create_container()
+        self._container = container
 
     @property
     def name(self) -> str:

--- a/src/tools/portfolio.py
+++ b/src/tools/portfolio.py
@@ -15,15 +15,13 @@ if TYPE_CHECKING:
 class OptimizePortfolioTool(BaseTool):
     """Tool to optimize trading strategy parameters with Optuna."""
 
-    def __init__(self, container: AppContainer | None = None) -> None:
-        """Initialize tool with optional container.
+    def __init__(self, container: AppContainer) -> None:
+        """Initialize tool with DI container.
 
         Args:
-            container: DI container (auto-created if not provided)
+            container: DI container for dependency resolution
         """
-        from src.di.container import create_container
-
-        self._container = container or create_container()
+        self._container = container
 
     @property
     def name(self) -> str:

--- a/src/tools/risk_metrics.py
+++ b/src/tools/risk_metrics.py
@@ -15,15 +15,13 @@ if TYPE_CHECKING:
 class GetRiskMetricsTool(BaseTool):
     """Tool to calculate institutional-grade risk metrics."""
 
-    def __init__(self, container: AppContainer | None = None) -> None:
-        """Initialize tool with optional container.
+    def __init__(self, container: AppContainer) -> None:
+        """Initialize tool with DI container.
 
         Args:
-            container: DI container (auto-created if not provided)
+            container: DI container for dependency resolution
         """
-        from src.di.container import create_container
-
-        self._container = container or create_container()
+        self._container = container
 
     @property
     def name(self) -> str:

--- a/src/tools/screen_stocks.py
+++ b/src/tools/screen_stocks.py
@@ -18,15 +18,13 @@ if TYPE_CHECKING:
 class ScreenStocksTool(BaseTool):
     """Tool to screen stocks for investment opportunities."""
 
-    def __init__(self, container: AppContainer | None = None) -> None:
-        """Initialize tool with optional container.
+    def __init__(self, container: AppContainer) -> None:
+        """Initialize tool with DI container.
 
         Args:
-            container: DI container (auto-created if not provided)
+            container: DI container for dependency resolution
         """
-        from src.di.container import create_container
-
-        self._container = container or create_container()
+        self._container = container
 
     @property
     def name(self) -> str:

--- a/src/tools/social_sentiment.py
+++ b/src/tools/social_sentiment.py
@@ -17,15 +17,13 @@ if TYPE_CHECKING:
 class GetSocialSentimentTool(BaseTool):
     """Tool to analyze social sentiment from Reddit and Finnhub."""
 
-    def __init__(self, container: AppContainer | None = None) -> None:
-        """Initialize tool with optional container.
+    def __init__(self, container: AppContainer) -> None:
+        """Initialize tool with DI container.
 
         Args:
-            container: DI container (auto-created if not provided)
+            container: DI container for dependency resolution
         """
-        from src.di.container import create_container
-
-        self._container = container or create_container()
+        self._container = container
 
     @property
     def name(self) -> str:

--- a/src/tools/tearsheet.py
+++ b/src/tools/tearsheet.py
@@ -19,15 +19,13 @@ if TYPE_CHECKING:
 class GenerateTearsheetTool(BaseTool):
     """Tool to generate QuantStats performance tearsheet."""
 
-    def __init__(self, container: AppContainer | None = None) -> None:
-        """Initialize tool with optional container.
+    def __init__(self, container: AppContainer) -> None:
+        """Initialize tool with DI container.
 
         Args:
-            container: DI container (auto-created if not provided)
+            container: DI container for dependency resolution
         """
-        from src.di.container import create_container
-
-        self._container = container or create_container()
+        self._container = container
 
     @property
     def name(self) -> str:

--- a/src/tools/trump_analysis.py
+++ b/src/tools/trump_analysis.py
@@ -34,15 +34,13 @@ class TrumpAnalysisTool(BaseTool):
 
     TOOL_NAME = "analyze_trump_posts"
 
-    def __init__(self, container: AppContainer | None = None) -> None:
-        """Initialize tool with optional container.
+    def __init__(self, container: AppContainer) -> None:
+        """Initialize tool with DI container.
 
         Args:
-            container: DI container (auto-created if not provided)
+            container: DI container for dependency resolution
         """
-        from src.di.container import create_container
-
-        self._container = container or create_container()
+        self._container = container
 
     @property
     def name(self) -> str:

--- a/src/tools/websearch.py
+++ b/src/tools/websearch.py
@@ -9,7 +9,7 @@ from src.tools.base import BaseTool
 from src.tools.models import ToolDefinition, ToolFunction, ToolParameter, ToolParametersSchema
 
 if TYPE_CHECKING:
-    from src.di.container import AppContainer
+    from src.data.websearch import WebSearchFetcher
 
 BODY_TRUNCATE_LENGTH = 300
 
@@ -19,16 +19,13 @@ class WebSearchTool(BaseTool):
 
     TOOL_NAME = "web_search"
 
-    def __init__(self, container: AppContainer | None = None) -> None:
-        """Initialize web search tool with optional container.
+    def __init__(self, fetcher: WebSearchFetcher) -> None:
+        """Initialize web search tool with websearch fetcher.
 
         Args:
-            container: DI container (auto-created if not provided)
+            fetcher: WebSearchFetcher for executing searches
         """
-        from src.di.container import create_container
-
-        self._container = container or create_container()
-        self.fetcher = self._container.websearch_fetcher()
+        self.fetcher = fetcher
         logger.info("Initialized WebSearchTool")
 
     @property

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -86,17 +86,17 @@ class TradingChatApp(App):
     def _create_tool_registry(self) -> ToolRegistry:
         """Create and populate tool registry."""
         registry = ToolRegistry()
-        registry.register(WebSearchTool())
-        registry.register(GetMarketDataTool())
-        registry.register(GetNewsTool())
+        registry.register(WebSearchTool(fetcher=self._container.websearch_fetcher()))
+        registry.register(GetMarketDataTool(container=self._container))
+        registry.register(GetNewsTool(container=self._container))
         registry.register(AnalyzeStockTool(container=self._container))
         registry.register(ScreenStocksTool(container=self._container))
         registry.register(TrumpAnalysisTool(container=self._container))
         registry.register(GetSocialSentimentTool(container=self._container))
-        registry.register(GetRiskMetricsTool())
-        registry.register(RunBacktestTool())
-        registry.register(GenerateTearsheetTool())
-        registry.register(OptimizePortfolioTool())
+        registry.register(GetRiskMetricsTool(container=self._container))
+        registry.register(RunBacktestTool(container=self._container))
+        registry.register(GenerateTearsheetTool(container=self._container))
+        registry.register(OptimizePortfolioTool(container=self._container))
         return registry
 
     def _get_model_name(self) -> str:

--- a/src/workers/web_research.py
+++ b/src/workers/web_research.py
@@ -25,15 +25,15 @@ MIN_AVG_FINDING_LENGTH = 50  # Minimum average finding length for quality boost
 class WebResearchWorker:
     """Worker for web-based research on stocks - stateless implementation."""
 
-    def __init__(self, llm_client: LLMClient, search_tool: WebSearchTool | None = None) -> None:
+    def __init__(self, llm_client: LLMClient, search_tool: WebSearchTool) -> None:
         """Initialize web research worker.
 
         Args:
             llm_client: LLM client for analysis
-            search_tool: Web search tool. Creates default if not provided.
+            search_tool: Web search tool for data fetching
         """
         self.llm = llm_client
-        self.search_tool = search_tool or WebSearchTool()
+        self.search_tool = search_tool
         self._prompts = PromptLoader("web_researcher")
         logger.info(f"Initialized WebResearchWorker (tools_enabled={llm_client.supports_tools})")
 

--- a/tests/test_tools/test_websearch_tool.py
+++ b/tests/test_tools/test_websearch_tool.py
@@ -55,12 +55,12 @@ class TestWebSearchTool:
 
     def test_tool_name(self, test_container_full):
         """Test tool name property."""
-        tool = WebSearchTool(container=test_container_full)
+        tool = WebSearchTool(fetcher=test_container_full.websearch_fetcher())
         assert tool.name == "web_search"
 
     def test_get_tool_definition(self, test_container_full):
         """Test tool definition format."""
-        tool = WebSearchTool(container=test_container_full)
+        tool = WebSearchTool(fetcher=test_container_full.websearch_fetcher())
         definition = tool.get_tool_definition().model_dump(mode="json", by_alias=True, exclude_none=True)
 
         assert definition["type"] == "function"
@@ -79,7 +79,7 @@ class TestWebSearchTool:
         mock_fetcher.search.return_value = mock_general_response
         test_container_full.websearch_fetcher.override(mock_fetcher)
 
-        tool = WebSearchTool(container=test_container_full)
+        tool = WebSearchTool(fetcher=test_container_full.websearch_fetcher())
 
         result = tool.execute(query="AAPL stock", search_type="general", max_results=5)
 
@@ -94,7 +94,7 @@ class TestWebSearchTool:
         mock_fetcher.search_news.return_value = mock_news_response
         test_container_full.websearch_fetcher.override(mock_fetcher)
 
-        tool = WebSearchTool(container=test_container_full)
+        tool = WebSearchTool(fetcher=test_container_full.websearch_fetcher())
 
         result = tool.execute(query="AAPL news", search_type="news", max_results=5)
 
@@ -115,7 +115,7 @@ class TestWebSearchTool:
         mock_fetcher.search.return_value = empty_response
         test_container_full.websearch_fetcher.override(mock_fetcher)
 
-        tool = WebSearchTool(container=test_container_full)
+        tool = WebSearchTool(fetcher=test_container_full.websearch_fetcher())
         result = tool.execute(query="nonexistent query", search_type="general")
 
         assert "No results found" in result
@@ -139,7 +139,7 @@ class TestWebSearchTool:
         mock_fetcher.search.return_value = long_response
         test_container_full.websearch_fetcher.override(mock_fetcher)
 
-        tool = WebSearchTool(container=test_container_full)
+        tool = WebSearchTool(fetcher=test_container_full.websearch_fetcher())
 
         result = tool.execute(query="test", search_type="general")
 
@@ -148,6 +148,6 @@ class TestWebSearchTool:
 
     def test_repr(self, test_container_full):
         """Test string representation."""
-        tool = WebSearchTool(container=test_container_full)
+        tool = WebSearchTool(fetcher=test_container_full.websearch_fetcher())
         repr_str = repr(tool)
         assert "WebSearchTool" in repr_str


### PR DESCRIPTION
## Motivation

Remove service locator anti-pattern from DI implementation where tools
created container instances inline if not provided, violating proper
dependency injection principles.

## Implementation information

**Pattern removed (11 tools):**
```python
# Before
def __init__(self, container: AppContainer | None = None):
    self._container = container or create_container()  # ❌

# After  
def __init__(self, container: AppContainer):
    self._container = container  # ✅
```

**WebSearchTool improved:**
- Changed from depending on full container to WebSearchFetcher
- Eliminates providers.Self() reliability issues
- Cleaner DI - depends only on what it uses

**Files changed:**
- 11 tool classes (news, market_data, social_sentiment, portfolio,
  backtest, tearsheet, analyze_stock, screen_stocks, trump_analysis,
  risk_metrics, websearch)
- 2 agents/workers (web_researcher, web_research)
- DI providers and container configuration
- TUI app instantiation
- Test fixtures

**Result:** All 1856 tests passing, all checks clean.

## Supporting documentation

Part of DI cleanup to enforce constructor injection without nulls.