### PR TITLE
fix(workers): raise max_tokens for LLM calls

### DIFF
--- a/src/workers/comparative.py
+++ b/src/workers/comparative.py
@@ -64,7 +64,7 @@ class ComparativeWorker:
             # Try structured output with fallback
             try:
                 llm_response = await self.llm.astructured(
-                    user_prompt, ComparativeLLMResponse, system=system, temperature=0.5, max_tokens=512
+                    user_prompt, ComparativeLLMResponse, system=system, temperature=0.5, max_tokens=1024
                 )
                 interpretation = llm_response.interpretation
                 confidence = self._calculate_confidence_from_keywords(

--- a/src/workers/news.py
+++ b/src/workers/news.py
@@ -63,7 +63,7 @@ class NewsWorker:
         confidence = 0.6
         try:
             llm_response = await self.llm.astructured(
-                prompt, NewsLLMResponse, system=system_prompt, temperature=0.4, max_tokens=512
+                prompt, NewsLLMResponse, system=system_prompt, temperature=0.4, max_tokens=1024
             )
             key_themes = llm_response.key_themes
             impact = llm_response.impact_assessment

--- a/src/workers/technical.py
+++ b/src/workers/technical.py
@@ -121,14 +121,14 @@ class TechnicalWorker:
         # Try structured output with fallback
         try:
             llm_response = await self.llm_client.astructured(
-                prompt, TechnicalLLMResponse, system=system_prompt, temperature=0.3, max_tokens=512
+                prompt, TechnicalLLMResponse, system=system_prompt, temperature=0.3, max_tokens=2048
             )
             interpretation = llm_response.interpretation
             confidence_keywords = llm_response.confidence_keywords
         except StructuredOutputError as e:
             logger.opt(exception=True).warning(f"Structured output failed, falling back: {e}")
             interpretation = await self.llm_client.acomplete(
-                prompt, system=system_prompt, temperature=0.3, max_tokens=512
+                prompt, system=system_prompt, temperature=0.3, max_tokens=2048
             )
             confidence_keywords = []
 
@@ -188,7 +188,7 @@ class TechnicalWorker:
 
             try:
                 llm_response = await self.llm_client.astructured(
-                    prompt, TechnicalLLMResponse, system=system_prompt, temperature=0.3, max_tokens=512
+                    prompt, TechnicalLLMResponse, system=system_prompt, temperature=0.3, max_tokens=2048
                 )
                 interpretation = llm_response.interpretation
                 confidence_keywords = llm_response.confidence_keywords
@@ -197,7 +197,7 @@ class TechnicalWorker:
                     f"Structured output failed for {timeframe}, falling back: {e}"
                 )
                 interpretation = await self.llm_client.acomplete(
-                    prompt, system=system_prompt, temperature=0.3, max_tokens=512
+                    prompt, system=system_prompt, temperature=0.3, max_tokens=2048
                 )
                 confidence_keywords = []
 


### PR DESCRIPTION
## Motivation

Workers were getting `StructuredOutputError` due to LLM responses being cut off at the token limit. Observed in Docker logs: `TechnicalLLMResponse` truncated at column 70, `ComparativeLLMResponse` and `NewsLLMResponse` at risk of same. All three had `max_tokens=512` which is insufficient for structured JSON responses with interpretation fields.

## Implementation information

Increased `max_tokens` for three workers:
- `technical.py`: 512 → 2048 (both single-timeframe and multi-timeframe paths, including fallback `acomplete`)
- `comparative.py`: 512 → 1024
- `news.py`: 512 → 1024

Note: `column 3` failures in social/thesis workers are a separate Gemini schema compat issue (model returns near-empty content despite having budget) — not addressed here.

> Changelog: fix(workers): raise max_tokens for LLM calls