### PR TITLE
feat(coordinator): switch to workflow_meta

### DIFF
--- a/src/coordinator/tools/analyze.py
+++ b/src/coordinator/tools/analyze.py
@@ -186,7 +186,7 @@ class AnalyzeSymbolTool(BaseTool):
             Formatted analysis summary
         """
         # Create workflow from container
-        workflow = self._container.workflow_momentum(container=self._container)
+        workflow = self._container.workflow_meta(container=self._container)
 
         # Get position context if requested
         position_ctx = None


### PR DESCRIPTION
## Motivation

`analyze_symbol` tool was using `workflow_momentum` (basic pipeline, no meta-agent, no supervisor routing) instead of `workflow_meta` (full supervisor + meta-agent + regime detection), degrading coordinator analyses vs the legacy pipeline.

## Implementation information

Single-line change in `src/coordinator/tools/analyze.py`: swap `workflow_momentum` for `workflow_meta` in `_run_analysis`.

## Supporting documentation

Fix: #790