### PR TITLE
feat(coordinator): inject context into prompts

### DIFF
--- a/src/coordinator/agent.py
+++ b/src/coordinator/agent.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from src.coordinator.event_prompt import EventCycleContext, EventCyclePromptBuilder, extract_symbols
-from src.coordinator.memory import CoordinatorMemory
+from src.coordinator.memory import CoordinatorMemory, DecisionQueryParams
 from src.coordinator.models import EVENT_CYCLE_TYPE, CoordinatorConfig, CoordinatorCycleResult
 from src.models.llm import LLMClient
 from src.prompts import PromptLoader
@@ -249,8 +249,7 @@ class TradingCoordinator:
             )
 
             positions_summary = await self._get_positions_summary()
-            has_signal_event = any(ev.event_type == "signal" for ev in events)
-            game_plan = await self._memory.get_today_game_plan(max_tokens=500) if has_signal_event else ""
+            game_plan = await self._memory.get_today_game_plan(max_tokens=500)
             prompt_builder = EventCyclePromptBuilder()
             user_prompt = prompt_builder.build(
                 events=events,
@@ -387,6 +386,7 @@ class TradingCoordinator:
             Formatted cycle prompt
         """
         positions_summary = await self._get_positions_summary()
+        recent_outcomes_section = await self._get_recent_outcomes_summary()
         current_date = datetime.now(UTC).strftime("%Y-%m-%d")
         session_name = trading_session.value
 
@@ -395,6 +395,7 @@ class TradingCoordinator:
             watchlist=", ".join(watchlist),
             last_summary=self._last_cycle_summary,
             positions_summary=positions_summary,
+            recent_outcomes_section=recent_outcomes_section,
             date=current_date,
             session=session_name,
             min_confidence_to_trade=self._config.min_confidence_to_trade,
@@ -565,6 +566,39 @@ class TradingCoordinator:
         except Exception as e:
             logger.opt(exception=True).warning(f"Failed to get positions summary: {e}")
             return "Positions data unavailable"
+
+    async def _get_recent_outcomes_summary(self, lookback_days: int = 7, limit: int = 10) -> str:
+        """Get recent trade outcomes for cycle prompt context.
+
+        Args:
+            lookback_days: Days to look back for outcomes
+            limit: Maximum number of outcomes to include
+
+        Returns:
+            Formatted outcomes summary or empty string
+        """
+        try:
+            decisions = await self._memory.query_decisions(
+                DecisionQueryParams(lookback_days=lookback_days, limit=limit)
+            )
+            if not decisions:
+                return ""
+
+            lines = ["## Recent Trade Outcomes (Last 7 Days)\n"]
+            hits = sum(1 for d in decisions if d.hit_miss == "HIT")
+            misses = sum(1 for d in decisions if d.hit_miss == "MISS")
+            total_decided = hits + misses
+            rate = f"{hits}/{total_decided} ({hits / total_decided:.0%})" if total_decided else "N/A"
+            lines.append(f"**Success Rate:** {rate}\n")
+
+            for d in decisions:
+                ret = f"{d.return_pct:+.1f}%" if d.return_pct is not None else "pending"
+                lines.append(f"- {d.symbol} {d.signal} {d.confidence:.0%} → {d.hit_miss} ({ret})")
+
+            return "\n".join(lines)
+        except Exception as e:
+            logger.opt(exception=True).warning(f"Failed to get recent outcomes: {e}")
+            return ""
 
     def _format_risk_limits(self) -> str:
         """Format risk limits from config as markdown.

--- a/src/coordinator/event_prompt.py
+++ b/src/coordinator/event_prompt.py
@@ -54,6 +54,8 @@ class EventCyclePromptBuilder:
             f"min confidence {config.min_confidence_to_trade:.0%}"
         )
 
+        game_plan_section = f"**Today's Game Plan:**\n{context.game_plan}" if context.game_plan else ""
+
         header = self._prompts.load(
             "event_header",
             date=datetime.now(UTC).strftime("%Y-%m-%d"),
@@ -62,6 +64,7 @@ class EventCyclePromptBuilder:
             symbols=", ".join(sorted(symbols)) if symbols else "None extracted",
             positions_summary=context.positions_summary,
             risk_limits=risk_limits,
+            game_plan_section=game_plan_section,
             event_count=len(events),
         )
 

--- a/src/prompts/coordinator/cycle.txt
+++ b/src/prompts/coordinator/cycle.txt
@@ -5,6 +5,8 @@
 **Current Positions:**
 {positions_summary}
 
+{recent_outcomes_section}
+
 **Last Cycle Summary:**
 {last_summary}
 

--- a/src/prompts/coordinator/events/anomaly.txt
+++ b/src/prompts/coordinator/events/anomaly.txt
@@ -11,3 +11,4 @@
 3. Use `analyze_symbol` to validate the signal with full technical + sentiment pipeline
 4. If market is closed, save observations — do NOT execute trades
 5. Gaps and volume spikes early in session are higher-signal than late-day moves
+6. Check if anomaly symbol aligns with game plan priorities

--- a/src/prompts/coordinator/events/event_header.txt
+++ b/src/prompts/coordinator/events/event_header.txt
@@ -7,6 +7,8 @@
 **Current Positions:**
 {positions_summary}
 
+{game_plan_section}
+
 {risk_limits}
 
 ---

--- a/src/prompts/coordinator/events/filing.txt
+++ b/src/prompts/coordinator/events/filing.txt
@@ -11,3 +11,4 @@
 3. Cross-reference with current positions — filing may change thesis
 4. If market is closed, save observations — do NOT execute trades
 5. Prioritize 8-K filings and large insider transactions
+6. Check if filing changes thesis for game plan priority symbols

--- a/src/prompts/coordinator/events/news.txt
+++ b/src/prompts/coordinator/events/news.txt
@@ -11,3 +11,4 @@
 3. Cross-reference with existing positions and recent analysis history
 4. If market is closed, save observations for next open — do NOT execute trades
 5. Focus on whether this news changes the fundamental thesis for any position
+6. Check if this catalyst aligns with today's game plan priorities

--- a/src/prompts/coordinator/events/news_trending.txt
+++ b/src/prompts/coordinator/events/news_trending.txt
@@ -11,3 +11,4 @@
 3. Check if trending correlates with price movement or is news-only noise
 4. If market is closed, save observations — do NOT execute trades
 5. High mention counts without price confirmation may indicate noise
+6. Check if trending symbol aligns with game plan priorities

--- a/src/prompts/coordinator/events/signal.txt
+++ b/src/prompts/coordinator/events/signal.txt
@@ -5,9 +5,6 @@
 **Triage:** urgency={urgency}, sentiment={sentiment}, confidence={confidence:.0%}
 **Reasoning:** {reasoning}
 
-**Today's Game Plan:**
-{game_plan}
-
 **Instructions:**
 1. This signal was generated during pre-market and deferred for regular session execution
 2. Check the game plan above — does this symbol align with today's priority symbols and risk stance?

--- a/src/prompts/coordinator/events/social.txt
+++ b/src/prompts/coordinator/events/social.txt
@@ -11,3 +11,4 @@
 3. Use `analyze_symbol` only if volume spike is confirmed by price action
 4. If market is closed, save observations — do NOT execute trades
 5. Be skeptical of meme-driven momentum without fundamental backing
+6. Check if social buzz aligns with game plan priorities

--- a/src/prompts/coordinator/events/trump.txt
+++ b/src/prompts/coordinator/events/trump.txt
@@ -11,3 +11,4 @@
 3. Use `analyze_symbol` if a specific stock or sector is clearly targeted
 4. If market is closed, save observations — do NOT execute trades
 5. Trump posts can move markets rapidly — act quickly if during market hours
+6. Check if affected sectors align with game plan sector focus

--- a/src/prompts/coordinator/system.txt
+++ b/src/prompts/coordinator/system.txt
@@ -45,6 +45,7 @@ Your mandate is to orchestrate systematic workflow execution by leveraging avail
 
 **Memory:**
 - `save_observation`: Persist learning insights (market patterns, errors, successes)
+- `query_past_decisions`: Query past BUY/SELL decisions with hit/miss outcomes and success rate (use before trading to check historical accuracy)
 
 **Research:**
 - `web_search`: Search web for breaking news, event investigation, company details

--- a/tests/test_coordinator/test_agent.py
+++ b/tests/test_coordinator/test_agent.py
@@ -62,6 +62,7 @@ def mock_memory():
             "- **Total Exposure**: $0.00 (0.0%)"
         )
     )
+    mock.query_decisions = AsyncMock(return_value=[])
     return mock
 
 
@@ -435,6 +436,64 @@ async def test_build_cycle_prompt_includes_date_and_session(coordinator):
     prompt = await coordinator._build_cycle_prompt(["AAPL", "TSLA"], TradingSession.PRE_MARKET)
     assert "PRE_MARKET" in prompt
     assert datetime.now(UTC).strftime("%Y-%m-%d") in prompt
+
+
+@pytest.mark.asyncio
+async def test_get_recent_outcomes_summary_empty(coordinator, mock_memory):
+    """Test outcomes summary with no decisions."""
+    mock_memory.query_decisions.return_value = []
+    result = await coordinator._get_recent_outcomes_summary()
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_get_recent_outcomes_summary_with_decisions(coordinator, mock_memory):
+    """Test outcomes summary with decisions."""
+    from src.coordinator.decision_models import DecisionQueryResult
+
+    mock_memory.query_decisions.return_value = [
+        DecisionQueryResult(
+            symbol="AAPL",
+            timestamp=datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC),
+            signal="BUY",
+            confidence=0.8,
+            price_at_signal=150.0,
+            price_at_outcome=160.0,
+            return_pct=6.7,
+            hit_miss="HIT",
+            regime="bullish",
+            strategy_used="momentum",
+            trading_session="REGULAR",
+        ),
+        DecisionQueryResult(
+            symbol="TSLA",
+            timestamp=datetime(2024, 1, 2, 12, 0, 0, tzinfo=UTC),
+            signal="BUY",
+            confidence=0.7,
+            price_at_signal=200.0,
+            price_at_outcome=190.0,
+            return_pct=-5.0,
+            hit_miss="MISS",
+            regime="bullish",
+            strategy_used="momentum",
+            trading_session="REGULAR",
+        ),
+    ]
+
+    result = await coordinator._get_recent_outcomes_summary()
+
+    assert "Recent Trade Outcomes" in result
+    assert "1/2 (50%)" in result
+    assert "AAPL BUY 80% → HIT (+6.7%)" in result
+    assert "TSLA BUY 70% → MISS (-5.0%)" in result
+
+
+@pytest.mark.asyncio
+async def test_get_recent_outcomes_summary_error(coordinator, mock_memory):
+    """Test outcomes summary gracefully handles errors."""
+    mock_memory.query_decisions.side_effect = RuntimeError("DB error")
+    result = await coordinator._get_recent_outcomes_summary()
+    assert result == ""
 
 
 def test_repr(coordinator):

--- a/tests/test_coordinator/test_agent_event_cycle.py
+++ b/tests/test_coordinator/test_agent_event_cycle.py
@@ -78,6 +78,7 @@ def mock_memory() -> AsyncMock:
     mock.get_today_summary = AsyncMock(return_value="No analyses today")
     mock.get_today_game_plan = AsyncMock(return_value="Game plan unavailable")
     mock.get_portfolio_summary = AsyncMock(return_value="No portfolio data")
+    mock.query_decisions = AsyncMock(return_value=[])
     return mock
 
 

--- a/tests/test_coordinator/test_event_prompt.py
+++ b/tests/test_coordinator/test_event_prompt.py
@@ -164,14 +164,26 @@ class TestEventCyclePromptBuilder:
         assert game_plan in prompt
         assert "Pre-Market Signal Event" in prompt
 
-    def test_non_signal_event_game_plan_ignored(
+    def test_game_plan_in_header_for_all_events(
+        self, builder: EventCyclePromptBuilder, config: CoordinatorConfig
+    ) -> None:
+        events = [_make_event(event_type="news")]
+        game_plan = "Priority: AAPL | Risk: NEUTRAL | Sector: Tech"
+        prompt = builder.build(
+            events=events,
+            context=_ctx(market_open=True, game_plan=game_plan),
+            config=config,
+        )
+        assert game_plan in prompt
+        assert "Today's Game Plan" in prompt
+
+    def test_empty_game_plan_omitted_from_header(
         self, builder: EventCyclePromptBuilder, config: CoordinatorConfig
     ) -> None:
         events = [_make_event(event_type="news")]
         prompt = builder.build(
             events=events,
-            context=_ctx(market_open=True, game_plan="some game plan text"),
+            context=_ctx(market_open=True, game_plan=""),
             config=config,
         )
-        # game_plan passed but news.txt doesn't use it — no error, extra kwarg silently ignored
-        assert len(prompt) > 100
+        assert "Today's Game Plan" not in prompt


### PR DESCRIPTION
## Motivation

Coordinator prompts lacked critical context for decision-making: game plan was only available to signal events, `query_past_decisions` tool was registered but undocumented (so LLM never called it), and cycle prompt had no visibility into recent trade outcomes.

## Implementation information

Three changes, all coordinator-only prompt injection:

**1. Game plan in event header (all event types)**
- Removed `has_signal_event` gate in `run_event_cycle()` — game plan always fetched
- Built `game_plan_section` in `EventCyclePromptBuilder.build()`, injected into `event_header.txt`
- Removed embedded `{game_plan}` from `signal.txt` (now in header)
- Added game plan alignment instruction to 6 event templates (news, anomaly, trump, social, filing, news_trending)
- `news_watchlist.txt` unchanged (light-touch, save observation only)

**2. Document `query_past_decisions` in system.txt**
- Added to Available Tools → Memory section so LLM knows it exists

**3. Recent trade outcomes in cycle prompt**
- New `_get_recent_outcomes_summary()` method queries last 7 days of decisions via `CoordinatorMemory.query_decisions()`
- Formats as concise list: symbol, signal, confidence, HIT/MISS, return%
- Injected into `cycle.txt` between positions and last summary
- Returns empty string gracefully on error or no data

> Changelog: feat(coordinator): inject context into prompts

## Supporting documentation

Based on prompt quality assessment in plan.