### PR TITLE
perf(reddit): reduce IPC, parallelize scraping

### DIFF
--- a/src/daemon/tasks/data_tasks.py
+++ b/src/daemon/tasks/data_tasks.py
@@ -317,6 +317,7 @@ class PeriodicRedditScrapingTask(TaskExecutor):
 
     async def execute(self) -> None:
         """Execute Reddit scraping logic."""
+        from src.data.reddit import RedditPost
         from src.data.reddit_scraper import RedditPlaywrightScraper
         from src.data.reddit_ticker_extractor import RedditTickerExtractor
         from src.database.connection import get_session
@@ -363,43 +364,58 @@ class PeriodicRedditScrapingTask(TaskExecutor):
         try:
             await scraper.start()
 
-            all_posts = []
-            all_comments = []
-            all_mentions = []
+            all_posts: list = []
+            all_top_posts: list = []
 
-            # Scrape each subreddit
+            # Scrape listing pages sequentially (rate-limit friendly)
             for subreddit in self.components.config.reddit_scraper.high_priority_subreddits:
                 try:
                     logger.info(f"Scraping r/{subreddit}")
-                    # Scrape posts
                     posts = await scraper.scrape_subreddit_posts(
                         subreddit=subreddit,
                         limit=self.components.config.reddit_scraper.posts_per_subreddit,
                     )
                     all_posts.extend(posts)
                     logger.info(f"Scraped {len(posts)} posts from r/{subreddit}")
-
-                    # Scrape comments from top posts
                     top_posts = sorted(posts, key=lambda p: p.score, reverse=True)[:10]
-                    logger.debug(f"Scraping comments from top {len(top_posts)} posts")
-                    for post in top_posts:
-                        comments = await scraper.scrape_post_comments(
-                            post=post,
-                            limit=self.components.config.reddit_scraper.comments_per_post,
-                        )
-                        all_comments.extend(comments)
-
-                        # Extract tickers
-                        if self.components.config.reddit_scraper.use_llm_extraction:
-                            logger.debug(f"Extracting tickers from post {post.id}")
-                            mentions = await extractor.extract_tickers(post=post, comments=comments)
-                            if mentions:
-                                logger.info(f"Extracted {len(mentions)} ticker mentions from post {post.id}")
-                            all_mentions.append((post, mentions))
-
+                    all_top_posts.extend(top_posts)
                 except Exception:
                     logger.opt(exception=True).warning(f"Failed to scrape r/{subreddit}")
                     continue
+
+            # Scrape comments + extract tickers in parallel across all top posts
+            semaphore = asyncio.Semaphore(3)
+
+            async def _scrape_and_extract(post: RedditPost) -> tuple:
+                async with semaphore:
+                    comments = await scraper.scrape_post_comments(
+                        post=post,
+                        limit=cfg.comments_per_post,
+                    )
+                mentions = []
+                if cfg.use_llm_extraction:
+                    logger.debug(f"Extracting tickers from post {post.id}")
+                    mentions = await extractor.extract_tickers(post=post, comments=comments)
+                    if mentions:
+                        logger.info(f"Extracted {len(mentions)} ticker mentions from post {post.id}")
+                return post, comments, mentions
+
+            logger.debug(f"Scraping comments from {len(all_top_posts)} top posts in parallel")
+            gather_results = await asyncio.gather(
+                *[_scrape_and_extract(p) for p in all_top_posts],
+                return_exceptions=True,
+            )
+
+            all_comments: list = []
+            all_mentions: list = []
+            for result in gather_results:
+                if isinstance(result, BaseException):
+                    logger.warning(f"Failed to scrape/extract post: {result}")
+                    continue
+                post, comments, mentions = result
+                all_comments.extend(comments)
+                if mentions:
+                    all_mentions.append((post, mentions))
 
             # Store to database
             async with get_session() as session:
@@ -411,17 +427,12 @@ class PeriodicRedditScrapingTask(TaskExecutor):
                 comment_repo = RedditCommentRepository(session)
                 comments_inserted = await comment_repo.bulk_insert(all_comments)
 
-                # Insert ticker mentions
+                # Bulk insert all ticker mentions in one statement
                 mention_repo = RedditTickerMentionRepository(session)
-                mentions_inserted = 0
-                for post, mentions in all_mentions:
-                    if mentions:
-                        count = await mention_repo.bulk_insert_from_post(
-                            post=post,
-                            mentions=mentions,
-                            extraction_method=ExtractionMethod.LLM,
-                        )
-                        mentions_inserted += count
+                mentions_inserted = await mention_repo.bulk_insert_all(
+                    post_mentions=all_mentions,
+                    extraction_method=ExtractionMethod.LLM,
+                )
 
                 # Compute sentiment aggregates
                 sentiment_repo = RedditTickerSentimentRepository(session)

--- a/src/data/reddit_scraper.py
+++ b/src/data/reddit_scraper.py
@@ -1,13 +1,16 @@
 """Reddit web scraper using Playwright with anti-bot measures."""
 
+from __future__ import annotations
+
 import asyncio
+import contextlib
 import json
 import random
 from datetime import UTC, datetime
 from pathlib import Path
 
 from loguru import logger
-from playwright.async_api import Browser, ElementHandle, Page, async_playwright
+from playwright.async_api import Browser, Page, async_playwright
 from playwright_stealth import Stealth
 
 from src.cache.historical import HistoricalCache
@@ -45,6 +48,36 @@ USER_AGENTS = [
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:122.0) Gecko/20100101 Firefox/122.0",
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:122.0) Gecko/20100101 Firefox/122.0",
 ]
+
+_JS_EXTRACT_POSTS = """
+() => Array.from(document.querySelectorAll('div.thing.link[data-fullname]')).map(el => ({
+    id: (el.dataset.fullname || '').replace('t3_', ''),
+    title: el.querySelector('a.title')?.textContent?.trim() || '',
+    url: (() => {
+        const h = el.querySelector('a.title')?.getAttribute('href');
+        return h && !h.startsWith('http') ? 'https://old.reddit.com' + h : (h || '');
+    })(),
+    score: parseInt(el.querySelector('div.score.unvoted')?.textContent?.replace(/[^0-9]/g, '') || '0') || 0,
+    num_comments: parseInt(
+        (el.querySelector('a.comments')?.textContent || '0 comments').split(' ')[0]
+    ) || 0,
+    created_utc: el.querySelector('time')?.getAttribute('datetime') || null,
+    body: el.querySelector('div.usertext-body div.md')?.textContent?.trim() || ''
+}))
+"""
+
+_JS_EXTRACT_COMMENTS = """
+(limit) => Array.from(document.querySelectorAll('div.comment[data-fullname]'))
+    .slice(0, limit)
+    .map(el => ({
+        id: (el.dataset.fullname || '').replace('t1_', ''),
+        body: el.querySelector('div.md')?.textContent?.trim() || '',
+        score: (() => {
+            const t = el.querySelector('div.score.unvoted')?.textContent?.trim().split(' ')[0];
+            return parseInt(t) || 1;
+        })()
+    }))
+"""
 
 
 class RedditPlaywrightScraper:
@@ -175,6 +208,57 @@ class RedditPlaywrightScraper:
         except Exception:
             logger.opt(exception=True).warning("Failed to save cookies")
 
+    def _parse_post(self, raw: dict, subreddit: str) -> RedditPost | None:
+        """Parse raw JS-evaluated dict into RedditPost.
+
+        Args:
+            raw: Dict from page.evaluate JS extraction
+            subreddit: Subreddit name
+
+        Returns:
+            RedditPost or None if id missing
+        """
+        if not raw.get("id"):
+            return None
+
+        created_utc = datetime.now(UTC)
+        with contextlib.suppress(ValueError, AttributeError):
+            if raw.get("created_utc"):
+                created_utc = datetime.fromisoformat(raw["created_utc"])
+
+        return RedditPost(
+            id=raw["id"],
+            title=raw.get("title", ""),
+            body=raw.get("body", ""),
+            subreddit=subreddit,
+            score=raw.get("score", 0),
+            upvote_ratio=0.0,  # Sentinel value (not available on listing)
+            url=raw.get("url", ""),
+            created_utc=created_utc,
+            num_comments=raw.get("num_comments", 0),
+        )
+
+    def _parse_comment(self, raw: dict, parent_post_id: str) -> RedditComment | None:
+        """Parse raw JS-evaluated dict into RedditComment.
+
+        Args:
+            raw: Dict from page.evaluate JS extraction
+            parent_post_id: Parent post Reddit ID
+
+        Returns:
+            RedditComment or None if id or body missing
+        """
+        if not raw.get("id") or not raw.get("body"):
+            return None
+
+        return RedditComment(
+            id=raw["id"],
+            parent_post_id=parent_post_id,
+            body=raw["body"],
+            score=raw.get("score", 1),
+            created_utc=datetime.now(UTC),
+        )
+
     async def scrape_subreddit_posts(
         self,
         subreddit: str,
@@ -196,7 +280,6 @@ class RedditPlaywrightScraper:
             msg = "Browser failed to start"
             raise RuntimeError(msg)
 
-        # Create new page with random user agent and viewport
         user_agent = random.choice(USER_AGENTS)
         context = await self._browser.new_context(
             user_agent=user_agent,
@@ -204,44 +287,34 @@ class RedditPlaywrightScraper:
         )
         page = await context.new_page()
 
-        # Apply stealth
         await self._apply_stealth(page)
-
-        # Load cookies
         await self._load_cookies(page)
 
         try:
-            # Navigate to subreddit
             url = f"https://old.reddit.com/r/{subreddit}/"
             logger.info(f"Scraping r/{subreddit} (limit={limit})")
 
             await page.goto(url, wait_until="domcontentloaded", timeout=30000)
             await self._random_delay(self.config.delay_page_load_min, self.config.delay_page_load_max)
 
-            # Scroll to trigger lazy load
             for scroll_num in range(3):
                 await page.evaluate("window.scrollBy(0, window.innerHeight * 2)")
                 await self._random_delay(self.config.delay_action_min, self.config.delay_action_max)
                 logger.debug(f"Scroll {scroll_num + 1}/3")
 
-            # Extract posts
+            raw_posts: list[dict] = await page.evaluate(_JS_EXTRACT_POSTS)
+            logger.info(f"Found {len(raw_posts)} post containers on r/{subreddit}")
+
             posts = []
-            post_containers = await page.query_selector_all("div.thing.link[data-fullname]")
-
-            logger.info(f"Found {len(post_containers)} post containers on r/{subreddit}")
-
-            for container in post_containers[:limit]:
+            for raw in raw_posts[:limit]:
                 try:
-                    post = await self._extract_post(container, subreddit)
+                    post = self._parse_post(raw, subreddit)
                     if post:
                         posts.append(post)
                 except Exception:
-                    logger.opt(exception=True).warning("Failed to extract post")
-                    continue
+                    logger.opt(exception=True).warning("Failed to parse post")
 
-            # Save cookies
             await self._save_cookies(page)
-
             logger.info(f"Scraped {len(posts)} posts from r/{subreddit}")
             return posts
 
@@ -252,141 +325,6 @@ class RedditPlaywrightScraper:
         finally:
             await page.close()
             await context.close()
-
-    async def _extract_reddit_id(self, container: ElementHandle) -> str | None:
-        """Extract Reddit ID from container.
-
-        Args:
-            container: Post container element
-
-        Returns:
-            Reddit ID or None if not found
-        """
-        reddit_id_attr = await container.get_attribute("data-fullname")
-        if not reddit_id_attr:
-            return None
-        return reddit_id_attr.replace("t3_", "")
-
-    async def _extract_title_and_url(self, container: ElementHandle) -> tuple[str, str]:
-        """Extract title and URL from container.
-
-        Args:
-            container: Post container element
-
-        Returns:
-            Tuple of (title, url)
-        """
-        title_elem = await container.query_selector("a.title")
-        title = await title_elem.text_content() if title_elem else ""
-        title = title.strip() if title else ""
-
-        url = await title_elem.get_attribute("href") if title_elem else None
-        if url and not url.startswith("http"):
-            url = f"https://old.reddit.com{url}"
-        if not url:
-            url = ""
-
-        return title, url
-
-    async def _extract_score(self, container: ElementHandle) -> int:
-        """Extract score from container.
-
-        Args:
-            container: Post container element
-
-        Returns:
-            Score as integer
-        """
-        score_elem = await container.query_selector("div.score.unvoted")
-        score_text = await score_elem.text_content() if score_elem else "0"
-        score_text = score_text.strip().replace("•", "").strip() if score_text else "0"
-        try:
-            return int(score_text) if score_text and score_text.isdigit() else 0
-        except ValueError:
-            return 0
-
-    async def _extract_comments_count(self, container: ElementHandle) -> int:
-        """Extract comments count from container.
-
-        Args:
-            container: Post container element
-
-        Returns:
-            Number of comments
-        """
-        comments_elem = await container.query_selector("a.comments")
-        comments_text = await comments_elem.text_content() if comments_elem else "0 comments"
-        if not comments_text or "comment" not in comments_text:
-            return 0
-
-        num_text = comments_text.split()[0]
-        try:
-            return int(num_text) if num_text.isdigit() else 0
-        except ValueError:
-            return 0
-
-    async def _extract_timestamp(self, container: ElementHandle) -> datetime:
-        """Extract timestamp from container.
-
-        Args:
-            container: Post container element
-
-        Returns:
-            Post creation datetime
-        """
-        time_elem = await container.query_selector("time")
-        if time_elem:
-            timestamp_attr = await time_elem.get_attribute("datetime")
-            if timestamp_attr:
-                try:
-                    return datetime.fromisoformat(timestamp_attr)
-                except ValueError:
-                    logger.debug(f"Failed to parse timestamp: {timestamp_attr}")
-                except AttributeError:
-                    logger.debug(f"Failed to parse timestamp: {timestamp_attr}")
-
-        return datetime.now(UTC)
-
-    async def _extract_post(self, container: ElementHandle, subreddit: str) -> RedditPost | None:
-        """Extract post data from container element.
-
-        Args:
-            container: Post container element
-            subreddit: Subreddit name
-
-        Returns:
-            RedditPost or None if extraction fails
-        """
-        try:
-            reddit_id = await self._extract_reddit_id(container)
-            if not reddit_id:
-                return None
-
-            title, url = await self._extract_title_and_url(container)
-            score = await self._extract_score(container)
-            num_comments = await self._extract_comments_count(container)
-            created_utc = await self._extract_timestamp(container)
-
-            # Body (self-posts only)
-            body_elem = await container.query_selector("div.usertext-body div.md")
-            body = await body_elem.text_content() if body_elem else ""
-            body = body.strip() if body else ""
-
-            return RedditPost(
-                id=reddit_id,
-                title=title,
-                body=body,
-                subreddit=subreddit,
-                score=score,
-                upvote_ratio=0.0,  # Sentinel value (not available on listing)
-                url=url,
-                created_utc=created_utc,
-                num_comments=num_comments,
-            )
-
-        except Exception:
-            logger.opt(exception=True).debug("Failed to extract post data")
-            return None
 
     async def scrape_post_comments(
         self,
@@ -409,7 +347,6 @@ class RedditPlaywrightScraper:
             msg = "Browser failed to start"
             raise RuntimeError(msg)
 
-        # Create new page with random user agent and viewport
         user_agent = random.choice(USER_AGENTS)
         context = await self._browser.new_context(
             user_agent=user_agent,
@@ -417,10 +354,7 @@ class RedditPlaywrightScraper:
         )
         page = await context.new_page()
 
-        # Apply stealth
         await self._apply_stealth(page)
-
-        # Load cookies
         await self._load_cookies(page)
 
         try:
@@ -429,18 +363,16 @@ class RedditPlaywrightScraper:
             await page.goto(post.url, wait_until="domcontentloaded", timeout=30000)
             await self._random_delay(self.config.delay_page_load_min, self.config.delay_page_load_max)
 
-            # Extract comments
-            comments = []
-            comment_containers = await page.query_selector_all("div.comment[data-fullname]")
+            raw_comments: list[dict] = await page.evaluate(_JS_EXTRACT_COMMENTS, limit)
 
-            for container in comment_containers[:limit]:
+            comments = []
+            for raw in raw_comments:
                 try:
-                    comment = await self._extract_comment(container, post.id)
+                    comment = self._parse_comment(raw, post.id)
                     if comment:
                         comments.append(comment)
                 except Exception:
-                    logger.opt(exception=True).debug("Failed to extract comment")
-                    continue
+                    logger.opt(exception=True).debug("Failed to parse comment")
 
             logger.debug(f"Scraped {len(comments)} comments for post {post.id}")
             return comments
@@ -452,55 +384,6 @@ class RedditPlaywrightScraper:
         finally:
             await page.close()
             await context.close()
-
-    async def _extract_comment(self, container: ElementHandle, parent_post_id: str) -> RedditComment | None:
-        """Extract comment data from container element.
-
-        Args:
-            container: Comment container element
-            parent_post_id: Parent post Reddit ID
-
-        Returns:
-            RedditComment or None if extraction fails
-        """
-        try:
-            # Comment ID
-            comment_id_attr = await container.get_attribute("data-fullname")
-            if not comment_id_attr:
-                return None
-            comment_id = comment_id_attr.replace("t1_", "")
-
-            # Body
-            body_elem = await container.query_selector("div.md")
-            body = await body_elem.text_content() if body_elem else ""
-            body = body.strip() if body else ""
-
-            if not body:
-                return None
-
-            # Score
-            score_elem = await container.query_selector("div.score.unvoted")
-            score_text = await score_elem.text_content() if score_elem else "1"
-            score_text = score_text.strip().split()[0] if score_text else "1"  # "123 points" -> "123"
-            try:
-                score = int(score_text) if score_text.lstrip("-").isdigit() else 1
-            except ValueError:
-                score = 1
-
-            # Created UTC (not easily available, use current time)
-            created_utc = datetime.now(UTC)
-
-            return RedditComment(
-                id=comment_id,
-                parent_post_id=parent_post_id,
-                body=body,
-                score=score,
-                created_utc=created_utc,
-            )
-
-        except Exception:
-            logger.opt(exception=True).debug("Failed to extract comment data")
-            return None
 
     def __repr__(self) -> str:
         """Return string representation."""

--- a/src/database/repositories/reddit.py
+++ b/src/database/repositories/reddit.py
@@ -377,6 +377,58 @@ class RedditTickerMentionRepository(BaseRepository[TickerMention]):
         logger.debug(f"Inserted {inserted_count} ticker mentions from post {post.id} (deduped)")
         return inserted_count
 
+    async def bulk_insert_all(
+        self,
+        post_mentions: list[tuple[RedditPost, list[TickerMention]]],
+        extraction_method: ExtractionMethod = ExtractionMethod.LLM,
+    ) -> int:
+        """Bulk insert ticker mentions from multiple posts in one statement.
+
+        Args:
+            post_mentions: List of (post, mentions) tuples
+            extraction_method: LLM or REGEX
+
+        Returns:
+            Number of mentions inserted
+        """
+        values = []
+        for post, mentions in post_mentions:
+            for mention in mentions:
+                values.append(
+                    {
+                        "id": uuid.uuid4(),
+                        "symbol": mention.symbol.upper(),
+                        "source_type": "post",
+                        "source_reddit_id": post.id,
+                        "subreddit": post.subreddit,
+                        "sentiment": mention.sentiment,
+                        "mention_context": mention.context[:200] if mention.context else None,
+                        "confidence": Decimal(str(mention.confidence)),
+                        "extraction_method": extraction_method.value,
+                        "created_utc": post.created_utc,
+                        "extracted_at": datetime.now(UTC),
+                    }
+                )
+
+        if not values:
+            return 0
+
+        stmt = (
+            insert(RedditTickerMentionORM)
+            .values(values)
+            .on_conflict_do_nothing(
+                index_elements=["source_type", "source_reddit_id", "symbol", "extraction_method"]
+            )
+        )
+        result: Result = await self._session.execute(stmt)
+        await self._session.commit()
+
+        inserted_count = getattr(result, "rowcount", 0) or 0
+        logger.info(
+            f"Bulk inserted {inserted_count} ticker mentions across {len(post_mentions)} posts (deduped)"
+        )
+        return inserted_count
+
     async def get_by_id(self, entity_id: str) -> TickerMention | None:
         """Get ticker mention by ID.
 

--- a/src/screening/screener.py
+++ b/src/screening/screener.py
@@ -1,6 +1,7 @@
 """Stock screener engine for finding investment opportunities."""
 
 import hashlib
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
@@ -162,6 +163,9 @@ class StockScreener:
         period = "1y" if criteria == ScreeningCriteria.BREAKOUT else "3mo"
         market_data = self._fetch_batch_data(symbols, period=period)
 
+        # Pre-fetch all ticker fundamentals in parallel (only needed for VALUE)
+        ticker_infos = self._prefetch_value_infos(symbols) if criteria == ScreeningCriteria.VALUE else {}
+
         # Score each stock
         results = []
         errors = []
@@ -177,7 +181,7 @@ class StockScreener:
                 if criteria == ScreeningCriteria.MOMENTUM:
                     result = self._score_momentum(df, info)
                 elif criteria == ScreeningCriteria.VALUE:
-                    result = self._score_value(df, info, symbol)
+                    result = self._score_value(df, info, ticker_infos.get(symbol, {}))
                 else:
                     result = self._score_breakout(df, info)
 
@@ -250,6 +254,25 @@ class StockScreener:
         logger.info(f"Fetched data for {len(all_data)} symbols")
         return all_data
 
+    def _prefetch_value_infos(self, symbols: list[str]) -> dict[str, dict]:
+        """Fetch yfinance fundamentals for all symbols in parallel.
+
+        Args:
+            symbols: List of stock symbols
+
+        Returns:
+            Dict mapping symbol to yfinance .info dict
+        """
+
+        def _fetch_one(sym: str) -> tuple[str, dict]:
+            try:
+                return sym, yf.Ticker(sym).info
+            except Exception:
+                return sym, {}
+
+        with ThreadPoolExecutor(max_workers=20) as executor:
+            return dict(executor.map(_fetch_one, symbols))
+
     def _score_momentum(self, df: pd.DataFrame, info: StockInfo) -> ScreeningResult | None:
         """Score stock for momentum criteria.
 
@@ -303,7 +326,7 @@ class StockScreener:
             reason=f"RSI {rsi:.1f} (oversold), MACD bullish ({macd_hist:.4f}), above 50-day MA",
         )
 
-    def _score_value(self, df: pd.DataFrame, info: StockInfo, symbol: str) -> ScreeningResult | None:
+    def _score_value(self, df: pd.DataFrame, info: StockInfo, ticker_info: dict) -> ScreeningResult | None:
         """Score stock for value criteria.
 
         Criteria: Low P/E vs market + P/B < 3 + positive price momentum
@@ -311,18 +334,11 @@ class StockScreener:
         Args:
             df: OHLCV DataFrame
             info: Stock info
-            symbol: Stock symbol
+            ticker_info: Pre-fetched yfinance .info dict
 
         Returns:
             ScreeningResult or None if doesn't match
         """
-        try:
-            ticker = yf.Ticker(symbol)
-            ticker_info = ticker.info
-        except Exception as e:
-            logger.opt(exception=True).warning(f"Failed to fetch yfinance info for {symbol}: {e}")
-            return None
-
         pe = ticker_info.get("trailingPE")
         pb = ticker_info.get("priceToBook")
         forward_pe = ticker_info.get("forwardPE")

--- a/tests/test_daemon/test_periodic_reddit_task.py
+++ b/tests/test_daemon/test_periodic_reddit_task.py
@@ -143,7 +143,7 @@ async def test_execute_success(reddit_task, sample_posts, sample_comments, sampl
     mock_comment_repo = Mock()
     mock_comment_repo.bulk_insert = AsyncMock(return_value=2)
     mock_mention_repo = Mock()
-    mock_mention_repo.bulk_insert_from_post = AsyncMock(return_value=2)
+    mock_mention_repo.bulk_insert_all = AsyncMock(return_value=2)
     mock_sentiment_repo = Mock()
     mock_sentiment_repo.compute_hourly_aggregates = AsyncMock(return_value=1)
 
@@ -177,7 +177,7 @@ async def test_execute_success(reddit_task, sample_posts, sample_comments, sampl
         # Verify DB inserts
         assert mock_post_repo.bulk_insert.called
         assert mock_comment_repo.bulk_insert.called
-        assert mock_mention_repo.bulk_insert_from_post.called
+        assert mock_mention_repo.bulk_insert_all.called
         assert mock_sentiment_repo.compute_hourly_aggregates.called
 
         # Verify stats recorded
@@ -205,6 +205,7 @@ async def test_execute_handles_subreddit_failure(reddit_task, sample_posts):
     mock_comment_repo = Mock()
     mock_comment_repo.bulk_insert = AsyncMock(return_value=0)
     mock_mention_repo = Mock()
+    mock_mention_repo.bulk_insert_all = AsyncMock(return_value=0)
     mock_sentiment_repo = Mock()
     mock_sentiment_repo.compute_hourly_aggregates = AsyncMock(return_value=0)
 

--- a/tests/test_data/test_reddit_scraper.py
+++ b/tests/test_data/test_reddit_scraper.py
@@ -1,6 +1,5 @@
 """Tests for RedditPlaywrightScraper."""
 
-from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -94,43 +93,21 @@ async def test_context_manager():
 
 
 @pytest.mark.unit
-async def test_extract_post_from_html(scraper, tmp_path):
-    """Test post extraction from HTML fixture."""
-    fixture_path = Path(__file__).parent.parent / "fixtures" / "reddit_html" / "subreddit_listing.html"
+def test_parse_post(scraper_config):
+    """Test _parse_post converts raw JS dict to RedditPost."""
+    scraper = RedditPlaywrightScraper(config=scraper_config)
 
-    if not fixture_path.exists():
-        pytest.skip("HTML fixture not found")
+    raw = {
+        "id": "abc123",
+        "title": "TSLA to the moon! 🚀",
+        "url": "https://reddit.com/r/wallstreetbets/post1",
+        "score": 2500,
+        "num_comments": 150,
+        "created_utc": "2024-01-15T12:00:00+00:00",
+        "body": "",
+    }
 
-    html_content = fixture_path.read_text()
-
-    # Mock Playwright page with fixture HTML
-    mock_container = AsyncMock()
-    mock_container.get_attribute = AsyncMock(return_value="t3_abc123")
-
-    # Mock selectors
-    title_elem = AsyncMock()
-    title_elem.text_content = AsyncMock(return_value="TSLA to the moon! 🚀")
-    title_elem.get_attribute = AsyncMock(return_value="https://reddit.com/r/wallstreetbets/post1")
-
-    score_elem = AsyncMock()
-    score_elem.text_content = AsyncMock(return_value="2500")
-
-    comments_elem = AsyncMock()
-    comments_elem.text_content = AsyncMock(return_value="150 comments")
-
-    async def query_selector_side_effect(selector):
-        if selector == "a.title":
-            return title_elem
-        if selector == "div.score.unvoted":
-            return score_elem
-        if selector == "a.comments":
-            return comments_elem
-        return None
-
-    mock_container.query_selector = AsyncMock(side_effect=query_selector_side_effect)
-
-    # Test extraction
-    post = await scraper._extract_post(mock_container, "wallstreetbets")
+    post = scraper._parse_post(raw, "wallstreetbets")
 
     assert post is not None
     assert post.id == "abc123"
@@ -141,34 +118,37 @@ async def test_extract_post_from_html(scraper, tmp_path):
 
 
 @pytest.mark.unit
-async def test_extract_comment_from_html(scraper):
-    """Test comment extraction."""
-    mock_container = AsyncMock()
-    mock_container.get_attribute = AsyncMock(return_value="t1_comment1")
+def test_parse_post_missing_id(scraper_config):
+    """Test _parse_post returns None when id is missing."""
+    scraper = RedditPlaywrightScraper(config=scraper_config)
 
-    # Mock selectors
-    body_elem = AsyncMock()
-    body_elem.text_content = AsyncMock(return_value="TSLA $350 by EOW! This is the way 🚀")
+    post = scraper._parse_post({"id": "", "title": "test"}, "wallstreetbets")
+    assert post is None
 
-    score_elem = AsyncMock()
-    score_elem.text_content = AsyncMock(return_value="450")
 
-    async def query_selector_side_effect(selector):
-        if selector == "div.md":
-            return body_elem
-        if selector == "div.score.unvoted":
-            return score_elem
-        return None
+@pytest.mark.unit
+def test_parse_comment(scraper_config):
+    """Test _parse_comment converts raw JS dict to RedditComment."""
+    scraper = RedditPlaywrightScraper(config=scraper_config)
 
-    mock_container.query_selector = AsyncMock(side_effect=query_selector_side_effect)
+    raw = {"id": "comment1", "body": "TSLA $350 by EOW! This is the way 🚀", "score": 450}
 
-    comment = await scraper._extract_comment(mock_container, "t3_abc123")
+    comment = scraper._parse_comment(raw, "t3_abc123")
 
     assert comment is not None
     assert comment.id == "comment1"
     assert comment.parent_post_id == "t3_abc123"
     assert comment.body == "TSLA $350 by EOW! This is the way 🚀"
     assert comment.score == 450
+
+
+@pytest.mark.unit
+def test_parse_comment_missing_body(scraper_config):
+    """Test _parse_comment returns None when body is empty."""
+    scraper = RedditPlaywrightScraper(config=scraper_config)
+
+    comment = scraper._parse_comment({"id": "c1", "body": "", "score": 1}, "post1")
+    assert comment is None
 
 
 @pytest.mark.unit
@@ -191,8 +171,8 @@ async def test_scrape_with_mock_browser(scraper_config):
         mock_context.new_page = AsyncMock(return_value=mock_page)
         mock_context.close = AsyncMock()
 
-        # Mock empty posts list
-        mock_page.query_selector_all = AsyncMock(return_value=[])
+        # Mock empty posts list via evaluate
+        mock_page.evaluate = AsyncMock(return_value=[])
         mock_page.goto = AsyncMock()
         mock_page.wait_for_selector = AsyncMock()
         mock_page.close = AsyncMock()

--- a/tests/test_screening/test_screener.py
+++ b/tests/test_screening/test_screener.py
@@ -312,16 +312,11 @@ class TestScoringFunctions:
             assert "pct_from_high" in result.metrics
             assert "volume_ratio" in result.metrics
 
-    @patch("src.screening.screener.yf.Ticker")
-    def test_score_value_logs_yfinance_errors(self, mock_ticker, stock_screener, sample_ohlcv_momentum):
-        """Verify yfinance errors return None and are logged."""
+    def test_score_value_empty_ticker_info_returns_none(self, stock_screener, sample_ohlcv_momentum):
+        """Verify missing fundamentals (empty ticker_info) returns None."""
         from src.data.universe import StockInfo
 
-        # Mock yfinance to raise an exception
-        mock_ticker.side_effect = Exception("API error")
-
         info = StockInfo(symbol="AAPL", name="Apple Inc", sector="Tech", industry="Software")
-        result = stock_screener._score_value(sample_ohlcv_momentum, info, "AAPL")
+        result = stock_screener._score_value(sample_ohlcv_momentum, info, {})
 
-        # Should return None on error (logging verified via stderr capture in test output)
         assert result is None


### PR DESCRIPTION
## Motivation

Profiling revealed three categories of runtime overhead per Reddit cycle:
- ~37-43s on Playwright IPC (stack introspection per ElementHandle call)
- ~216s sequential comment scraping + LLM extraction across 3 subreddits × 10 posts
- ~260s sequential yfinance `.info` fetches for VALUE screening (525 stocks)

## Implementation information

**Change 1 — `src/data/reddit_scraper.py`:** Replaced all per-element
`ElementHandle` calls (query_selector, get_attribute, text_content) with two
module-level JS constants evaluated via `page.evaluate()`. 600+ IPC calls/cycle
→ 1 per page. Removed 7 async helper methods, added 2 sync parse methods.

**Change 2 — `src/daemon/tasks/data_tasks.py`:** Subreddit listing pages still
scraped sequentially (rate-limit friendly). All top posts across subreddits
then processed in parallel via `asyncio.gather + Semaphore(3)`. Playwright
(per-context) bounded by semaphore; LLM extraction runs fully concurrent after
release.

**Change 3 — `src/screening/screener.py`:** Extracted `_prefetch_value_infos()`
using `ThreadPoolExecutor(max_workers=20)` — pre-fetches all yfinance
fundamentals before the scoring loop when `criteria == VALUE`. `_score_value`
now accepts pre-fetched `ticker_info: dict`.

**Change 4 — `src/database/repositories/reddit.py`:** Added `bulk_insert_all()`
that builds one `values` list across all posts and executes a single
`INSERT ... ON CONFLICT DO NOTHING` + commit instead of N per-post inserts.

> Changelog: perf(reddit): reduce IPC, parallelize scraping