### PR TITLE
fix(supervisor): raise astructured max_tokens

### DIFF
--- a/src/agents/supervisor/agent.py
+++ b/src/agents/supervisor/agent.py
@@ -111,7 +111,7 @@ class TradingSupervisor:
 
         try:
             decision = await self.llm.astructured(
-                prompt, AnalysisRoutingDecision, system=system, temperature=0.4, max_tokens=512
+                prompt, AnalysisRoutingDecision, system=system, temperature=0.4, max_tokens=4096
             )
         except StructuredOutputError as e:
             logger.opt(exception=True).warning(f"Structured output failed, using default: {e}")
@@ -213,7 +213,7 @@ class TradingSupervisor:
 
         try:
             weights = await self.llm.astructured(
-                prompt, AnalysisWeights, system=system, temperature=0.4, max_tokens=512
+                prompt, AnalysisWeights, system=system, temperature=0.4, max_tokens=4096
             )
         except StructuredOutputError as e:
             logger.opt(exception=True).warning(f"Structured output failed, uniform weights: {e}")


### PR DESCRIPTION
## Motivation

`AnalysisRoutingDecision` and `AnalysisWeights` structured output calls had `max_tokens=512`. Observed responses reaching ~13822 chars (~3500 tokens), causing `StructuredOutputError` on every cycle and falling back to default routing.

## Implementation information

Raised `max_tokens` from 512 to 4096 for both `plan_analyses` and synthesis `astructured` calls in `TradingSupervisor`. 4096 provides headroom over the observed ~3500 token responses.

> Changelog: fix(supervisor): raise astructured max_tokens