### PR TITLE
refactor(daemon): remove circular deps

### DIFF
--- a/src/daemon/cycle_orchestrator.py
+++ b/src/daemon/cycle_orchestrator.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import time as time_mod
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from loguru import logger
@@ -18,7 +20,7 @@ from src.workflows.types import TradingWorkflowResult
 if TYPE_CHECKING:
     from src.coordinator.models import CoordinatorCycleResult
     from src.daemon.degradation import DegradationContext
-    from src.daemon.factory import DaemonComponents
+    from src.daemon.factory import DaemonComponents, DaemonFactory
     from src.daemon.profiling.profiler import CycleProfiler
     from src.daemon.task_runner import ScheduledTaskRunner
 
@@ -42,7 +44,7 @@ class DaemonCycleOrchestrator:
         self,
         components: DaemonComponents,
         task_runner: ScheduledTaskRunner,
-        runner: object,  # DaemonRunner (can't import due to circular dependency)
+        factory: DaemonFactory,
         profiler: CycleProfiler | None = None,
     ) -> None:
         """Initialize cycle orchestrator.
@@ -50,12 +52,12 @@ class DaemonCycleOrchestrator:
         Args:
             components: Daemon components
             task_runner: Task runner for scheduled tasks
-            runner: DaemonRunner for delegation to helper methods
+            factory: DaemonFactory for lazy component initialization
             profiler: Optional cycle profiler
         """
         self.components = components
         self.task_runner = task_runner
-        self.runner = runner  # For delegating to runner methods
+        self.factory = factory
         self.profiler = profiler
         self._notification_helper = DaemonNotificationHelper()
         self._cycle_counter = 0
@@ -120,7 +122,7 @@ class DaemonCycleOrchestrator:
                 logger.opt(exception=True).warning(f"Execution tracker cleanup failed: {e}")
 
             # Phase 4: Evaluate degradation before analysis
-            degradation_context = self.runner._evaluate_degradation()  # type: ignore[attr-defined]  # noqa: SLF001
+            degradation_context = self._evaluate_degradation()
 
             # Check for halted state (returns early if halted)
             halted_result = await self._handle_degradation_state(degradation_context)
@@ -262,7 +264,7 @@ class DaemonCycleOrchestrator:
         await self._sync_coordinator_positions()
 
         # Run coordinator cycle
-        coordinator_result: CoordinatorCycleResult = await self.runner._run_coordinator_cycle(  # type: ignore[attr-defined]  # noqa: SLF001
+        coordinator_result: CoordinatorCycleResult = await self._run_coordinator_cycle_impl(
             watchlist, degradation_context, trading_session
         )
 
@@ -366,7 +368,7 @@ class DaemonCycleOrchestrator:
         )
 
         cycle_start_time = time_mod.time()
-        results = await self.runner._analyze_watchlist(watchlist, degradation_context)  # type: ignore[attr-defined]  # noqa: SLF001
+        results = await self._analyze_watchlist(watchlist, degradation_context)
         cycle_duration = time_mod.time() - cycle_start_time
 
         # Log results
@@ -512,6 +514,81 @@ class DaemonCycleOrchestrator:
         except Exception as e:
             logger.opt(exception=True).warning(f"Pattern detection failed: {e}")
             return 0
+
+    def _evaluate_degradation(self) -> DegradationContext:
+        """Load latest health report and evaluate degradation tier."""
+        from src.daemon.degradation import DegradationPolicy
+        from src.daemon.health import HealthReport
+
+        health_report = None
+        health_dir = Path(self.components.config.health.health_dir).expanduser()
+        if health_dir.exists():
+            report_files = sorted(health_dir.glob("health-*.json"), reverse=True)
+            if report_files:
+                try:
+                    with report_files[0].open() as f:
+                        health_report = HealthReport.model_validate(json.load(f))
+                except Exception as e:
+                    logger.opt(exception=True).warning(f"Failed to load health report: {e}")
+
+        policy = DegradationPolicy(self.components.config)
+        return policy.evaluate_degradation(health_report)
+
+    async def _run_coordinator_cycle_impl(
+        self,
+        watchlist: list[str],
+        degradation_context: DegradationContext,
+        trading_session: TradingSession,
+    ) -> CoordinatorCycleResult:
+        """Run coordinator-driven cycle.
+
+        Args:
+            watchlist: Symbols to analyze
+            degradation_context: Degradation context for cycle
+            trading_session: Trading session type (REGULAR or PRE_MARKET)
+
+        Returns:
+            CoordinatorCycleResult from coordinator
+        """
+        from src.daemon.degradation import AgentType, DegradationTier
+
+        coordinator = self.factory.init_coordinator(self.components)
+
+        degradation_dict = None
+        if degradation_context.tier != DegradationTier.NONE:
+            degradation_dict = {
+                "tier": degradation_context.tier.value,
+                "unavailable_services": degradation_context.unavailable_services,
+                "confidence_adjustment": degradation_context.confidence_adjustment,
+                "disabled_agents": [
+                    str(agent) for agent in AgentType if agent not in degradation_context.available_agents
+                ],
+            }
+
+        return await coordinator.run_cycle(watchlist, degradation_dict, trading_session)
+
+    async def _analyze_watchlist(
+        self,
+        watchlist: list[str],
+        degradation_context: DegradationContext | None = None,
+    ) -> list[TradingWorkflowResult]:
+        """Analyze all symbols in watchlist (delegates to analysis orchestrator)."""
+        target_allocations = None
+
+        context_builder = self.components.container.context_builder(
+            components=self.components,
+            container=self.components.container,
+        )
+        orchestrator = self.factory.init_analysis_orchestrator(self.components, context_builder)
+        result = await orchestrator.orchestrate(watchlist, target_allocations, degradation_context)
+
+        logger.info(
+            f"Orchestration complete: {result.successful}/{result.total_symbols} successful, "
+            f"{result.failed} failed, {result.position_actions} position actions, "
+            f"{result.duration_seconds:.2f}s"
+        )
+
+        return result.results
 
     async def _publish_event(self, event_type: str, data: dict[str, object]) -> None:
         """Publish event to event bus.

--- a/src/daemon/runner.py
+++ b/src/daemon/runner.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -18,13 +17,11 @@ from src.workflows.types import TradingWorkflowResult
 
 if TYPE_CHECKING:
     from src.coordinator.agent import TradingCoordinator
-    from src.coordinator.models import CoordinatorCycleResult
     from src.daemon.analysis_orchestrator import AnalysisOrchestrator
     from src.daemon.degradation import DegradationContext
     from src.daemon.event_bus import EventBus
     from src.daemon.factory import DaemonComponents
     from src.di.container import AppContainer
-    from src.strategies.session import TradingSession
     from src.workflows import TradingWorkflow
 
 console = Console()
@@ -116,40 +113,6 @@ class DaemonRunner:
 
         return self._factory.init_coordinator(self._components)
 
-    async def _run_coordinator_cycle(
-        self,
-        watchlist: list[str],
-        degradation_context: DegradationContext,
-        trading_session: TradingSession,
-    ) -> CoordinatorCycleResult:
-        """Run coordinator-driven cycle.
-
-        Args:
-            watchlist: Symbols to analyze
-            degradation_context: Degradation context for cycle
-            trading_session: Trading session type (REGULAR or PRE_MARKET)
-
-        Returns:
-            CoordinatorCycleResult from coordinator
-        """
-        from src.daemon.degradation import AgentType, DegradationTier
-
-        coordinator = self._init_coordinator()
-
-        # Convert DegradationContext to dict for coordinator API
-        degradation_dict = None
-        if degradation_context.tier != DegradationTier.NONE:
-            degradation_dict = {
-                "tier": degradation_context.tier.value,
-                "unavailable_services": degradation_context.unavailable_services,
-                "confidence_adjustment": degradation_context.confidence_adjustment,
-                "disabled_agents": [
-                    str(agent) for agent in AgentType if agent not in degradation_context.available_agents
-                ],
-            }
-
-        return await coordinator.run_cycle(watchlist, degradation_dict, trading_session)
-
     def _init_analysis_orchestrator(self) -> AnalysisOrchestrator:
         """Initialize analysis orchestrator (lazy)."""
         if self._components.analysis_orchestrator is None:
@@ -184,29 +147,6 @@ class DaemonRunner:
         """Get watchlist merged with broker positions and screening candidates."""
         return await self._broker_manager.get_merged_watchlist()
 
-    async def _analyze_watchlist(
-        self,
-        watchlist: list[str],
-        degradation_context: DegradationContext | None = None,
-    ) -> list[TradingWorkflowResult]:
-        """Analyze all symbols in watchlist (delegates to orchestrator)."""
-        # Build target allocations from last rebalancing (if recent)
-        # NOTE: Requires async state access after JSON elimination
-        # TODO: Implement using await self.state.get_active_target_allocations()
-        target_allocations = None
-
-        # Delegate to orchestrator
-        orchestrator = self._init_analysis_orchestrator()
-        result = await orchestrator.orchestrate(watchlist, target_allocations, degradation_context)
-
-        logger.info(
-            f"Orchestration complete: {result.successful}/{result.total_symbols} successful, "
-            f"{result.failed} failed, {result.position_actions} position actions, "
-            f"{result.duration_seconds:.2f}s"
-        )
-
-        return result.results
-
     async def _analyze_symbol(
         self,
         symbol: str,
@@ -235,26 +175,6 @@ class DaemonRunner:
         except Exception as e:
             logger.opt(exception=True).error(f"Failed to publish {event_type} event: {e}")
 
-    def _evaluate_degradation(self) -> DegradationContext:
-        """Load latest health report and evaluate degradation tier."""
-        from src.daemon.degradation import DegradationPolicy
-        from src.daemon.health import HealthReport
-
-        # Load latest health report
-        health_report = None
-        health_dir = Path(self.config.health.health_dir).expanduser()
-        if health_dir.exists():
-            report_files = sorted(health_dir.glob("health-*.json"), reverse=True)
-            if report_files:
-                try:
-                    with report_files[0].open() as f:
-                        health_report = HealthReport.model_validate(json.load(f))
-                except Exception as e:
-                    logger.opt(exception=True).warning(f"Failed to load health report: {e}")
-
-        policy = DegradationPolicy(self.config)
-        return policy.evaluate_degradation(health_report)
-
     async def _run_cycle(self) -> int:
         """Run a single analysis cycle (delegates to cycle orchestrator).
 
@@ -273,7 +193,7 @@ class DaemonRunner:
         cycle_orchestrator = DaemonCycleOrchestrator(
             components=self._components,
             task_runner=self._task_runner,
-            runner=self,
+            factory=self._factory,
             profiler=profiler,
         )
 
@@ -306,7 +226,7 @@ class DaemonRunner:
         cycle_orchestrator = DaemonCycleOrchestrator(
             components=self._components,
             task_runner=self._task_runner,
-            runner=self,
+            factory=self._factory,
             profiler=profiler,
         )
 

--- a/src/daemon/state/__init__.py
+++ b/src/daemon/state/__init__.py
@@ -21,26 +21,6 @@ from src.daemon.state.models import (
     SectorRotationRecord,
 )
 
-
-def _rebuild_daemon_state_model() -> None:
-    """Rebuild DaemonState model to resolve forward references.
-
-    Must happen after ExecutionGraphTracker is defined (in src.execution_tracking.tracker).
-    """
-    try:
-        from src.execution_tracking.models import ExecutionGraph
-        from src.execution_tracking.tracker import ExecutionGraphTracker
-
-        # Import triggers rebuild - ExecutionGraphTracker and ExecutionGraph are now available
-        if ExecutionGraphTracker and ExecutionGraph:
-            DaemonState.model_rebuild()
-    except ImportError:
-        # ExecutionGraphTracker/ExecutionGraph not yet available during import ordering
-        pass
-
-
-_rebuild_daemon_state_model()
-
 __all__ = [
     "AnalysisRecord",
     "CorrelationAuditRecord",

--- a/src/data/universe.py
+++ b/src/data/universe.py
@@ -321,9 +321,6 @@ class StockUniverseFetcher:
         Returns:
             StockUniverse with filtered stocks (~500-1500 depending on filters)
         """
-        # Import here to avoid circular dependency
-        from src.daemon.config import LiquidityFilterConfig  # noqa: F401
-
         # Generate cache key from filter config hash
         filter_hash = hashlib.sha256(
             f"{filters.min_market_cap}_{filters.min_avg_volume}_{filters.price_range}".encode()

--- a/tests/test_daemon/test_cycle_orchestrator.py
+++ b/tests/test_daemon/test_cycle_orchestrator.py
@@ -9,7 +9,7 @@ from src.coordinator.models import CoordinatorCycleResult
 from src.daemon.config import DaemonConfig
 from src.daemon.cycle_orchestrator import CycleResult, DaemonCycleOrchestrator
 from src.daemon.degradation import DegradationContext, DegradationTier
-from src.daemon.runner import DaemonRunner
+from src.daemon.factory import DaemonFactory
 from src.strategies.session import TradingSession
 
 pytestmark = pytest.mark.skip(reason="Cycle orchestrator tests need rewrite for async state")
@@ -95,12 +95,12 @@ async def test_coordinator_routing_when_enabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test that cycle orchestrator routes to coordinator when enabled."""
-    runner = DaemonRunner(sample_config_coordinator_enabled)
+    factory = DaemonFactory(sample_config_coordinator_enabled)
+    components = factory.create_components()
 
     # Mock market hours check
-    monkeypatch.setattr(runner.scheduler, "is_market_open", lambda: True)
-    monkeypatch.setattr(runner._task_runner, "run_scheduled_tasks", AsyncMock())
-    monkeypatch.setattr(runner, "_evaluate_degradation", lambda: mock_degradation_context)
+    monkeypatch.setattr(components.scheduler, "is_market_open", lambda: True)
+    monkeypatch.setattr(components.task_runner, "run_scheduled_tasks", AsyncMock())
 
     # Mock coordinator cycle to return successful result
     mock_coordinator_result = CoordinatorCycleResult(
@@ -112,22 +112,23 @@ async def test_coordinator_routing_when_enabled(
         game_plan_generated=True,
     )
 
-    mock_run_coordinator_cycle = AsyncMock(return_value=mock_coordinator_result)
-    monkeypatch.setattr(runner, "_run_coordinator_cycle", mock_run_coordinator_cycle)
-
-    # Create orchestrator and run cycle
+    # Create orchestrator and mock its methods
     orchestrator = DaemonCycleOrchestrator(
-        components=runner._components,
-        task_runner=runner._task_runner,
-        runner=runner,
+        components=components,
+        task_runner=components.task_runner,
+        factory=factory,
         profiler=None,
     )
+
+    monkeypatch.setattr(orchestrator, "_evaluate_degradation", lambda: mock_degradation_context)
+    mock_run_coordinator = AsyncMock(return_value=mock_coordinator_result)
+    monkeypatch.setattr(orchestrator, "_run_coordinator_cycle_impl", mock_run_coordinator)
 
     result = await orchestrator.run_cycle()
 
     # Verify coordinator was called
-    mock_run_coordinator_cycle.assert_called_once()
-    call_args = mock_run_coordinator_cycle.call_args
+    mock_run_coordinator.assert_called_once()
+    call_args = mock_run_coordinator.call_args
     assert call_args[0][0] == ["TSLA", "MSFT"]  # watchlist
     assert call_args[0][1] == mock_degradation_context
     assert isinstance(call_args[0][2], TradingSession)
@@ -145,33 +146,35 @@ async def test_coordinator_routing_when_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test that cycle orchestrator uses legacy cycle when coordinator disabled."""
-    runner = DaemonRunner(sample_config_coordinator_disabled)
+    factory = DaemonFactory(sample_config_coordinator_disabled)
+    components = factory.create_components()
 
     # Mock market hours check
-    monkeypatch.setattr(runner.scheduler, "is_market_open", lambda: True)
-    monkeypatch.setattr(runner._task_runner, "run_scheduled_tasks", AsyncMock())
-    monkeypatch.setattr(runner, "_evaluate_degradation", lambda: mock_degradation_context)
+    monkeypatch.setattr(components.scheduler, "is_market_open", lambda: True)
+    monkeypatch.setattr(components.task_runner, "run_scheduled_tasks", AsyncMock())
+
+    # Create orchestrator and mock its methods
+    orchestrator = DaemonCycleOrchestrator(
+        components=components,
+        task_runner=components.task_runner,
+        factory=factory,
+        profiler=None,
+    )
+
+    monkeypatch.setattr(orchestrator, "_evaluate_degradation", lambda: mock_degradation_context)
 
     # Mock legacy cycle
     mock_analyze_watchlist = AsyncMock(return_value=[])
-    monkeypatch.setattr(runner, "_analyze_watchlist", mock_analyze_watchlist)
+    monkeypatch.setattr(orchestrator, "_analyze_watchlist", mock_analyze_watchlist)
 
     # Ensure coordinator is NOT called
-    mock_run_coordinator_cycle = AsyncMock()
-    monkeypatch.setattr(runner, "_run_coordinator_cycle", mock_run_coordinator_cycle)
-
-    # Create orchestrator and run cycle
-    orchestrator = DaemonCycleOrchestrator(
-        components=runner._components,
-        task_runner=runner._task_runner,
-        runner=runner,
-        profiler=None,
-    )
+    mock_run_coordinator = AsyncMock()
+    monkeypatch.setattr(orchestrator, "_run_coordinator_cycle_impl", mock_run_coordinator)
 
     result = await orchestrator.run_cycle()
 
     # Verify coordinator was NOT called
-    mock_run_coordinator_cycle.assert_not_called()
+    mock_run_coordinator.assert_not_called()
 
     # Verify legacy cycle was used
     mock_analyze_watchlist.assert_called_once()
@@ -187,33 +190,35 @@ async def test_coordinator_fallback_on_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test that coordinator failures fall back to legacy cycle."""
-    runner = DaemonRunner(sample_config_coordinator_enabled)
+    factory = DaemonFactory(sample_config_coordinator_enabled)
+    components = factory.create_components()
 
     # Mock market hours check
-    monkeypatch.setattr(runner.scheduler, "is_market_open", lambda: True)
-    monkeypatch.setattr(runner._task_runner, "run_scheduled_tasks", AsyncMock())
-    monkeypatch.setattr(runner, "_evaluate_degradation", lambda: mock_degradation_context)
+    monkeypatch.setattr(components.scheduler, "is_market_open", lambda: True)
+    monkeypatch.setattr(components.task_runner, "run_scheduled_tasks", AsyncMock())
+
+    # Create orchestrator and mock its methods
+    orchestrator = DaemonCycleOrchestrator(
+        components=components,
+        task_runner=components.task_runner,
+        factory=factory,
+        profiler=None,
+    )
+
+    monkeypatch.setattr(orchestrator, "_evaluate_degradation", lambda: mock_degradation_context)
 
     # Mock coordinator to raise exception
-    mock_run_coordinator_cycle = AsyncMock(side_effect=RuntimeError("Coordinator init failed"))
-    monkeypatch.setattr(runner, "_run_coordinator_cycle", mock_run_coordinator_cycle)
+    mock_run_coordinator = AsyncMock(side_effect=RuntimeError("Coordinator init failed"))
+    monkeypatch.setattr(orchestrator, "_run_coordinator_cycle_impl", mock_run_coordinator)
 
     # Mock legacy cycle
     mock_analyze_watchlist = AsyncMock(return_value=[])
-    monkeypatch.setattr(runner, "_analyze_watchlist", mock_analyze_watchlist)
-
-    # Create orchestrator and run cycle
-    orchestrator = DaemonCycleOrchestrator(
-        components=runner._components,
-        task_runner=runner._task_runner,
-        runner=runner,
-        profiler=None,
-    )
+    monkeypatch.setattr(orchestrator, "_analyze_watchlist", mock_analyze_watchlist)
 
     result = await orchestrator.run_cycle()
 
     # Verify coordinator was attempted
-    mock_run_coordinator_cycle.assert_called_once()
+    mock_run_coordinator.assert_called_once()
 
     # Verify fallback to legacy cycle occurred
     mock_analyze_watchlist.assert_called_once()
@@ -230,16 +235,12 @@ async def test_coordinator_fallback_on_various_exceptions(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test that all exception types trigger fallback, not just ValueError."""
-    runner = DaemonRunner(sample_config_coordinator_enabled)
+    factory = DaemonFactory(sample_config_coordinator_enabled)
+    components = factory.create_components()
 
     # Mock market hours check
-    monkeypatch.setattr(runner.scheduler, "is_market_open", lambda: True)
-    monkeypatch.setattr(runner._task_runner, "run_scheduled_tasks", AsyncMock())
-    monkeypatch.setattr(runner, "_evaluate_degradation", lambda: mock_degradation_context)
-
-    # Mock legacy cycle
-    mock_analyze_watchlist = AsyncMock(return_value=[])
-    monkeypatch.setattr(runner, "_analyze_watchlist", mock_analyze_watchlist)
+    monkeypatch.setattr(components.scheduler, "is_market_open", lambda: True)
+    monkeypatch.setattr(components.task_runner, "run_scheduled_tasks", AsyncMock())
 
     # Test different exception types
     exception_types = [
@@ -250,20 +251,23 @@ async def test_coordinator_fallback_on_various_exceptions(
     ]
 
     for exc in exception_types:
-        # Reset mocks
-        mock_analyze_watchlist.reset_mock()
-
-        # Mock coordinator to raise specific exception
-        mock_run_coordinator_cycle = AsyncMock(side_effect=exc)
-        monkeypatch.setattr(runner, "_run_coordinator_cycle", mock_run_coordinator_cycle)
-
-        # Create orchestrator and run cycle
+        # Create orchestrator and mock its methods
         orchestrator = DaemonCycleOrchestrator(
-            components=runner._components,
-            task_runner=runner._task_runner,
-            runner=runner,
+            components=components,
+            task_runner=components.task_runner,
+            factory=factory,
             profiler=None,
         )
+
+        monkeypatch.setattr(orchestrator, "_evaluate_degradation", lambda: mock_degradation_context)
+
+        # Mock coordinator to raise specific exception
+        mock_run_coordinator = AsyncMock(side_effect=exc)
+        monkeypatch.setattr(orchestrator, "_run_coordinator_cycle_impl", mock_run_coordinator)
+
+        # Mock legacy cycle
+        mock_analyze_watchlist = AsyncMock(return_value=[])
+        monkeypatch.setattr(orchestrator, "_analyze_watchlist", mock_analyze_watchlist)
 
         result = await orchestrator.run_cycle()
 

--- a/tests/test_daemon/test_runner_degradation.py
+++ b/tests/test_daemon/test_runner_degradation.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from src.daemon.config import DaemonConfig
+from src.daemon.cycle_orchestrator import DaemonCycleOrchestrator
 from src.daemon.degradation import DegradationTier
 from src.daemon.health import HealthReport, ServiceCheckResult, ServiceStatus
 from src.daemon.runner import DaemonRunner
@@ -84,7 +85,7 @@ async def test_daemon_halts_on_alpha_vantage_down(daemon_config_with_health, tem
     # Mock to avoid overwriting fake report and analyzing
     with (
         patch.object(runner._task_runner, "run_scheduled_tasks", new_callable=AsyncMock),
-        patch.object(runner, "_analyze_watchlist", new_callable=AsyncMock) as mock_analyze,
+        patch.object(DaemonCycleOrchestrator, "_analyze_watchlist", new_callable=AsyncMock) as mock_analyze,
     ):
         sleep_time = await runner._run_cycle()
 
@@ -127,7 +128,7 @@ async def test_daemon_halts_on_llm_down(daemon_config_with_health, temp_health_d
 
     with (
         patch.object(runner._task_runner, "run_scheduled_tasks", new_callable=AsyncMock),
-        patch.object(runner, "_analyze_watchlist", new_callable=AsyncMock) as mock_analyze,
+        patch.object(DaemonCycleOrchestrator, "_analyze_watchlist", new_callable=AsyncMock) as mock_analyze,
     ):
         sleep_time = await runner._run_cycle()
 
@@ -175,7 +176,7 @@ async def test_daemon_continues_in_degraded_mode(daemon_config_with_health, temp
 
     with (
         patch.object(runner._task_runner, "run_scheduled_tasks", new_callable=AsyncMock),
-        patch.object(runner, "_analyze_watchlist", new_callable=AsyncMock) as mock_analyze,
+        patch.object(DaemonCycleOrchestrator, "_analyze_watchlist", new_callable=AsyncMock) as mock_analyze,
     ):
         mock_analyze.return_value = []
 
@@ -222,16 +223,15 @@ async def test_notification_sent_on_degradation(daemon_config_with_health, temp_
 
     runner = DaemonRunner(daemon_config_with_health)
 
-    # Mock notification service (both on components and runner property)
+    # Mock notification service on components
     # Cycle orchestrator checks components.notification_service
-    # _notify_degradation checks runner.notification_service
     mock_notification_service = AsyncMock()
     runner._components.notification_service = mock_notification_service
     runner.notification_service = mock_notification_service
 
     with (
         patch.object(runner._task_runner, "run_scheduled_tasks", new_callable=AsyncMock),
-        patch.object(runner, "_analyze_watchlist", new_callable=AsyncMock) as mock_analyze,
+        patch.object(DaemonCycleOrchestrator, "_analyze_watchlist", new_callable=AsyncMock) as mock_analyze,
     ):
         mock_analyze.return_value = []
 
@@ -278,7 +278,7 @@ async def test_no_degradation_when_all_healthy(daemon_config_with_health, temp_h
 
     with (
         patch.object(runner._task_runner, "run_scheduled_tasks", new_callable=AsyncMock),
-        patch.object(runner, "_analyze_watchlist", new_callable=AsyncMock) as mock_analyze,
+        patch.object(DaemonCycleOrchestrator, "_analyze_watchlist", new_callable=AsyncMock) as mock_analyze,
     ):
         mock_analyze.return_value = []
 


### PR DESCRIPTION
## Motivation

3 circular dependency issues: `cycle_orchestrator` ↔ `runner` (untyped `runner: object` with `type: ignore`), dead `_rebuild_daemon_state_model` hack in `state/__init__`, dead runtime import in `universe.py`.

## Implementation information

**Issue 1 (HIGH): `cycle_orchestrator` ↔ `runner`**
- Replace `runner: object` with `factory: DaemonFactory` in `DaemonCycleOrchestrator.__init__`
- Move `_evaluate_degradation`, `_run_coordinator_cycle`, `_analyze_watchlist` from `runner.py` into `cycle_orchestrator.py`
- Remove all `self.runner.*` calls and their `type: ignore` / `noqa: SLF001` suppressions
- Update `runner.py` to pass `factory=self._factory` when constructing orchestrator
- Net: -22 lines, 0 `type: ignore` for runner access

**Issue 2 (MEDIUM): `state/__init__.py` model rebuild hack**
- Delete `_rebuild_daemon_state_model()` — defensive code for a circular dep that doesn't exist (verified imports are clean)

**Issue 3 (LOW): `universe.py` dead import**
- Delete runtime `from src.daemon.config import LiquidityFilterConfig` — already imported under `TYPE_CHECKING`

**Tests:** Both `test_cycle_orchestrator.py` and `test_runner_degradation.py` updated to use `factory`/`DaemonFactory` instead of `runner`/`DaemonRunner` (both remain skipped pending async state rewrite).

> Changelog: refactor(daemon): remove circular deps