### PR TITLE
fix(api): use index 0 for game plan history

### DIFF
--- a/src/daemon/api/routers/trading.py
+++ b/src/daemon/api/routers/trading.py
@@ -120,7 +120,7 @@ async def get_game_plan(request: Request) -> GamePlanResponse | None:
         if not game_plan_history:
             return None
 
-        latest = game_plan_history[-1]
+        latest = game_plan_history[0]
 
         # Return None if essential fields are missing (old records)
         if latest.reasoning is None or latest.confidence is None or latest.generated_at is None:

--- a/src/database/migrations/027_add_reddit_ticker_sentiment_unique_constraint.sql
+++ b/src/database/migrations/027_add_reddit_ticker_sentiment_unique_constraint.sql
@@ -1,0 +1,4 @@
+-- Add unique constraint to reddit_ticker_sentiment for ON CONFLICT deduplication
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_reddit_ticker_sentiment_unique
+    ON reddit_ticker_sentiment(symbol, subreddit, window_start);


### PR DESCRIPTION
## Motivation

Two small fixes:
- `game_plan_history[-1]` was used after fetching with `limit=1`; `[0]` is correct and explicit
- Missing unique constraint on `reddit_ticker_sentiment` prevented `ON CONFLICT` deduplication

## Implementation information

- `trading.py`: `[-1]` → `[0]` for single-element list from `get_game_plan_history(limit=1)`
- Migration `027`: adds `UNIQUE INDEX` on `(symbol, subreddit, window_start)` for upsert support

## Supporting documentation

> Changelog: fix(api): use index 0 for game plan history