### PR TITLE
fix(deps): remove duplicate ruff specification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,6 @@ dev = [
     "pytest-asyncio==1.3.0",
     "pytest-cov==7.0.0",
     "pytest-mock==3.15.1",
-    "ruff==0.15.1",
     "aiosqlite==0.22.1",
 ]
 profiling = [

--- a/uv.lock
+++ b/uv.lock
@@ -58,7 +58,6 @@ dev = [
     { name = "pytest-asyncio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pytest-cov", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pytest-mock", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "ruff", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 profiling = [
     { name = "snakeviz", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -107,7 +106,6 @@ requires-dist = [
     { name = "quantstats", specifier = "==0.0.81" },
     { name = "rich", specifier = "==14.3.2" },
     { name = "riskfolio-lib", specifier = "==6.3.1" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.1" },
     { name = "snakeviz", marker = "extra == 'profiling'", specifier = ">=2.2.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = "==2.0.46" },
     { name = "tenacity", specifier = "==9.1.4" },


### PR DESCRIPTION
## Motivation

Fix duplicate ruff version specs. ruff appeared in two dependency groups with conflicting specs: ruff==0.15.1 in [project.optional-dependencies] dev and ruff>=0.15.0 in [dependency-groups] dev. This created confusion about which version is canonical.

## Implementation information

Removed ruff==0.15.1 from [project.optional-dependencies] dev (line 64). Kept ruff>=0.15.0 in [dependency-groups] dev (line 138) as single source of truth. The dependency-groups section is the modern uv-native approach.

## Supporting documentation

Fix: #701