### PR TITLE
docs(docs): add DI guidelines, finnhub research

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,22 @@ Markers: `@pytest.mark.unit`, `.integration`, `.slow`. Mock all external APIs.
 
 All deps via `__init__`. Use `dependency-injector` container (`src/di/container.py`). Singletons for stateful services, Factories for per-request.
 
+**Constructor-only injection:** All dependencies pass through `__init__` as non-null typed params. Initialize all instance attributes in `__init__` with defaults (never leave uninitialized). NEVER use setter methods or `| None` for required dependencies.
+
+```python
+# ❌ Setter injection or nullable deps
+class Service:
+    def __init__(self):
+        self.dep: Dependency | None = None
+    def set_dep(self, dep: Dependency): ...
+
+# ✅ Constructor injection with non-null types
+class Service:
+    def __init__(self, dep: Dependency):
+        self.dep = dep
+        self._state = 0  # Initialize all attrs
+```
+
 **CRITICAL:** `providers.Self()` doesn't work with Factory — always pass container explicitly:
 
 ```python

--- a/docs/api/finnhub.md
+++ b/docs/api/finnhub.md
@@ -1,0 +1,68 @@
+# Finnhub API - Free Tier Endpoints
+
+Research findings on Finnhub API endpoint availability (free vs premium tier).
+
+## ✅ Free Tier (60 req/min)
+
+### Market Data
+- `/quote` - real-time quotes
+- `/stock/candle` - OHLCV candlestick data
+- `/forex/candle`, `/crypto/candle` - forex/crypto prices
+
+### Company Info
+- `/stock/profile2` - company profile
+- `/company-news` - company-specific news (currently used)
+- `/news` - general market news
+- `/company-basic-financials` - fundamental metrics
+
+### Economic
+- `/calendar/earnings` - earnings calendar
+- `/calendar/economic` - economic events
+
+## ❌ Premium Only (403 errors)
+
+### Alternative Data
+- `/stock/social-sentiment` - Reddit/Twitter sentiment ⚠️ currently used
+- `/news-sentiment` - news sentiment indicator ⚠️ currently used
+- `/stock/dividends` - dividend data
+- `/stock/insider-transactions` - insider trading
+- `/stock/pattern` - pattern recognition
+- `/stock/support-resistance` - S/R levels
+
+### Other Premium
+- Congressional trading, lobbying data, USA spending
+- Filing sentiment analysis
+- Earnings call transcripts
+
+## Current Issues
+
+Our code uses **premium-only endpoints**:
+- `src/data/finnhub.py:151` - `/stock/social-sentiment`
+- `src/data/finnhub.py:234` - `/news-sentiment`
+
+Both return 403 on free tier.
+
+## Recommendation
+
+Switch to free endpoints:
+- Keep `/company-news` (already in `finnhub_news.py`)
+- Remove `FinnhubFetcher` social/news sentiment methods
+- Use FinBERT for sentiment instead (already have)
+
+## Rate Limits
+
+- Free: 60 API calls/minute
+- Premium: varies by plan (500k/day mentioned)
+- All plans: 30 calls/second hard limit
+
+## Sources
+
+- [Finnhub API Docs](https://finnhub.io/docs/api)
+- [GitHub Issue #271 - Free Endpoints now Premium](https://github.com/finnhubio/Finnhub-API/issues/271)
+- [GitHub Issue #534 - Free Tier Access](https://github.com/finnhubio/Finnhub-API/issues/534)
+- [IBKR Campus Guide](https://www.interactivebrokers.com/campus/ibkr-quant-news/exploring-the-finnhub-io-api/)
+- [Robot Wealth - Finnhub API](https://robotwealth.com/finnhub-api/)
+
+## Date
+
+Research conducted: 2026-02-16


### PR DESCRIPTION
## Motivation

Document constructor-only DI pattern and capture Finnhub API tier research for future reference.

## Implementation information

- Added constructor-only injection guidelines to CLAUDE.md with examples
- Created docs/api/finnhub.md documenting free vs premium endpoints
- Identified premium-only endpoints currently in use (social/news sentiment)

## Supporting documentation

Research findings show `/stock/social-sentiment` and `/news-sentiment` require premium tier.