### PR TITLE
feat(daemon): add options flow watcher

### DIFF
--- a/docs/daemon.yaml.example
+++ b/docs/daemon.yaml.example
@@ -706,6 +706,19 @@ daemon:
     # FRED API cache TTL (10-120 minutes)
     cache_ttl_minutes: 30
 
+  options_flow_watcher:
+    # Options flow analysis (institutional positioning via yfinance)
+    # Detects unusual volume, high-premium contracts, put/call ratio
+    # Injects per-symbol flow signal into supervisor planning context
+    # No API key needed (uses yfinance free data)
+    enabled: false
+    # How often to poll options chains (5-60 minutes)
+    poll_interval_minutes: 15
+    # Volume spike detection threshold (1.5-5.0x average)
+    volume_spike_threshold: 2.0
+    # Minimum premium to flag as block trade ($10k-$1M)
+    block_trade_threshold: 100000
+
   event_integration:
     # Event watcher → discovery integration (Phase 3)
     # Routes event watchers through discovery engine instead of direct analysis

--- a/src/agents/supervisor/models.py
+++ b/src/agents/supervisor/models.py
@@ -71,6 +71,7 @@ class PlanningContext(BaseModel):
     market_data_rows: int = 0
     is_high_volatility: bool = False
     economic_risk: str | None = None  # e.g. "HIGH: Fed in 1.5h - avoid new positions"
+    options_flow: str | None = None  # e.g. "BULLISH | P/C=0.65 | Vol 2.3x | Score=0.72"
 
 
 class SynthesisContext(BaseModel):

--- a/src/daemon/analysis_orchestrator.py
+++ b/src/daemon/analysis_orchestrator.py
@@ -123,6 +123,7 @@ class AnalysisOrchestrator:
                 self._signal_outcome_repo = components.container.signal_outcome_repository()
 
         self._economic_watcher = components.economic_calendar_watcher
+        self._options_flow_watcher = components.options_flow_watcher
 
         self._notification_helper = DaemonNotificationHelper()
         logger.info("AnalysisOrchestrator initialized")
@@ -461,6 +462,17 @@ class AnalysisOrchestrator:
                     f"Events: {', '.join(e.event for e in signal.upcoming_events[:3])}"
                 )
 
+        options_flow_ctx = None
+        if self._options_flow_watcher:
+            sig = self._options_flow_watcher.get_signal(symbol)
+            if sig and sig.significance_score >= 0.3:
+                options_flow_ctx = (
+                    f"OPTIONS FLOW: {sig.net_premium_direction} | "
+                    f"P/C={sig.put_call_ratio:.2f} | Vol {sig.volume_vs_avg:.1f}x | "
+                    f"Score={sig.significance_score:.2f} | "
+                    f"Blocks={len(sig.block_trades)} | {sig.reason}"
+                )
+
         return WorkflowExtraContext(
             sector_rotation_context=sector_ctx,
             earnings_context=earnings_ctx,
@@ -469,6 +481,7 @@ class AnalysisOrchestrator:
             position_context=position_context,
             degradation_context=degradation_context,
             economic_calendar_context=economic_ctx,
+            options_flow_context=options_flow_ctx,
         )
 
     async def _run_workflow_analysis(

--- a/src/daemon/config/__init__.py
+++ b/src/daemon/config/__init__.py
@@ -17,6 +17,7 @@ from src.daemon.config.analysis import (
     NewsSourcesConfig,
     NewsTrendingWatcherConfig,
     NewsWatcherConfig,
+    OptionsFlowWatcherConfig,
     SocialWatcherConfig,
     TrumpWatcherConfig,
 )
@@ -97,6 +98,7 @@ __all__ = [
     "NotificationTrigger",
     "NotificationsConfig",
     "OptimizationConfig",
+    "OptionsFlowWatcherConfig",
     "PaperTradingConfig",
     "PeerAnalysisConfig",
     "PortfolioRebalancingConfig",
@@ -165,6 +167,7 @@ class DaemonConfig(BaseModel):
     economic_calendar_watcher: EconomicCalendarWatcherConfig = Field(
         default_factory=EconomicCalendarWatcherConfig
     )
+    options_flow_watcher: OptionsFlowWatcherConfig = Field(default_factory=OptionsFlowWatcherConfig)
     event_integration: EventWatcherIntegrationConfig = Field(default_factory=EventWatcherIntegrationConfig)
     api: ApiConfig = Field(default_factory=ApiConfig)
     llm: LLMConfig = Field(default_factory=LLMConfig)
@@ -224,6 +227,7 @@ class DaemonConfig(BaseModel):
             "anomaly_watcher": daemon_data.pop("anomaly_watcher", {}) or {},
             "news_trending_watcher": daemon_data.pop("news_trending_watcher", {}) or {},
             "economic_calendar_watcher": daemon_data.pop("economic_calendar_watcher", {}) or {},
+            "options_flow_watcher": daemon_data.pop("options_flow_watcher", {}) or {},
             "event_integration": daemon_data.pop("event_integration", {}) or {},
             "api": daemon_data.pop("api", {}) or {},
             "llm": daemon_data.pop("llm", {}) or {},
@@ -304,6 +308,7 @@ class DaemonConfig(BaseModel):
             anomaly_watcher=AnomalyWatcherConfig(**sections["anomaly_watcher"]),
             news_trending_watcher=NewsTrendingWatcherConfig(**sections["news_trending_watcher"]),
             economic_calendar_watcher=EconomicCalendarWatcherConfig(**sections["economic_calendar_watcher"]),
+            options_flow_watcher=OptionsFlowWatcherConfig(**sections["options_flow_watcher"]),
             event_integration=EventWatcherIntegrationConfig(**sections["event_integration"]),
             api=ApiConfig(
                 **sections["api"], circuit_breaker=CircuitBreakerConfig(**sections["circuit_breaker"])

--- a/src/daemon/config/analysis.py
+++ b/src/daemon/config/analysis.py
@@ -126,3 +126,12 @@ class EconomicCalendarWatcherConfig(BaseModel):
     lookahead_hours: int = Field(default=24, ge=12, le=48)
     high_impact_avoid_hours: float = Field(default=2.0, ge=1.0, le=4.0)
     cache_ttl_minutes: int = Field(default=30, ge=10, le=120)
+
+
+class OptionsFlowWatcherConfig(BaseModel):
+    """Configuration for options flow watcher."""
+
+    enabled: bool = False
+    poll_interval_minutes: int = Field(default=15, ge=5, le=60)
+    volume_spike_threshold: float = Field(default=2.0, ge=1.5, le=5.0)
+    block_trade_threshold: float = Field(default=100_000, ge=10_000, le=1_000_000)

--- a/src/daemon/events.py
+++ b/src/daemon/events.py
@@ -357,6 +357,52 @@ class EconomicEventSignal(BaseModel):
         )
 
 
+class OptionsFlowDirection(StrEnum):
+    """Net premium direction from options flow."""
+
+    BULLISH = "BULLISH"
+    BEARISH = "BEARISH"
+    NEUTRAL = "NEUTRAL"
+
+
+class BlockTrade(BaseModel):
+    """High-premium options contract detection."""
+
+    strike: float
+    expiry: str
+    premium: float
+    volume: int
+    option_type: str = Field(description="call or put")
+    is_itm: bool
+
+    def __repr__(self) -> str:
+        """String representation."""
+        return f"BlockTrade({self.option_type} {self.strike} ${self.premium:,.0f})"
+
+
+class OptionsFlowSignal(BaseModel):
+    """Options flow assessment for a single symbol."""
+
+    symbol: str
+    put_call_ratio: float
+    volume_vs_avg: float
+    has_unusual_activity: bool
+    block_trades: list[BlockTrade] = Field(default_factory=list)
+    net_premium_direction: OptionsFlowDirection
+    significance_score: float = Field(ge=0.0, le=1.0)
+    reason: str
+    computed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    def __repr__(self) -> str:
+        """String representation."""
+        return (
+            f"OptionsFlowSignal({self.symbol} "
+            f"P/C={self.put_call_ratio:.2f} "
+            f"dir={self.net_premium_direction} "
+            f"score={self.significance_score:.2f})"
+        )
+
+
 class TriageResult(BaseModel):
     """LLM triage result for an event."""
 

--- a/src/daemon/factory.py
+++ b/src/daemon/factory.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
     from src.daemon.watchers.economic_calendar_watcher import EconomicCalendarWatcher
     from src.daemon.watchers.news_trending_watcher import NewsTrendingWatcher
     from src.daemon.watchers.news_watcher import NewsWatcher
+    from src.daemon.watchers.options_flow_watcher import OptionsFlowWatcher
     from src.daemon.watchers.social_watcher import SocialWatcher
     from src.daemon.watchers.trump_watcher import TrumpWatcher
     from src.di.container import AppContainer
@@ -85,6 +86,7 @@ class DaemonComponents:
     trump_watcher: TrumpWatcher | None = None
     news_trending_watcher: NewsTrendingWatcher | None = None
     economic_calendar_watcher: EconomicCalendarWatcher | None = None
+    options_flow_watcher: OptionsFlowWatcher | None = None
 
 
 class DaemonFactory:
@@ -202,6 +204,7 @@ class DaemonFactory:
             trump_watcher,
             news_trending_watcher,
             economic_calendar_watcher,
+            options_flow_watcher,
         ) = self._create_event_watchers(historical_cache, state)
 
         # Phase 12.5: Supervisor (lazy-initialized via container)
@@ -241,6 +244,7 @@ class DaemonFactory:
             trump_watcher=trump_watcher,
             news_trending_watcher=news_trending_watcher,
             economic_calendar_watcher=economic_calendar_watcher,
+            options_flow_watcher=options_flow_watcher,
         )
 
         # Phase 14: Create task runner (needs components reference)
@@ -448,6 +452,7 @@ class DaemonFactory:
         TrumpWatcher | None,
         NewsTrendingWatcher | None,
         EconomicCalendarWatcher | None,
+        OptionsFlowWatcher | None,
     ]:
         """Create event watchers based on config.
 
@@ -457,13 +462,14 @@ class DaemonFactory:
 
         Returns:
             Tuple of (news_watcher, social_watcher, trump_watcher, news_trending_watcher,
-                      economic_calendar_watcher)
+                      economic_calendar_watcher, options_flow_watcher)
         """
         news_watcher = None
         social_watcher = None
         trump_watcher = None
         news_trending_watcher = None
         economic_calendar_watcher = None
+        options_flow_watcher = None
 
         any_enabled = (
             self.config.news_watcher.enabled
@@ -471,6 +477,7 @@ class DaemonFactory:
             or self.config.trump_watcher.enabled
             or self.config.news_trending_watcher.enabled
             or self.config.economic_calendar_watcher.enabled
+            or self.config.options_flow_watcher.enabled
         )
         if not any_enabled:
             return (
@@ -479,6 +486,7 @@ class DaemonFactory:
                 trump_watcher,
                 news_trending_watcher,
                 economic_calendar_watcher,
+                options_flow_watcher,
             )
 
         # Call provider functions directly to pass container (providers.Self() doesn't work reliably)
@@ -520,6 +528,11 @@ class DaemonFactory:
                 self.config,
             )
 
+        if self.config.options_flow_watcher.enabled:
+            options_flow_watcher = watcher_providers.create_options_flow_watcher(
+                self.config,
+            )
+
         logger.info("Event watchers initialized")
         return (
             news_watcher,
@@ -527,6 +540,7 @@ class DaemonFactory:
             trump_watcher,
             news_trending_watcher,
             economic_calendar_watcher,
+            options_flow_watcher,
         )
 
     def init_workflow(self, components: DaemonComponents) -> TradingWorkflow:

--- a/src/daemon/lifecycle.py
+++ b/src/daemon/lifecycle.py
@@ -274,6 +274,9 @@ class DaemonLifecycle:
         if self.components.economic_calendar_watcher:
             watchers.append(("EconomicCalendarWatcher", self.components.economic_calendar_watcher))
 
+        if self.components.options_flow_watcher:
+            watchers.append(("OptionsFlowWatcher", self.components.options_flow_watcher))
+
         if not watchers:
             return
 
@@ -312,6 +315,8 @@ class DaemonLifecycle:
                 self.components.news_trending_watcher.running = False
             if self.components.economic_calendar_watcher:
                 self.components.economic_calendar_watcher.running = False
+            if self.components.options_flow_watcher:
+                self.components.options_flow_watcher.running = False
 
             # Wait for tasks to complete (up to 5 seconds)
             _done, pending = await asyncio.wait(self._watcher_tasks, timeout=5.0)

--- a/src/daemon/watchers/__init__.py
+++ b/src/daemon/watchers/__init__.py
@@ -3,7 +3,15 @@
 from src.daemon.watchers.anomaly_watcher import AnomalyWatcher
 from src.daemon.watchers.economic_calendar_watcher import EconomicCalendarWatcher
 from src.daemon.watchers.news_watcher import NewsWatcher
+from src.daemon.watchers.options_flow_watcher import OptionsFlowWatcher
 from src.daemon.watchers.social_watcher import SocialWatcher
 from src.daemon.watchers.trump_watcher import TrumpWatcher
 
-__all__ = ["AnomalyWatcher", "EconomicCalendarWatcher", "NewsWatcher", "SocialWatcher", "TrumpWatcher"]
+__all__ = [
+    "AnomalyWatcher",
+    "EconomicCalendarWatcher",
+    "NewsWatcher",
+    "OptionsFlowWatcher",
+    "SocialWatcher",
+    "TrumpWatcher",
+]

--- a/src/daemon/watchers/options_flow_watcher.py
+++ b/src/daemon/watchers/options_flow_watcher.py
@@ -1,0 +1,302 @@
+"""Options flow watcher - monitors institutional positioning via options chains."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from dataclasses import dataclass
+
+from loguru import logger
+
+from src.daemon.events import BlockTrade, OptionsFlowDirection, OptionsFlowSignal
+from src.data.options_flow import OptionContract, OptionsChainSnapshot, OptionsFlowFetcher
+
+
+@dataclass
+class OptionsFlowWatcherConfig:
+    """Configuration for options flow watcher."""
+
+    poll_interval_minutes: int = 15
+    volume_spike_threshold: float = 2.0
+    block_trade_threshold: float = 100_000
+    symbols: list[str] | None = None
+
+
+class OptionsFlowWatcher:
+    """Background service that polls yfinance options chains and computes flow signals."""
+
+    def __init__(
+        self,
+        fetcher: OptionsFlowFetcher,
+        config: OptionsFlowWatcherConfig,
+    ) -> None:
+        """Initialize options flow watcher.
+
+        Args:
+            fetcher: Options chain data fetcher
+            config: Watcher configuration
+        """
+        self._fetcher = fetcher
+        self._config = config
+        self._signals: dict[str, OptionsFlowSignal] = {}
+        self._volume_history: dict[str, list[int]] = defaultdict(list)
+        self.running: bool = False
+
+    def get_signal(self, symbol: str) -> OptionsFlowSignal | None:
+        """Return current flow signal for a symbol (sync, no await).
+
+        Args:
+            symbol: Stock ticker
+
+        Returns:
+            OptionsFlowSignal if available, None otherwise
+        """
+        return self._signals.get(symbol)
+
+    def _detect_block_trades(self, snapshot: OptionsChainSnapshot) -> list[BlockTrade]:
+        """Detect high-premium contracts from options chain.
+
+        Args:
+            snapshot: Options chain snapshot
+
+        Returns:
+            List of detected block trades
+        """
+        blocks: list[BlockTrade] = []
+        threshold = self._config.block_trade_threshold
+
+        for contract in snapshot.calls + snapshot.puts:
+            premium = self._compute_contract_premium(contract)
+            if premium >= threshold:
+                blocks.append(
+                    BlockTrade(
+                        strike=contract.strike,
+                        expiry=str(contract.expiry),
+                        premium=premium,
+                        volume=contract.volume,
+                        option_type=contract.option_type,
+                        is_itm=contract.in_the_money,
+                    )
+                )
+
+        blocks.sort(key=lambda b: b.premium, reverse=True)
+        return blocks
+
+    @staticmethod
+    def _compute_contract_premium(contract: OptionContract) -> float:
+        """Compute premium for a contract.
+
+        Uses midpoint if available, falls back to lastPrice.
+
+        Args:
+            contract: Option contract
+
+        Returns:
+            Estimated premium in dollars
+        """
+        midpoint = (contract.bid + contract.ask) / 2
+        price = midpoint if midpoint > 0 else contract.last_price
+        return contract.volume * price * 100
+
+    def _compute_put_call_ratio(self, snapshot: OptionsChainSnapshot) -> float:
+        """Compute put/call volume ratio.
+
+        Args:
+            snapshot: Options chain snapshot
+
+        Returns:
+            Put/call ratio (>1 = bearish, <1 = bullish)
+        """
+        if snapshot.total_call_volume == 0:
+            return 0.0 if snapshot.total_put_volume == 0 else 10.0
+        return snapshot.total_put_volume / snapshot.total_call_volume
+
+    def _compute_volume_spike(self, symbol: str, total_volume: int) -> float:
+        """Compute volume spike vs rolling 5-session average.
+
+        Args:
+            symbol: Stock ticker
+            total_volume: Current total options volume
+
+        Returns:
+            Volume as multiple of average (1.0 = normal)
+        """
+        history = self._volume_history[symbol]
+        history.append(total_volume)
+
+        # Keep rolling window of 6 (current + 5 history)
+        if len(history) > 6:
+            self._volume_history[symbol] = history[-6:]
+            history = self._volume_history[symbol]
+
+        if len(history) < 2:
+            return 1.0
+
+        # Average of previous sessions (exclude current)
+        prev_avg = sum(history[:-1]) / len(history[:-1])
+        if prev_avg == 0:
+            return 1.0
+        return total_volume / prev_avg
+
+    def _determine_direction(self, snapshot: OptionsChainSnapshot) -> OptionsFlowDirection:
+        """Determine net premium direction from call vs put premium.
+
+        Args:
+            snapshot: Options chain snapshot
+
+        Returns:
+            OptionsFlowDirection
+        """
+        call_premium = sum(self._compute_contract_premium(c) for c in snapshot.calls)
+        put_premium = sum(self._compute_contract_premium(c) for c in snapshot.puts)
+
+        total = call_premium + put_premium
+        if total == 0:
+            return OptionsFlowDirection.NEUTRAL
+
+        ratio = call_premium / total
+        if ratio > 0.6:
+            return OptionsFlowDirection.BULLISH
+        if ratio < 0.4:
+            return OptionsFlowDirection.BEARISH
+        return OptionsFlowDirection.NEUTRAL
+
+    def _compute_significance(
+        self,
+        spike: float,
+        blocks: list[BlockTrade],
+        pcr: float,
+    ) -> float:
+        """Compute composite significance score (0.0-1.0).
+
+        Weights: 40% volume spike, 30% block trades, 30% PCR extremity.
+
+        Args:
+            spike: Volume spike multiple
+            blocks: Detected block trades
+            pcr: Put/call ratio
+
+        Returns:
+            Significance score between 0.0 and 1.0
+        """
+        # Volume spike component (0-1): spike of 2x = 0.5, 4x+ = 1.0
+        spike_score = min(1.0, max(0.0, (spike - 1.0) / 3.0))
+
+        # Block trades component (0-1): 1 block = 0.33, 3+ blocks = 1.0
+        block_score = min(1.0, len(blocks) / 3.0)
+
+        # PCR extremity component (0-1): distance from neutral (1.0)
+        pcr_deviation = abs(pcr - 1.0)
+        pcr_score = min(1.0, pcr_deviation / 1.5)
+
+        return 0.4 * spike_score + 0.3 * block_score + 0.3 * pcr_score
+
+    def _build_reason(
+        self,
+        pcr: float,
+        spike: float,
+        blocks: list[BlockTrade],
+        direction: OptionsFlowDirection,
+    ) -> str:
+        """Build human-readable reason string.
+
+        Args:
+            pcr: Put/call ratio
+            spike: Volume spike multiple
+            blocks: Detected block trades
+            direction: Net premium direction
+
+        Returns:
+            Reason string
+        """
+        parts = []
+        if spike >= self._config.volume_spike_threshold:
+            parts.append(f"Vol {spike:.1f}x avg")
+        if blocks:
+            total_premium = sum(b.premium for b in blocks)
+            parts.append(f"{len(blocks)} large trades (${total_premium:,.0f})")
+        if pcr > 1.5:
+            parts.append(f"Elevated puts P/C={pcr:.2f}")
+        elif pcr < 0.5:
+            parts.append(f"Heavy calls P/C={pcr:.2f}")
+
+        if not parts:
+            return f"{direction} flow, normal activity"
+        return f"{direction} flow: {'; '.join(parts)}"
+
+    async def _fetch_and_assess_symbol(self, symbol: str) -> None:
+        """Fetch and assess options flow for a single symbol.
+
+        Args:
+            symbol: Stock ticker
+        """
+        snapshot = await asyncio.to_thread(self._fetcher.fetch_options_chain, symbol)
+
+        if snapshot.is_empty:
+            return
+
+        pcr = self._compute_put_call_ratio(snapshot)
+        spike = self._compute_volume_spike(symbol, snapshot.total_volume)
+        blocks = self._detect_block_trades(snapshot)
+        direction = self._determine_direction(snapshot)
+        significance = self._compute_significance(spike, blocks, pcr)
+        has_unusual = spike >= self._config.volume_spike_threshold or len(blocks) > 0
+        reason = self._build_reason(pcr, spike, blocks, direction)
+
+        signal = OptionsFlowSignal(
+            symbol=symbol,
+            put_call_ratio=pcr,
+            volume_vs_avg=spike,
+            has_unusual_activity=has_unusual,
+            block_trades=blocks,
+            net_premium_direction=direction,
+            significance_score=significance,
+            reason=reason,
+        )
+        self._signals[symbol] = signal
+
+    async def _fetch_and_assess_all(self) -> None:
+        """Fetch and assess all configured symbols with concurrency limit."""
+        symbols = self._config.symbols or []
+        if not symbols:
+            return
+
+        sem = asyncio.Semaphore(3)
+
+        async def _limited(sym: str) -> None:
+            async with sem:
+                try:
+                    await self._fetch_and_assess_symbol(sym)
+                except Exception as e:
+                    logger.opt(exception=True).warning(f"Options flow assessment failed for {sym}: {e}")
+
+        await asyncio.gather(*[_limited(s) for s in symbols])
+
+        active = [s for s in self._signals.values() if s.has_unusual_activity]
+        logger.info(f"Options flow assessed: {len(symbols)} symbols, {len(active)} with unusual activity")
+
+    async def run(self) -> None:
+        """Poll loop - runs until self.running is set to False."""
+        self.running = True
+        logger.info(
+            f"OptionsFlowWatcher started "
+            f"(poll={self._config.poll_interval_minutes}m, "
+            f"symbols={len(self._config.symbols or [])})"
+        )
+
+        while self.running:
+            try:
+                await self._fetch_and_assess_all()
+            except Exception as e:
+                logger.opt(exception=True).error(f"OptionsFlowWatcher cycle failed: {e}")
+
+            remaining: float = self._config.poll_interval_minutes * 60
+            while remaining > 0 and self.running:
+                await asyncio.sleep(min(1.0, remaining))
+                remaining -= 1.0
+
+        logger.info("OptionsFlowWatcher stopped")
+
+    def __repr__(self) -> str:
+        """String representation."""
+        return f"OptionsFlowWatcher(running={self.running}, signals={len(self._signals)})"

--- a/src/data/options_flow.py
+++ b/src/data/options_flow.py
@@ -1,0 +1,179 @@
+"""Options flow data fetcher using yfinance."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+import pandas as pd
+from loguru import logger
+from pydantic import BaseModel, Field
+
+
+class OptionContract(BaseModel):
+    """Single options contract data."""
+
+    strike: float
+    last_price: float
+    bid: float
+    ask: float
+    volume: int
+    open_interest: int
+    implied_volatility: float
+    in_the_money: bool
+    expiry: date
+    option_type: str = Field(description="call or put")
+
+    def __repr__(self) -> str:
+        """String representation."""
+        return f"OptionContract({self.option_type} {self.strike} exp={self.expiry} vol={self.volume})"
+
+
+class OptionsChainSnapshot(BaseModel):
+    """Aggregated options chain snapshot for a symbol."""
+
+    symbol: str
+    fetched_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    total_call_volume: int = 0
+    total_put_volume: int = 0
+    total_call_oi: int = 0
+    total_put_oi: int = 0
+    near_term_expiry: date | None = None
+    calls: list[OptionContract] = Field(default_factory=list)
+    puts: list[OptionContract] = Field(default_factory=list)
+
+    @property
+    def total_volume(self) -> int:
+        """Total options volume (calls + puts)."""
+        return self.total_call_volume + self.total_put_volume
+
+    @property
+    def is_empty(self) -> bool:
+        """Check if snapshot has no data."""
+        return self.total_call_volume == 0 and self.total_put_volume == 0
+
+    def __repr__(self) -> str:
+        """String representation."""
+        return (
+            f"OptionsChainSnapshot({self.symbol} calls={self.total_call_volume} puts={self.total_put_volume})"
+        )
+
+
+class OptionsFlowFetcher:
+    """Fetch options chain data from yfinance."""
+
+    def __init__(self, max_expirations: int = 2) -> None:
+        """Initialize options flow fetcher.
+
+        Args:
+            max_expirations: Maximum number of nearest expirations to fetch
+        """
+        self._max_expirations = max_expirations
+
+    def fetch_options_chain(self, symbol: str) -> OptionsChainSnapshot:
+        """Fetch options chain for symbol (sync, call via to_thread).
+
+        Gets nearest non-expired expirations and aggregates volume/OI.
+
+        Args:
+            symbol: Stock ticker
+
+        Returns:
+            OptionsChainSnapshot with aggregated data
+        """
+        import yfinance as yf
+
+        try:
+            ticker = yf.Ticker(symbol)
+            expirations = ticker.options
+
+            if not expirations:
+                logger.warning(f"No options expirations for {symbol}")
+                return OptionsChainSnapshot(symbol=symbol)
+
+            today = datetime.now(UTC).date()
+            valid_expiries = [exp for exp in expirations if date.fromisoformat(exp) > today]
+
+            if not valid_expiries:
+                logger.warning(f"No future expirations for {symbol}")
+                return OptionsChainSnapshot(symbol=symbol)
+
+            selected = valid_expiries[: self._max_expirations]
+
+            all_calls: list[OptionContract] = []
+            all_puts: list[OptionContract] = []
+            total_call_vol, total_put_vol = 0, 0
+            total_call_oi, total_put_oi = 0, 0
+
+            for exp_str in selected:
+                exp_date = date.fromisoformat(exp_str)
+                chain = ticker.option_chain(exp_str)
+
+                calls_df: pd.DataFrame = chain[0].fillna(0)
+                puts_df: pd.DataFrame = chain[1].fillna(0)
+
+                for _, row in calls_df.iterrows():
+                    vol = int(row.get("volume", 0))
+                    oi = int(row.get("openInterest", 0))
+                    total_call_vol += vol
+                    total_call_oi += oi
+                    all_calls.append(
+                        OptionContract(
+                            strike=float(row["strike"]),
+                            last_price=float(row.get("lastPrice", 0)),
+                            bid=float(row.get("bid", 0)),
+                            ask=float(row.get("ask", 0)),
+                            volume=vol,
+                            open_interest=oi,
+                            implied_volatility=float(row.get("impliedVolatility", 0)),
+                            in_the_money=bool(row.get("inTheMoney", False)),
+                            expiry=exp_date,
+                            option_type="call",
+                        )
+                    )
+
+                for _, row in puts_df.iterrows():
+                    vol = int(row.get("volume", 0))
+                    oi = int(row.get("openInterest", 0))
+                    total_put_vol += vol
+                    total_put_oi += oi
+                    all_puts.append(
+                        OptionContract(
+                            strike=float(row["strike"]),
+                            last_price=float(row.get("lastPrice", 0)),
+                            bid=float(row.get("bid", 0)),
+                            ask=float(row.get("ask", 0)),
+                            volume=vol,
+                            open_interest=oi,
+                            implied_volatility=float(row.get("impliedVolatility", 0)),
+                            in_the_money=bool(row.get("inTheMoney", False)),
+                            expiry=exp_date,
+                            option_type="put",
+                        )
+                    )
+
+            near_term = date.fromisoformat(selected[0])
+
+            logger.debug(
+                f"Options chain for {symbol}: "
+                f"calls_vol={total_call_vol} puts_vol={total_put_vol} "
+                f"expirations={len(selected)}"
+            )
+
+            return OptionsChainSnapshot(
+                symbol=symbol,
+                total_call_volume=total_call_vol,
+                total_put_volume=total_put_vol,
+                total_call_oi=total_call_oi,
+                total_put_oi=total_put_oi,
+                near_term_expiry=near_term,
+                calls=all_calls,
+                puts=all_puts,
+            )
+
+        except Exception as e:
+            logger.opt(exception=True).warning(f"Failed to fetch options for {symbol}: {e}")
+            return OptionsChainSnapshot(symbol=symbol)
+
+    def __repr__(self) -> str:
+        """String representation."""
+        return f"OptionsFlowFetcher(max_expirations={self._max_expirations})"

--- a/src/di/providers/watchers.py
+++ b/src/di/providers/watchers.py
@@ -17,6 +17,7 @@ from src.data.base_news_fetcher import BaseNewsFetcher
 if TYPE_CHECKING:
     from src.daemon.state.facade import DaemonState
     from src.daemon.watchers.economic_calendar_watcher import EconomicCalendarWatcher
+    from src.daemon.watchers.options_flow_watcher import OptionsFlowWatcher
     from src.di.container import AppContainer
 
 
@@ -243,4 +244,38 @@ def create_news_trending_watcher(
     )
 
     logger.info("News trending watcher created (discovery mode)")
+    return watcher
+
+
+def create_options_flow_watcher(
+    daemon_config: DaemonConfig,
+) -> OptionsFlowWatcher | None:
+    """Create options flow watcher if enabled.
+
+    Args:
+        daemon_config: Daemon configuration
+
+    Returns:
+        OptionsFlowWatcher instance if enabled, None otherwise
+    """
+    from src.daemon.watchers.options_flow_watcher import (
+        OptionsFlowWatcher,
+        OptionsFlowWatcherConfig,
+    )
+    from src.data.options_flow import OptionsFlowFetcher
+
+    config = daemon_config.options_flow_watcher
+    if not config.enabled:
+        logger.debug("OptionsFlowWatcher disabled in config")
+        return None
+
+    fetcher = OptionsFlowFetcher()
+    watcher_config = OptionsFlowWatcherConfig(
+        poll_interval_minutes=config.poll_interval_minutes,
+        volume_spike_threshold=config.volume_spike_threshold,
+        block_trade_threshold=config.block_trade_threshold,
+        symbols=list(daemon_config.watchlist),
+    )
+    watcher = OptionsFlowWatcher(fetcher=fetcher, config=watcher_config)
+    logger.info("OptionsFlowWatcher created")
     return watcher

--- a/src/workflows/stages/instrumented_analysis.py
+++ b/src/workflows/stages/instrumented_analysis.py
@@ -377,6 +377,7 @@ async def _run_analyses_with_validation(
         market_data_rows=market_data_rows,
         is_high_volatility=is_high_volatility,
         economic_risk=ctx.extra_context.economic_calendar_context if ctx.extra_context else None,
+        options_flow=ctx.extra_context.options_flow_context if ctx.extra_context else None,
     )
 
     planning_fallback_used = False

--- a/src/workflows/types.py
+++ b/src/workflows/types.py
@@ -35,6 +35,7 @@ class WorkflowExtraContext(BaseModel):
     game_plan_context: str | None = None
     position_context: dict[str, object] | None = None
     economic_calendar_context: str | None = None
+    options_flow_context: str | None = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 

--- a/tests/integration/test_daemon_with_watchers.py
+++ b/tests/integration/test_daemon_with_watchers.py
@@ -45,6 +45,7 @@ def minimal_daemon_components(mock_news_watcher):
     components.trump_watcher = None
     components.news_trending_watcher = None
     components.economic_calendar_watcher = None
+    components.options_flow_watcher = None
     components.position_manager = None
     components.broker_manager = None
     components.broker = None
@@ -177,6 +178,7 @@ async def test_multiple_watchers_run_independently():
     components.trump_watcher = None
     components.news_trending_watcher = None
     components.economic_calendar_watcher = None
+    components.options_flow_watcher = None
     components.position_manager = None
     components.broker_manager = None
     components.broker = None
@@ -235,6 +237,7 @@ async def test_shutdown_waits_then_cancels():
     components.trump_watcher = None
     components.news_trending_watcher = None
     components.economic_calendar_watcher = None
+    components.options_flow_watcher = None
     components.position_manager = None
     components.broker_manager = None
     components.broker = None

--- a/tests/test_daemon/test_options_flow_watcher.py
+++ b/tests/test_daemon/test_options_flow_watcher.py
@@ -1,0 +1,321 @@
+"""Unit tests for OptionsFlowWatcher."""
+
+import asyncio
+from datetime import date
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.daemon.events import OptionsFlowDirection
+from src.daemon.watchers.options_flow_watcher import (
+    OptionsFlowWatcher,
+    OptionsFlowWatcherConfig,
+)
+from src.data.options_flow import OptionContract, OptionsChainSnapshot, OptionsFlowFetcher
+
+
+def _contract(
+    strike: float = 180.0,
+    volume: int = 100,
+    last_price: float = 5.0,
+    bid: float = 4.8,
+    ask: float = 5.2,
+    option_type: str = "call",
+    in_the_money: bool = False,
+) -> OptionContract:
+    """Helper to create OptionContract."""
+    return OptionContract(
+        strike=strike,
+        last_price=last_price,
+        bid=bid,
+        ask=ask,
+        volume=volume,
+        open_interest=volume * 10,
+        implied_volatility=0.3,
+        in_the_money=in_the_money,
+        expiry=date(2026, 3, 21),
+        option_type=option_type,
+    )
+
+
+def _snapshot(
+    symbol: str = "AAPL",
+    calls: list[OptionContract] | None = None,
+    puts: list[OptionContract] | None = None,
+) -> OptionsChainSnapshot:
+    """Helper to create OptionsChainSnapshot."""
+    c = calls or []
+    p = puts or []
+    return OptionsChainSnapshot(
+        symbol=symbol,
+        total_call_volume=sum(x.volume for x in c),
+        total_put_volume=sum(x.volume for x in p),
+        total_call_oi=sum(x.open_interest for x in c),
+        total_put_oi=sum(x.open_interest for x in p),
+        near_term_expiry=date(2026, 3, 21),
+        calls=c,
+        puts=p,
+    )
+
+
+@pytest.fixture
+def mock_fetcher() -> MagicMock:
+    """Mock OptionsFlowFetcher."""
+    return MagicMock(spec=OptionsFlowFetcher)
+
+
+@pytest.fixture
+def config() -> OptionsFlowWatcherConfig:
+    """Default watcher config."""
+    return OptionsFlowWatcherConfig(
+        poll_interval_minutes=15,
+        volume_spike_threshold=2.0,
+        block_trade_threshold=100_000,
+        symbols=["AAPL", "TSLA"],
+    )
+
+
+@pytest.fixture
+def watcher(mock_fetcher: MagicMock, config: OptionsFlowWatcherConfig) -> OptionsFlowWatcher:
+    """Create OptionsFlowWatcher with mocked fetcher."""
+    return OptionsFlowWatcher(fetcher=mock_fetcher, config=config)
+
+
+@pytest.mark.unit
+def test_init(watcher: OptionsFlowWatcher) -> None:
+    """get_signal returns None on init."""
+    assert watcher.get_signal("AAPL") is None
+    assert watcher.running is False
+
+
+@pytest.mark.unit
+def test_put_call_ratio_balanced(watcher: OptionsFlowWatcher) -> None:
+    """P/C ratio with equal volume = 1.0."""
+    snap = _snapshot(
+        calls=[_contract(volume=100)],
+        puts=[_contract(volume=100, option_type="put")],
+    )
+    assert watcher._compute_put_call_ratio(snap) == 1.0
+
+
+@pytest.mark.unit
+def test_put_call_ratio_bullish(watcher: OptionsFlowWatcher) -> None:
+    """P/C ratio < 1 when call volume dominates."""
+    snap = _snapshot(
+        calls=[_contract(volume=200)],
+        puts=[_contract(volume=50, option_type="put")],
+    )
+    assert watcher._compute_put_call_ratio(snap) == 0.25
+
+
+@pytest.mark.unit
+def test_put_call_ratio_zero_calls(watcher: OptionsFlowWatcher) -> None:
+    """P/C ratio capped at 10.0 when no calls."""
+    snap = _snapshot(
+        calls=[],
+        puts=[_contract(volume=100, option_type="put")],
+    )
+    assert watcher._compute_put_call_ratio(snap) == 10.0
+
+
+@pytest.mark.unit
+def test_put_call_ratio_zero_both(watcher: OptionsFlowWatcher) -> None:
+    """P/C ratio 0.0 when no volume at all."""
+    snap = _snapshot()
+    assert watcher._compute_put_call_ratio(snap) == 0.0
+
+
+@pytest.mark.unit
+def test_block_trade_detection(watcher: OptionsFlowWatcher) -> None:
+    """Detect contracts with premium > threshold."""
+    # vol=200, midpoint=5.0, premium = 200*5*100 = 100,000 → at threshold
+    big = _contract(volume=200, bid=4.8, ask=5.2)
+    # vol=10, premium = 10*5*100 = 5,000 → below threshold
+    small = _contract(strike=190, volume=10, bid=0.9, ask=1.1)
+
+    snap = _snapshot(calls=[big, small])
+    blocks = watcher._detect_block_trades(snap)
+
+    assert len(blocks) == 1
+    assert blocks[0].strike == 180.0
+    assert blocks[0].premium >= 100_000
+
+
+@pytest.mark.unit
+def test_block_trade_lastprice_fallback(watcher: OptionsFlowWatcher) -> None:
+    """Use lastPrice when bid/ask are 0 (after hours)."""
+    # bid=0, ask=0 → midpoint=0, fallback to lastPrice=5.0
+    # premium = 300 * 5.0 * 100 = 150,000
+    contract = _contract(volume=300, bid=0, ask=0, last_price=5.0)
+    snap = _snapshot(calls=[contract])
+    blocks = watcher._detect_block_trades(snap)
+
+    assert len(blocks) == 1
+    assert blocks[0].premium == 150_000
+
+
+@pytest.mark.unit
+def test_volume_spike_first_observation(watcher: OptionsFlowWatcher) -> None:
+    """First observation returns 1.0 (no history)."""
+    spike = watcher._compute_volume_spike("AAPL", 1000)
+    assert spike == 1.0
+
+
+@pytest.mark.unit
+def test_volume_spike_calculation(watcher: OptionsFlowWatcher) -> None:
+    """Volume spike calculated vs rolling average."""
+    # Build history: 3 sessions at 1000
+    for _ in range(3):
+        watcher._compute_volume_spike("AAPL", 1000)
+
+    # Now 3000 volume → 3x spike
+    spike = watcher._compute_volume_spike("AAPL", 3000)
+    assert spike == pytest.approx(3.0, rel=0.1)
+
+
+@pytest.mark.unit
+def test_direction_bullish(watcher: OptionsFlowWatcher) -> None:
+    """Direction BULLISH when call premium dominates."""
+    snap = _snapshot(
+        calls=[_contract(volume=500, last_price=5.0, bid=4.8, ask=5.2)],
+        puts=[_contract(volume=50, last_price=2.0, bid=1.8, ask=2.2, option_type="put")],
+    )
+    direction = watcher._determine_direction(snap)
+    assert direction == OptionsFlowDirection.BULLISH
+
+
+@pytest.mark.unit
+def test_direction_bearish(watcher: OptionsFlowWatcher) -> None:
+    """Direction BEARISH when put premium dominates."""
+    snap = _snapshot(
+        calls=[_contract(volume=50, last_price=1.0, bid=0.8, ask=1.2)],
+        puts=[_contract(volume=500, last_price=5.0, bid=4.8, ask=5.2, option_type="put")],
+    )
+    direction = watcher._determine_direction(snap)
+    assert direction == OptionsFlowDirection.BEARISH
+
+
+@pytest.mark.unit
+def test_direction_neutral(watcher: OptionsFlowWatcher) -> None:
+    """Direction NEUTRAL when premiums are balanced."""
+    snap = _snapshot(
+        calls=[_contract(volume=100, last_price=5.0, bid=4.8, ask=5.2)],
+        puts=[_contract(volume=100, last_price=5.0, bid=4.8, ask=5.2, option_type="put")],
+    )
+    direction = watcher._determine_direction(snap)
+    assert direction == OptionsFlowDirection.NEUTRAL
+
+
+@pytest.mark.unit
+def test_direction_empty(watcher: OptionsFlowWatcher) -> None:
+    """Direction NEUTRAL when no data."""
+    snap = _snapshot()
+    direction = watcher._determine_direction(snap)
+    assert direction == OptionsFlowDirection.NEUTRAL
+
+
+@pytest.mark.unit
+def test_significance_zero(watcher: OptionsFlowWatcher) -> None:
+    """Significance 0.0 when no unusual activity."""
+    score = watcher._compute_significance(spike=1.0, blocks=[], pcr=1.0)
+    assert score == 0.0
+
+
+@pytest.mark.unit
+def test_significance_high(watcher: OptionsFlowWatcher) -> None:
+    """Significance near 1.0 with extreme values."""
+    from src.daemon.events import BlockTrade
+
+    blocks = [
+        BlockTrade(
+            strike=180, expiry="2026-03-21", premium=200_000, volume=400, option_type="call", is_itm=True
+        ),
+        BlockTrade(
+            strike=170, expiry="2026-03-21", premium=150_000, volume=300, option_type="call", is_itm=True
+        ),
+        BlockTrade(
+            strike=190, expiry="2026-03-21", premium=120_000, volume=250, option_type="put", is_itm=False
+        ),
+    ]
+    score = watcher._compute_significance(spike=4.0, blocks=blocks, pcr=2.5)
+    assert score > 0.8
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_and_assess_symbol(watcher: OptionsFlowWatcher, mock_fetcher: MagicMock) -> None:
+    """_fetch_and_assess_symbol updates signal for symbol."""
+    snap = _snapshot(
+        symbol="AAPL",
+        calls=[_contract(volume=500)],
+        puts=[_contract(volume=200, option_type="put")],
+    )
+    mock_fetcher.fetch_options_chain.return_value = snap
+
+    await watcher._fetch_and_assess_symbol("AAPL")
+
+    signal = watcher.get_signal("AAPL")
+    assert signal is not None
+    assert signal.symbol == "AAPL"
+    assert signal.put_call_ratio == pytest.approx(0.4)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_and_assess_empty_snapshot(watcher: OptionsFlowWatcher, mock_fetcher: MagicMock) -> None:
+    """Empty snapshot doesn't create a signal."""
+    mock_fetcher.fetch_options_chain.return_value = OptionsChainSnapshot(symbol="AAPL")
+
+    await watcher._fetch_and_assess_symbol("AAPL")
+
+    assert watcher.get_signal("AAPL") is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_and_assess_all(watcher: OptionsFlowWatcher, mock_fetcher: MagicMock) -> None:
+    """_fetch_and_assess_all processes all configured symbols."""
+    snap_aapl = _snapshot(
+        symbol="AAPL",
+        calls=[_contract(volume=100)],
+        puts=[_contract(volume=50, option_type="put")],
+    )
+    snap_tsla = _snapshot(
+        symbol="TSLA",
+        calls=[_contract(volume=200)],
+        puts=[_contract(volume=300, option_type="put")],
+    )
+
+    def side_effect(symbol: str) -> OptionsChainSnapshot:
+        return snap_aapl if symbol == "AAPL" else snap_tsla
+
+    mock_fetcher.fetch_options_chain.side_effect = side_effect
+
+    await watcher._fetch_and_assess_all()
+
+    assert watcher.get_signal("AAPL") is not None
+    assert watcher.get_signal("TSLA") is not None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_updates_signals(watcher: OptionsFlowWatcher, mock_fetcher: MagicMock) -> None:
+    """run() executes one cycle and sets signals."""
+    snap = _snapshot(
+        symbol="AAPL",
+        calls=[_contract(volume=100)],
+        puts=[_contract(volume=50, option_type="put")],
+    )
+    mock_fetcher.fetch_options_chain.return_value = snap
+
+    async def stop_after_first_cycle() -> None:
+        await asyncio.sleep(0.05)
+        watcher.running = False
+
+    await asyncio.gather(
+        watcher.run(),
+        stop_after_first_cycle(),
+    )
+
+    assert watcher.get_signal("AAPL") is not None
+    mock_fetcher.fetch_options_chain.assert_called()

--- a/tests/test_data/test_options_flow.py
+++ b/tests/test_data/test_options_flow.py
@@ -1,0 +1,138 @@
+"""Unit tests for OptionsFlowFetcher."""
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from src.data.options_flow import OptionsFlowFetcher
+
+
+def _make_chain_df(
+    strikes: list[float],
+    volumes: list[int],
+    last_prices: list[float],
+) -> pd.DataFrame:
+    """Build a minimal options chain dataframe."""
+    return pd.DataFrame(
+        {
+            "strike": strikes,
+            "lastPrice": last_prices,
+            "bid": [p * 0.95 for p in last_prices],
+            "ask": [p * 1.05 for p in last_prices],
+            "volume": volumes,
+            "openInterest": [v * 10 for v in volumes],
+            "impliedVolatility": [0.3] * len(strikes),
+            "inTheMoney": [s < 180 for s in strikes],
+        }
+    )
+
+
+@pytest.fixture
+def fetcher() -> OptionsFlowFetcher:
+    """Create fetcher instance."""
+    return OptionsFlowFetcher(max_expirations=2)
+
+
+@pytest.mark.unit
+def test_fetch_options_chain_success(fetcher: OptionsFlowFetcher) -> None:
+    """Fetch chains from 2 expirations, aggregate volume/OI."""
+    tomorrow = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d")
+    next_week = (datetime.now() + timedelta(days=7)).strftime("%Y-%m-%d")
+
+    calls_df = _make_chain_df([170, 180, 190], [100, 200, 50], [5.0, 3.0, 1.0])
+    puts_df = _make_chain_df([170, 180, 190], [80, 150, 30], [2.0, 4.0, 6.0])
+    chain_mock = (calls_df, puts_df)
+
+    ticker_mock = MagicMock()
+    ticker_mock.options = (tomorrow, next_week)
+    ticker_mock.option_chain.return_value = chain_mock
+
+    with patch("yfinance.Ticker", return_value=ticker_mock):
+        snapshot = fetcher.fetch_options_chain("AAPL")
+
+    assert snapshot.symbol == "AAPL"
+    # 2 expirations * (100+200+50) = 700
+    assert snapshot.total_call_volume == 700
+    assert snapshot.total_put_volume == 520
+    assert len(snapshot.calls) == 6  # 3 strikes * 2 expirations
+    assert len(snapshot.puts) == 6
+    assert snapshot.near_term_expiry is not None
+    assert not snapshot.is_empty
+
+
+@pytest.mark.unit
+def test_fetch_no_expirations(fetcher: OptionsFlowFetcher) -> None:
+    """Return empty snapshot when no expirations available."""
+    ticker_mock = MagicMock()
+    ticker_mock.options = ()
+
+    with patch("yfinance.Ticker", return_value=ticker_mock):
+        snapshot = fetcher.fetch_options_chain("AAPL")
+
+    assert snapshot.is_empty
+    assert snapshot.symbol == "AAPL"
+
+
+@pytest.mark.unit
+def test_fetch_error_returns_empty(fetcher: OptionsFlowFetcher) -> None:
+    """Return empty snapshot on exception."""
+    with patch("yfinance.Ticker", side_effect=Exception("API error")):
+        snapshot = fetcher.fetch_options_chain("AAPL")
+
+    assert snapshot.is_empty
+    assert snapshot.symbol == "AAPL"
+
+
+@pytest.mark.unit
+def test_fetch_skips_today_expiry(fetcher: OptionsFlowFetcher) -> None:
+    """Today's expiration is skipped (stale data)."""
+    today = datetime.now().strftime("%Y-%m-%d")
+    tomorrow = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d")
+
+    calls_df = _make_chain_df([180], [100], [5.0])
+    puts_df = _make_chain_df([180], [50], [3.0])
+    chain_mock = (calls_df, puts_df)
+
+    ticker_mock = MagicMock()
+    ticker_mock.options = (today, tomorrow)
+    ticker_mock.option_chain.return_value = chain_mock
+
+    with patch("yfinance.Ticker", return_value=ticker_mock):
+        snapshot = fetcher.fetch_options_chain("AAPL")
+
+    # Only tomorrow's expiration should be fetched
+    ticker_mock.option_chain.assert_called_once_with(tomorrow)
+
+
+@pytest.mark.unit
+def test_nan_handling(fetcher: OptionsFlowFetcher) -> None:
+    """NaN values in volume/OI are handled via fillna(0)."""
+    tomorrow = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d")
+
+    calls_df = pd.DataFrame(
+        {
+            "strike": [180.0],
+            "lastPrice": [5.0],
+            "bid": [float("nan")],
+            "ask": [float("nan")],
+            "volume": [float("nan")],
+            "openInterest": [float("nan")],
+            "impliedVolatility": [0.3],
+            "inTheMoney": [True],
+        }
+    )
+    puts_df = _make_chain_df([180], [0], [0.0])
+    chain_mock = (calls_df, puts_df)
+
+    ticker_mock = MagicMock()
+    ticker_mock.options = (tomorrow,)
+    ticker_mock.option_chain.return_value = chain_mock
+
+    with patch("yfinance.Ticker", return_value=ticker_mock):
+        snapshot = fetcher.fetch_options_chain("AAPL")
+
+    # NaN volume should become 0
+    assert snapshot.total_call_volume == 0
+    assert snapshot.calls[0].volume == 0


### PR DESCRIPTION
## Motivation

Options flow reveals institutional positioning via large block trades, volume spikes, and put/call ratios. Adding OptionsFlowWatcher injects per-symbol options flow signals into the supervisor planning context, boosting confidence when flow aligns with technical analysis.

Closes #585

## Implementation information

Standalone watcher (like EconomicCalendarWatcher), NOT EventWatcher-based. Options flow provides supplementary context, not event-driven triggers. No LLM triage needed.

**Data source:** yfinance (free, no API key). Nearest 2 non-expired expirations. All calls via `asyncio.to_thread()`.

**New files (4):**
- `src/data/options_flow.py` — `OptionContract`, `OptionsChainSnapshot`, `OptionsFlowFetcher`
- `src/daemon/watchers/options_flow_watcher.py` — watcher with block detection, PCR, volume spike, direction, significance scoring
- `tests/test_data/test_options_flow.py` — 5 fetcher tests
- `tests/test_daemon/test_options_flow_watcher.py` — 19 watcher tests

**Modified files (13):**
- `src/daemon/events.py` — `OptionsFlowDirection`, `BlockTrade`, `OptionsFlowSignal` models
- `src/daemon/config/analysis.py` + `__init__.py` — `OptionsFlowWatcherConfig` wired into `DaemonConfig`
- `src/daemon/watchers/__init__.py` — export
- `src/di/providers/watchers.py` — `create_options_flow_watcher()` provider
- `src/daemon/factory.py` — `DaemonComponents` field + creation in `_create_event_watchers`
- `src/daemon/lifecycle.py` — start/stop hooks
- `src/workflows/types.py` — `options_flow_context` on `WorkflowExtraContext`
- `src/agents/supervisor/models.py` — `options_flow` on `PlanningContext`
- `src/workflows/stages/instrumented_analysis.py` — pass context to supervisor
- `src/daemon/analysis_orchestrator.py` — inject per-symbol flow (significance >= 0.3)
- `docs/daemon.yaml.example` — config section
- `tests/integration/test_daemon_with_watchers.py` — mock fixture fix

**Signal scoring:**
- 40% volume spike (vs 5-session rolling avg)
- 30% block trades (volume × price × 100 > threshold)
- 30% PCR extremity (distance from neutral 1.0)

> Changelog: feat(daemon): add options flow watcher

## Supporting documentation

- Issue: #585