### PR TITLE
fix(db): per-request repos for session leaks

### DIFF
--- a/src/coordinator/memory.py
+++ b/src/coordinator/memory.py
@@ -14,8 +14,7 @@ if TYPE_CHECKING:
     from src.daemon.state import DaemonState
     from src.daemon.state.models import SignalOutcome
     from src.data.broker import AlpacaBroker
-    from src.database.repositories.analysis import AnalysisRecordRepository
-    from src.database.repositories.signal_outcome import SignalOutcomeRepository
+    from src.database.engine import DatabaseEngine
 
 # Constants for memory limits
 _MAX_IN_MEMORY_RECORDS: Final[int] = 20
@@ -47,8 +46,7 @@ class CoordinatorMemory:
         self,
         memory_file: Path | None = None,
         daemon_state: DaemonState | None = None,
-        analysis_repo: AnalysisRecordRepository | None = None,
-        signal_outcome_repo: SignalOutcomeRepository | None = None,
+        database_engine: DatabaseEngine | None = None,
         broker: AlpacaBroker | None = None,
     ) -> None:
         """Initialize coordinator memory.
@@ -56,8 +54,7 @@ class CoordinatorMemory:
         Args:
             memory_file: Path to JSONL memory file (default: ~/.ai-casino/coordinator-memory.jsonl)
             daemon_state: Optional daemon state for today's data access
-            analysis_repo: Optional analysis repository for historical queries
-            signal_outcome_repo: Optional signal outcome repository for learning queries
+            database_engine: Optional database engine for per-request repo creation
             broker: Optional broker for portfolio data access
         """
         self._memory_file = memory_file or Path("~/.ai-casino/coordinator-memory.jsonl").expanduser()
@@ -65,8 +62,7 @@ class CoordinatorMemory:
 
         # Dependencies for multi-tier memory
         self._daemon_state = daemon_state
-        self._analysis_repo = analysis_repo
-        self._signal_outcome_repo = signal_outcome_repo
+        self._database_engine = database_engine
         self._broker = broker
 
         # Create file if it doesn't exist
@@ -306,8 +302,8 @@ class CoordinatorMemory:
         Returns:
             Formatted markdown analysis history
         """
-        if not self._analysis_repo:
-            # Fallback to in-memory if no repository
+        if not self._database_engine:
+            # Fallback to in-memory if no database
             if self._daemon_state:
                 all_analyses = await self._daemon_state.get_analyses(limit=1000)
                 records = [r for r in all_analyses if r.symbol.upper() == symbol.upper()]
@@ -344,13 +340,17 @@ class CoordinatorMemory:
             return f"No analysis history available for {symbol}"
 
         try:
-            # Query database for historical records
-            start_date = datetime.now(UTC) - timedelta(days=days)
-            records = await self._analysis_repo.get_by_date_range(
-                start=start_date,
-                end=datetime.now(UTC),
-                symbol=symbol,
-            )
+            from src.database.repositories.analysis import AnalysisRecordRepository
+
+            repo = AnalysisRecordRepository(self._database_engine.session())
+            repo.owns_session = True
+            async with repo:
+                start_date = datetime.now(UTC) - timedelta(days=days)
+                records = await repo.get_by_date_range(
+                    start=start_date,
+                    end=datetime.now(UTC),
+                    symbol=symbol,
+                )
 
             if not records:
                 return f"No analysis history found for {symbol} in last {days} days"
@@ -419,8 +419,8 @@ class CoordinatorMemory:
         if params is None:
             params = DecisionQueryParams()
 
-        if not self._signal_outcome_repo:
-            logger.warning("Signal outcome repository not available")
+        if not self._database_engine:
+            logger.warning("Database engine not available for decision queries")
             return []
 
         try:
@@ -452,24 +452,29 @@ class CoordinatorMemory:
         Returns:
             List of SignalOutcome instances
         """
-        if not self._signal_outcome_repo:
+        if not self._database_engine:
             return []
 
-        start_date = datetime.now(UTC) - timedelta(days=lookback_days)
+        from src.database.repositories.signal_outcome import SignalOutcomeRepository
 
-        if symbol:
-            outcomes = await self._signal_outcome_repo.get_by_symbol(
-                symbol=symbol,
-                limit=limit,
-                start_date=start_date,
-            )
-        else:
-            outcomes = await self._signal_outcome_repo.get_recent_outcomes(
-                window=lookback_days,
-                signal_type=signal,
-                min_confidence=min_confidence,
-            )
-            outcomes = outcomes[:limit]
+        repo = SignalOutcomeRepository(self._database_engine.session())
+        repo.owns_session = True
+        async with repo:
+            start_date = datetime.now(UTC) - timedelta(days=lookback_days)
+
+            if symbol:
+                outcomes = await repo.get_by_symbol(
+                    symbol=symbol,
+                    limit=limit,
+                    start_date=start_date,
+                )
+            else:
+                outcomes = await repo.get_recent_outcomes(
+                    window=lookback_days,
+                    signal_type=signal,
+                    min_confidence=min_confidence,
+                )
+                outcomes = outcomes[:limit]
 
         return outcomes
 
@@ -575,8 +580,8 @@ class CoordinatorMemory:
         """
         from src.coordinator.decision_models import SuccessRateStats
 
-        if not self._signal_outcome_repo:
-            logger.warning("Signal outcome repository not available")
+        if not self._database_engine:
+            logger.warning("Database engine not available for success rate")
             return SuccessRateStats(
                 total_decisions=0,
                 hit_count=0,
@@ -651,10 +656,8 @@ class CoordinatorMemory:
         deps = []
         if self._daemon_state:
             deps.append("daemon_state")
-        if self._analysis_repo:
-            deps.append("analysis_repo")
-        if self._signal_outcome_repo:
-            deps.append("signal_outcome_repo")
+        if self._database_engine:
+            deps.append("database_engine")
         if self._broker:
             deps.append("broker")
         deps_str = f", deps={','.join(deps)}" if deps else ""

--- a/src/daemon/analysis_orchestrator.py
+++ b/src/daemon/analysis_orchestrator.py
@@ -111,17 +111,6 @@ class AnalysisOrchestrator:
             "DaemonContextBuilder | None", deprecated_kwargs.get("context_builder")
         )
 
-        # Extract signal_outcome_repo from components (not in deprecated_kwargs)
-        from contextlib import suppress
-
-        from src.database.repositories.signal_outcome import SignalOutcomeRepository
-
-        self._signal_outcome_repo: SignalOutcomeRepository | None = None
-        if hasattr(components, "container") and components.container:
-            with suppress(Exception):
-                # Repository creation may fail if database not enabled
-                self._signal_outcome_repo = components.container.signal_outcome_repository()
-
         self._economic_watcher = components.economic_calendar_watcher
 
         self._notification_helper = DaemonNotificationHelper()
@@ -553,13 +542,14 @@ class AnalysisOrchestrator:
             symbol: Stock ticker
             result: TradingWorkflowResult
         """
-        if self._signal_outcome_repo:
+        container = self._components.container if self._components else None
+        if container:
             await self._record_signal_to_postgres(symbol, result)
         elif self.historical_cache:
             self._record_signal_to_sqlite(symbol, result)
 
     async def _record_signal_to_postgres(self, symbol: str, result: TradingWorkflowResult) -> None:
-        """Record signal to PostgreSQL.
+        """Record signal to PostgreSQL with per-request repo.
 
         Args:
             symbol: Stock ticker
@@ -567,7 +557,8 @@ class AnalysisOrchestrator:
         """
         from src.database.repositories.signal_outcome import SignalRecordInput
 
-        if not self._signal_outcome_repo:
+        container = self._components.container if self._components else None
+        if not container:
             return
 
         try:
@@ -591,7 +582,9 @@ class AnalysisOrchestrator:
                     else None
                 ),
             )
-            await self._signal_outcome_repo.record_signal(input_data)
+            repo = container.signal_outcome_repository()
+            async with repo:
+                await repo.record_signal(input_data)
         except Exception as e:
             logger.opt(exception=True).warning(f"Failed to record signal outcome: {e}")
 

--- a/src/daemon/cycle_orchestrator.py
+++ b/src/daemon/cycle_orchestrator.py
@@ -419,7 +419,8 @@ class DaemonCycleOrchestrator:
             try:
                 if self.components.container:
                     repo = self.components.container.coordinator_metrics_repository()
-                    await repo.create(metrics)
+                    async with repo:
+                        await repo.create(metrics)
                     logger.debug(f"Saved coordinator metrics to PostgreSQL: cycle={self._cycle_counter}")
                     return
             except Exception as pg_error:

--- a/src/daemon/threshold_adapter.py
+++ b/src/daemon/threshold_adapter.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 if TYPE_CHECKING:
     from src.coordinator.models import AdaptiveThresholdConfig
     from src.daemon.state.models import SignalOutcome
-    from src.database.repositories.signal_outcome import SignalOutcomeRepository
+    from src.database.engine import DatabaseEngine
 
 
 class AdaptiveThresholds(BaseModel):
@@ -35,16 +35,16 @@ class AdaptiveThresholdManager:
     def __init__(
         self,
         config: AdaptiveThresholdConfig,
-        signal_outcome_repo: SignalOutcomeRepository,
+        database_engine: DatabaseEngine,
     ) -> None:
         """Initialize threshold manager.
 
         Args:
             config: Adaptive threshold configuration
-            signal_outcome_repo: Repository for signal outcomes
+            database_engine: Database engine for per-request repo creation
         """
         self._config = config
-        self._repo = signal_outcome_repo
+        self._database_engine = database_engine
         self._thresholds = AdaptiveThresholds(
             buy_threshold=config.min_threshold,
             sell_threshold=config.min_threshold,
@@ -64,14 +64,19 @@ class AdaptiveThresholdManager:
 
         # Query recent outcomes for BUY and SELL
         try:
-            buy_outcomes = await self._repo.get_recent_outcomes(
-                window=self._config.min_sample_size,
-                signal_type="BUY",
-            )
-            sell_outcomes = await self._repo.get_recent_outcomes(
-                window=self._config.min_sample_size,
-                signal_type="SELL",
-            )
+            from src.database.repositories.signal_outcome import SignalOutcomeRepository
+
+            repo = SignalOutcomeRepository(self._database_engine.session())
+            repo.owns_session = True
+            async with repo:
+                buy_outcomes = await repo.get_recent_outcomes(
+                    window=self._config.min_sample_size,
+                    signal_type="BUY",
+                )
+                sell_outcomes = await repo.get_recent_outcomes(
+                    window=self._config.min_sample_size,
+                    signal_type="SELL",
+                )
         except Exception as e:
             logger.opt(exception=True).error(f"Failed to query signal outcomes: {e}")
             return self._thresholds

--- a/src/di/providers/agents.py
+++ b/src/di/providers/agents.py
@@ -234,12 +234,9 @@ def create_adaptive_threshold_manager(
     if not daemon_config.coordinator.adaptive_thresholds.enabled:
         return None
 
-    # Get signal outcome repository
-    signal_outcome_repo = container.signal_outcome_repository()
-
     return AdaptiveThresholdManager(
         config=daemon_config.coordinator.adaptive_thresholds,
-        signal_outcome_repo=signal_outcome_repo,
+        database_engine=container.database_engine(),
     )
 
 
@@ -283,23 +280,21 @@ def create_trading_coordinator(
 
     # Get dependencies for enhanced memory
     broker = container.alpaca_broker()
-    analysis_repo = container.analysis_repository()
 
-    # Get signal outcome repository if database enabled
-    signal_outcome_repo = None
+    # Get database engine for per-request repo creation (avoids session leaks)
+    database_engine = None
     if daemon_config.database.enable_persistence:
         try:
-            signal_outcome_repo = container.signal_outcome_repository()
+            database_engine = container.database_engine()
         except Exception as e:
             from loguru import logger
 
-            logger.opt(exception=True).warning(f"Failed to create signal_outcome_repository for memory: {e}")
+            logger.opt(exception=True).warning(f"Failed to get database_engine for memory: {e}")
 
     # Create enhanced memory with multi-tier context
     memory = CoordinatorMemory(
         daemon_state=daemon_state,
-        analysis_repo=analysis_repo,
-        signal_outcome_repo=signal_outcome_repo,
+        database_engine=database_engine,
         broker=broker,
     )
 

--- a/src/di/providers/models.py
+++ b/src/di/providers/models.py
@@ -295,25 +295,21 @@ def create_coordinator_tool_registry(
     memory = None
     if daemon_state is not None:
         broker = container.alpaca_broker()
-        analysis_repo = container.analysis_repository()
 
-        # Get signal outcome repository if database enabled
-        signal_outcome_repo = None
+        # Get database engine for per-request repo creation (avoids session leaks)
+        database_engine = None
         daemon_config = container.daemon_config()
         if daemon_config.database.enable_persistence:
             try:
-                signal_outcome_repo = container.signal_outcome_repository()
+                database_engine = container.database_engine()
             except Exception as e:
                 from loguru import logger
 
-                logger.opt(exception=True).warning(
-                    f"Failed to create signal_outcome_repository for memory: {e}"
-                )
+                logger.opt(exception=True).warning(f"Failed to get database_engine for memory: {e}")
 
         memory = CoordinatorMemory(
             daemon_state=daemon_state,
-            analysis_repo=analysis_repo,
-            signal_outcome_repo=signal_outcome_repo,
+            database_engine=database_engine,
             broker=broker,
         )
 

--- a/tests/test_coordinator/test_memory.py
+++ b/tests/test_coordinator/test_memory.py
@@ -1,7 +1,7 @@
 """Tests for CoordinatorMemory enhanced functionality."""
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -320,12 +320,22 @@ async def test_get_portfolio_summary_broker_error(tmp_path):
 @pytest.mark.asyncio
 async def test_get_analysis_history_from_db(mock_analysis_repo, tmp_path):
     """Test get_analysis_history querying database."""
-    memory = CoordinatorMemory(
-        memory_file=tmp_path / "memory.jsonl",
-        analysis_repo=mock_analysis_repo,
-    )
+    mock_analysis_repo.__aenter__ = AsyncMock(return_value=mock_analysis_repo)
+    mock_analysis_repo.__aexit__ = AsyncMock(return_value=False)
 
-    result = await memory.get_analysis_history("AAPL", days=7)
+    mock_engine = MagicMock()
+    mock_engine.session.return_value = AsyncMock()
+
+    with patch(
+        "src.database.repositories.analysis.AnalysisRecordRepository",
+        return_value=mock_analysis_repo,
+    ):
+        memory = CoordinatorMemory(
+            memory_file=tmp_path / "memory.jsonl",
+            database_engine=mock_engine,
+        )
+
+        result = await memory.get_analysis_history("AAPL", days=7)
 
     assert "# Analysis History - AAPL (last 7 days)" in result
     assert "BUY" in result
@@ -346,13 +356,22 @@ async def test_get_analysis_history_from_db(mock_analysis_repo, tmp_path):
 async def test_get_analysis_history_no_records(mock_analysis_repo, tmp_path):
     """Test get_analysis_history with no records found."""
     mock_analysis_repo.get_by_date_range.return_value = []
+    mock_analysis_repo.__aenter__ = AsyncMock(return_value=mock_analysis_repo)
+    mock_analysis_repo.__aexit__ = AsyncMock(return_value=False)
 
-    memory = CoordinatorMemory(
-        memory_file=tmp_path / "memory.jsonl",
-        analysis_repo=mock_analysis_repo,
-    )
+    mock_engine = MagicMock()
+    mock_engine.session.return_value = AsyncMock()
 
-    result = await memory.get_analysis_history("NVDA", days=7)
+    with patch(
+        "src.database.repositories.analysis.AnalysisRecordRepository",
+        return_value=mock_analysis_repo,
+    ):
+        memory = CoordinatorMemory(
+            memory_file=tmp_path / "memory.jsonl",
+            database_engine=mock_engine,
+        )
+
+        result = await memory.get_analysis_history("NVDA", days=7)
     assert "No analysis history found for NVDA in last 7 days" in result
 
 
@@ -422,18 +441,18 @@ def test_truncate_to_budget():
 def test_memory_repr_with_dependencies(mock_broker, tmp_path):
     """Test __repr__ shows dependencies."""
     state = Mock()
-    repo = AsyncMock()
+    engine = MagicMock()
 
     memory = CoordinatorMemory(
         memory_file=tmp_path / "memory.jsonl",
         daemon_state=state,
-        analysis_repo=repo,
+        database_engine=engine,
         broker=mock_broker,
     )
 
     repr_str = repr(memory)
     assert "daemon_state" in repr_str
-    assert "analysis_repo" in repr_str
+    assert "database_engine" in repr_str
     assert "broker" in repr_str
     assert str(tmp_path / "memory.jsonl") in repr_str
 
@@ -446,4 +465,4 @@ def test_memory_repr_without_dependencies(tmp_path):
     repr_str = repr(memory)
     assert str(tmp_path / "memory.jsonl") in repr_str
     assert "daemon_state" not in repr_str
-    assert "analysis_repo" not in repr_str
+    assert "database_engine" not in repr_str

--- a/tests/test_coordinator/test_memory_decision_queries.py
+++ b/tests/test_coordinator/test_memory_decision_queries.py
@@ -1,7 +1,7 @@
 """Tests for CoordinatorMemory decision query methods."""
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -11,9 +11,21 @@ from src.daemon.state.models import SignalOutcome
 
 
 @pytest.fixture
+def mock_database_engine():
+    """Create mock database engine."""
+    engine = MagicMock()
+    engine.session.return_value = AsyncMock()
+    return engine
+
+
+@pytest.fixture
 def mock_signal_outcome_repo():
-    """Create mock signal outcome repository."""
-    return AsyncMock()
+    """Create mock signal outcome repository with async context manager support."""
+    repo = AsyncMock()
+    repo.owns_session = True
+    repo.__aenter__ = AsyncMock(return_value=repo)
+    repo.__aexit__ = AsyncMock(return_value=False)
+    return repo
 
 
 @pytest.fixture
@@ -69,43 +81,55 @@ def sample_signal_outcomes():
     ]
 
 
+def _patch_signal_repo(mock_repo):
+    """Patch SignalOutcomeRepository to return mock repo."""
+    return patch(
+        "src.database.repositories.signal_outcome.SignalOutcomeRepository",
+        return_value=mock_repo,
+    )
+
+
 @pytest.mark.asyncio
 class TestCoordinatorMemoryDecisionQueries:
     """Test CoordinatorMemory decision query functionality."""
 
-    async def test_query_decisions_basic(self, mock_signal_outcome_repo, sample_signal_outcomes):
+    async def test_query_decisions_basic(
+        self, mock_database_engine, mock_signal_outcome_repo, sample_signal_outcomes
+    ):
         """Test basic decision query without filters."""
         mock_signal_outcome_repo.get_recent_outcomes.return_value = sample_signal_outcomes
 
-        memory = CoordinatorMemory(signal_outcome_repo=mock_signal_outcome_repo)
-
-        decisions = await memory.query_decisions(DecisionQueryParams(lookback_days=90, limit=50))
+        with _patch_signal_repo(mock_signal_outcome_repo):
+            memory = CoordinatorMemory(database_engine=mock_database_engine)
+            decisions = await memory.query_decisions(DecisionQueryParams(lookback_days=90, limit=50))
 
         assert len(decisions) == 4
         assert isinstance(decisions[0], DecisionQueryResult)
         mock_signal_outcome_repo.get_recent_outcomes.assert_called_once()
 
-    async def test_query_decisions_with_symbol_filter(self, mock_signal_outcome_repo, sample_signal_outcomes):
+    async def test_query_decisions_with_symbol_filter(
+        self, mock_database_engine, mock_signal_outcome_repo, sample_signal_outcomes
+    ):
         """Test querying decisions for specific symbol."""
         mock_signal_outcome_repo.get_by_symbol.return_value = [sample_signal_outcomes[0]]
 
-        memory = CoordinatorMemory(signal_outcome_repo=mock_signal_outcome_repo)
-
-        decisions = await memory.query_decisions(DecisionQueryParams(symbol="AAPL", lookback_days=90))
+        with _patch_signal_repo(mock_signal_outcome_repo):
+            memory = CoordinatorMemory(database_engine=mock_database_engine)
+            decisions = await memory.query_decisions(DecisionQueryParams(symbol="AAPL", lookback_days=90))
 
         assert len(decisions) == 1
         assert decisions[0].symbol == "AAPL"
         mock_signal_outcome_repo.get_by_symbol.assert_called_once()
 
     async def test_query_decisions_hit_miss_classification(
-        self, mock_signal_outcome_repo, sample_signal_outcomes
+        self, mock_database_engine, mock_signal_outcome_repo, sample_signal_outcomes
     ):
         """Test HIT/MISS classification for decisions."""
         mock_signal_outcome_repo.get_recent_outcomes.return_value = sample_signal_outcomes
 
-        memory = CoordinatorMemory(signal_outcome_repo=mock_signal_outcome_repo)
-
-        decisions = await memory.query_decisions(DecisionQueryParams(lookback_days=90))
+        with _patch_signal_repo(mock_signal_outcome_repo):
+            memory = CoordinatorMemory(database_engine=mock_database_engine)
+            decisions = await memory.query_decisions(DecisionQueryParams(lookback_days=90))
 
         # Check HIT/MISS classification
         aapl_decision = next(d for d in decisions if d.symbol == "AAPL")
@@ -124,13 +148,15 @@ class TestCoordinatorMemoryDecisionQueries:
         assert tsla_decision.hit_miss == "PENDING"  # No outcome yet
         assert tsla_decision.return_pct is None
 
-    async def test_query_decisions_return_calculation(self, mock_signal_outcome_repo, sample_signal_outcomes):
+    async def test_query_decisions_return_calculation(
+        self, mock_database_engine, mock_signal_outcome_repo, sample_signal_outcomes
+    ):
         """Test return percentage calculation."""
         mock_signal_outcome_repo.get_recent_outcomes.return_value = [sample_signal_outcomes[0]]
 
-        memory = CoordinatorMemory(signal_outcome_repo=mock_signal_outcome_repo)
-
-        decisions = await memory.query_decisions(DecisionQueryParams(lookback_days=90))
+        with _patch_signal_repo(mock_signal_outcome_repo):
+            memory = CoordinatorMemory(database_engine=mock_database_engine)
+            decisions = await memory.query_decisions(DecisionQueryParams(lookback_days=90))
 
         assert len(decisions) == 1
         decision = decisions[0]
@@ -139,7 +165,7 @@ class TestCoordinatorMemoryDecisionQueries:
         expected_return = ((155.0 - 150.0) / 150.0) * 100
         assert abs(decision.return_pct - expected_return) < 0.01
 
-    async def test_query_decisions_horizon_selection(self, mock_signal_outcome_repo):
+    async def test_query_decisions_horizon_selection(self, mock_database_engine, mock_signal_outcome_repo):
         """Test selecting different outcome horizons."""
         outcome_with_multiple_horizons = SignalOutcome(
             symbol="AAPL",
@@ -157,27 +183,30 @@ class TestCoordinatorMemoryDecisionQueries:
 
         mock_signal_outcome_repo.get_recent_outcomes.return_value = [outcome_with_multiple_horizons]
 
-        memory = CoordinatorMemory(signal_outcome_repo=mock_signal_outcome_repo)
+        with _patch_signal_repo(mock_signal_outcome_repo):
+            memory = CoordinatorMemory(database_engine=mock_database_engine)
 
-        # Test 1d horizon
-        decisions_1d = await memory.query_decisions(DecisionQueryParams(horizon="1d"))
-        assert decisions_1d[0].price_at_outcome == 152.0
+            # Test 1d horizon
+            decisions_1d = await memory.query_decisions(DecisionQueryParams(horizon="1d"))
+            assert decisions_1d[0].price_at_outcome == 152.0
 
-        # Test 5d horizon
-        decisions_5d = await memory.query_decisions(DecisionQueryParams(horizon="5d"))
-        assert decisions_5d[0].price_at_outcome == 155.0
+            # Test 5d horizon
+            decisions_5d = await memory.query_decisions(DecisionQueryParams(horizon="5d"))
+            assert decisions_5d[0].price_at_outcome == 155.0
 
-        # Test 20d horizon
-        decisions_20d = await memory.query_decisions(DecisionQueryParams(horizon="20d"))
-        assert decisions_20d[0].price_at_outcome == 160.0
+            # Test 20d horizon
+            decisions_20d = await memory.query_decisions(DecisionQueryParams(horizon="20d"))
+            assert decisions_20d[0].price_at_outcome == 160.0
 
-    async def test_get_success_rate_basic(self, mock_signal_outcome_repo, sample_signal_outcomes):
+    async def test_get_success_rate_basic(
+        self, mock_database_engine, mock_signal_outcome_repo, sample_signal_outcomes
+    ):
         """Test calculating basic success rate statistics."""
         mock_signal_outcome_repo.get_recent_outcomes.return_value = sample_signal_outcomes
 
-        memory = CoordinatorMemory(signal_outcome_repo=mock_signal_outcome_repo)
-
-        stats = await memory.get_success_rate(lookback_days=90)
+        with _patch_signal_repo(mock_signal_outcome_repo):
+            memory = CoordinatorMemory(database_engine=mock_database_engine)
+            stats = await memory.get_success_rate(lookback_days=90)
 
         assert isinstance(stats, dict)
         assert stats["total_decisions"] == 4
@@ -187,15 +216,15 @@ class TestCoordinatorMemoryDecisionQueries:
         assert stats["success_rate"] == 2 / 3  # 2 hits out of 3 completed
 
     async def test_get_success_rate_with_signal_filter(
-        self, mock_signal_outcome_repo, sample_signal_outcomes
+        self, mock_database_engine, mock_signal_outcome_repo, sample_signal_outcomes
     ):
         """Test success rate filtered by signal type."""
         buy_signals = [s for s in sample_signal_outcomes if s.signal == "BUY"]
         mock_signal_outcome_repo.get_recent_outcomes.return_value = buy_signals
 
-        memory = CoordinatorMemory(signal_outcome_repo=mock_signal_outcome_repo)
-
-        stats = await memory.get_success_rate(signal="BUY", lookback_days=90)
+        with _patch_signal_repo(mock_signal_outcome_repo):
+            memory = CoordinatorMemory(database_engine=mock_database_engine)
+            stats = await memory.get_success_rate(signal="BUY", lookback_days=90)
 
         assert stats["total_decisions"] == 3
         assert stats["hit_count"] == 1  # Only AAPL
@@ -203,29 +232,34 @@ class TestCoordinatorMemoryDecisionQueries:
         assert stats["pending_count"] == 1  # TSLA
 
     async def test_get_success_rate_with_regime_filter(
-        self, mock_signal_outcome_repo, sample_signal_outcomes
+        self, mock_database_engine, mock_signal_outcome_repo, sample_signal_outcomes
     ):
         """Test success rate filtered by regime."""
         bullish_signals = [s for s in sample_signal_outcomes if s.regime == "trending_bullish"]
         mock_signal_outcome_repo.get_recent_outcomes.return_value = bullish_signals
 
-        memory = CoordinatorMemory(signal_outcome_repo=mock_signal_outcome_repo)
+        with _patch_signal_repo(mock_signal_outcome_repo):
+            memory = CoordinatorMemory(database_engine=mock_database_engine)
 
-        # Query all, then filter by regime
-        decisions = await memory.query_decisions(DecisionQueryParams(lookback_days=90))
-        # Filter happens in get_success_rate
-        bullish_decisions = [d for d in decisions if hasattr(d, "regime") and d.regime == "trending_bullish"]
+            # Query all, then filter by regime
+            decisions = await memory.query_decisions(DecisionQueryParams(lookback_days=90))
+            # Filter happens in get_success_rate
+            bullish_decisions = [
+                d for d in decisions if hasattr(d, "regime") and d.regime == "trending_bullish"
+            ]
 
         assert len(bullish_decisions) >= 1
 
-    async def test_get_success_rate_average_return(self, mock_signal_outcome_repo, sample_signal_outcomes):
+    async def test_get_success_rate_average_return(
+        self, mock_database_engine, mock_signal_outcome_repo, sample_signal_outcomes
+    ):
         """Test average return calculation in success rate stats."""
         completed_signals = [s for s in sample_signal_outcomes if s.price_at_5d is not None]
         mock_signal_outcome_repo.get_recent_outcomes.return_value = completed_signals
 
-        memory = CoordinatorMemory(signal_outcome_repo=mock_signal_outcome_repo)
-
-        stats = await memory.get_success_rate(lookback_days=90)
+        with _patch_signal_repo(mock_signal_outcome_repo):
+            memory = CoordinatorMemory(database_engine=mock_database_engine)
+            stats = await memory.get_success_rate(lookback_days=90)
 
         # AAPL: +3.33%, MSFT: -1.67%, GOOGL: -3.57%
         # Average: (-3.33 - 1.67 - 3.57) / 3 ≈ -0.30%
@@ -233,52 +267,52 @@ class TestCoordinatorMemoryDecisionQueries:
         assert isinstance(stats["avg_return"], float)
 
     async def test_get_success_rate_average_confidence(
-        self, mock_signal_outcome_repo, sample_signal_outcomes
+        self, mock_database_engine, mock_signal_outcome_repo, sample_signal_outcomes
     ):
         """Test average confidence calculation."""
         mock_signal_outcome_repo.get_recent_outcomes.return_value = sample_signal_outcomes
 
-        memory = CoordinatorMemory(signal_outcome_repo=mock_signal_outcome_repo)
-
-        stats = await memory.get_success_rate(lookback_days=90)
+        with _patch_signal_repo(mock_signal_outcome_repo):
+            memory = CoordinatorMemory(database_engine=mock_database_engine)
+            stats = await memory.get_success_rate(lookback_days=90)
 
         # Expected average confidence from sample outcomes is 0.825
         assert abs(stats["avg_confidence"] - 0.825) < 0.01
 
-    async def test_query_decisions_without_repo(self):
-        """Test graceful handling when repository is not available."""
-        memory = CoordinatorMemory(signal_outcome_repo=None)
+    async def test_query_decisions_without_engine(self):
+        """Test graceful handling when database engine is not available."""
+        memory = CoordinatorMemory()
 
         decisions = await memory.query_decisions(DecisionQueryParams(lookback_days=90))
 
         assert decisions == []
 
-    async def test_get_success_rate_without_repo(self):
-        """Test success rate returns zero stats when repository unavailable."""
-        memory = CoordinatorMemory(signal_outcome_repo=None)
+    async def test_get_success_rate_without_engine(self):
+        """Test success rate returns zero stats when database engine unavailable."""
+        memory = CoordinatorMemory()
 
         stats = await memory.get_success_rate(lookback_days=90)
 
         assert stats["total_decisions"] == 0
         assert stats["success_rate"] == 0.0
 
-    async def test_query_decisions_error_handling(self, mock_signal_outcome_repo):
+    async def test_query_decisions_error_handling(self, mock_database_engine, mock_signal_outcome_repo):
         """Test error handling in decision queries."""
         mock_signal_outcome_repo.get_recent_outcomes.side_effect = Exception("Database error")
 
-        memory = CoordinatorMemory(signal_outcome_repo=mock_signal_outcome_repo)
-
-        decisions = await memory.query_decisions(DecisionQueryParams(lookback_days=90))
+        with _patch_signal_repo(mock_signal_outcome_repo):
+            memory = CoordinatorMemory(database_engine=mock_database_engine)
+            decisions = await memory.query_decisions(DecisionQueryParams(lookback_days=90))
 
         assert decisions == []
 
-    async def test_get_success_rate_error_handling(self, mock_signal_outcome_repo):
+    async def test_get_success_rate_error_handling(self, mock_database_engine, mock_signal_outcome_repo):
         """Test error handling in success rate calculation."""
         mock_signal_outcome_repo.get_recent_outcomes.side_effect = Exception("Database error")
 
-        memory = CoordinatorMemory(signal_outcome_repo=mock_signal_outcome_repo)
-
-        stats = await memory.get_success_rate(lookback_days=90)
+        with _patch_signal_repo(mock_signal_outcome_repo):
+            memory = CoordinatorMemory(database_engine=mock_database_engine)
+            stats = await memory.get_success_rate(lookback_days=90)
 
         assert stats["total_decisions"] == 0
         assert stats["success_rate"] == 0.0


### PR DESCRIPTION
## Motivation

Daemon logs show `SAWarning: The garbage collector is trying to clean up non-checked-in connection` because repos with owned sessions were stored on long-lived objects (AnalysisOrchestrator, CoordinatorMemory, AdaptiveThresholdManager) and never returned to the pool.

## Implementation information

Replace stored repos with `database_engine` injection + per-request repo creation via `async with` blocks, so sessions are returned to the pool immediately after each operation.

**4 leak sites fixed:**

| Component | Before | After |
|-----------|--------|-------|
| `AnalysisOrchestrator` | Stored `signal_outcome_repo` in `__init__` forever | Creates repo per `_record_signal_to_postgres` call |
| `CycleOrchestrator` | Created `coordinator_metrics_repo` without closing | Wraps in `async with` |
| `CoordinatorMemory` | Stored `analysis_repo` + `signal_outcome_repo` | Accepts `database_engine`, creates repos per-method |
| `AdaptiveThresholdManager` | Stored `signal_outcome_repo` | Accepts `database_engine`, creates repo per `update_thresholds` |

DI providers (`agents.py`, `models.py`) updated to pass `database_engine` singleton instead of creating per-init repos.