### PR TITLE
build(docker): optimize layer caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build stage - install build tools and compile dependencies
 FROM python:3.14.3-slim AS builder
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build stage
 FROM node:24-alpine AS builder
 

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Development Dockerfile for Svelte frontend with HMR
 FROM node:24-alpine
 

--- a/services/finbert/Dockerfile
+++ b/services/finbert/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Multi-stage build for CPU-optimized FinBERT service
 FROM python:3.14-slim AS builder
 

--- a/services/finbert/Dockerfile.gpu
+++ b/services/finbert/Dockerfile.gpu
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Multi-stage build for GPU-optimized FinBERT service
 FROM nvidia/cuda:13.1.1-runtime-ubuntu22.04 AS builder
 


### PR DESCRIPTION
## Motivation

Docker images rebuild all deps on every src change, and playwright
(~130MB) reinstalls unnecessarily on src changes.

## Implementation information

**Root Dockerfile:**
- Builder: add `--no-install-project` to `uv sync` and move `COPY src`
  after it — deps layer is now cached independently of source changes
- Runtime: move playwright install before `COPY src` — src changes no
  longer trigger browser reinstall
- Both stages: `--mount=type=cache` for apt and uv

**finbert/Dockerfile + Dockerfile.gpu:**
- `--mount=type=cache,target=/root/.cache/pip` for pip
- Removed `--no-cache-dir` (counterproductive with BuildKit cache)
- apt cache mounts in both stages

**frontend/Dockerfile + Dockerfile.dev:**
- `--mount=type=cache,target=/root/.npm` for npm

> Changelog: build(docker): optimize layer caching