### PR TITLE
refactor(game-plan): remove file-based persistence

### DIFF
--- a/docs/daemon.yaml.example
+++ b/docs/daemon.yaml.example
@@ -373,8 +373,6 @@ daemon:
     enabled: false
     # Time to generate plan (HH:MM, 04:00-09:30 pre-market window)
     generation_time: "04:00"
-    # Output directory for game plans
-    plan_dir: "~/.ai-casino/game-plans"
     # Futures symbols to analyze for market sentiment
     futures_symbols: ["ES=F", "NQ=F"]
     # Hours of overnight news to analyze

--- a/src/agents/game_plan.py
+++ b/src/agents/game_plan.py
@@ -1,8 +1,6 @@
 """Game plan agent for next-day trading strategy."""
 
-import json
 from datetime import UTC, date, datetime, tzinfo
-from pathlib import Path
 from typing import Literal
 
 from loguru import logger
@@ -182,27 +180,6 @@ class GamePlanAgent:
         except Exception as e:
             logger.opt(exception=True).error(f"Game plan tool failed: {name} - {e}")
             return f"Error: {e!s}"
-
-    def persist(self, plan: GamePlan, plan_dir: str) -> Path:
-        """Persist game plan to JSON.
-
-        Args:
-            plan: GamePlan to save
-            plan_dir: Directory for plans
-
-        Returns:
-            Path to saved file
-        """
-        path = Path(plan_dir).expanduser()
-        path.mkdir(parents=True, exist_ok=True)
-
-        file_path = path / f"{plan.date}.json"
-
-        with file_path.open("w") as f:
-            json.dump(plan.model_dump(mode="json"), f, indent=2, default=str)
-
-        logger.info(f"Persisted game plan to {file_path}")
-        return file_path
 
     def __repr__(self) -> str:
         """String representation."""

--- a/src/daemon/analysis_orchestrator.py
+++ b/src/daemon/analysis_orchestrator.py
@@ -442,7 +442,7 @@ class AnalysisOrchestrator:
         sector_ctx, earnings_ctx, peer_ctx, game_plan_ctx = None, None, None, None
         context_builder = self._context_builder
         if context_builder:
-            sector_ctx, earnings_ctx, peer_ctx, game_plan_ctx = context_builder.build_analysis_contexts(
+            sector_ctx, earnings_ctx, peer_ctx, game_plan_ctx = await context_builder.build_analysis_contexts(
                 symbol
             )
 

--- a/src/daemon/config/portfolio.py
+++ b/src/daemon/config/portfolio.py
@@ -94,7 +94,6 @@ class GamePlanConfig(BaseModel):
 
     enabled: bool = False
     generation_time: str = "04:00"
-    plan_dir: str = "~/.ai-casino/game-plans"
     futures_symbols: list[str] = Field(default_factory=lambda: ["ES=F", "NQ=F"])
     lookback_hours: int = 16
 

--- a/src/daemon/context_builder.py
+++ b/src/daemon/context_builder.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-import json
 from datetime import datetime
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from loguru import logger
-
-from src.agents.game_plan import GamePlan
 
 if TYPE_CHECKING:
     from src.daemon.factory import DaemonComponents
@@ -38,7 +34,7 @@ class DaemonContextBuilder:
         """Return string representation."""
         return "DaemonContextBuilder()"
 
-    def build_analysis_contexts(
+    async def build_analysis_contexts(
         self,
         symbol: str,
     ) -> tuple[str | None, str | None, str | None, str | None]:
@@ -53,7 +49,7 @@ class DaemonContextBuilder:
         sector_ctx = self._build_sector_context()
         earnings_ctx = self._build_earnings_context(symbol)
         peer_ctx = self._build_peer_context(symbol)
-        game_plan_ctx = self._load_game_plan_context()
+        game_plan_ctx = await self._load_game_plan_context()
         return sector_ctx, earnings_ctx, peer_ctx, game_plan_ctx
 
     def build_earnings_context_for_watchlist(self, watchlist: list[str]) -> str | None:
@@ -110,31 +106,27 @@ class DaemonContextBuilder:
         # TODO: Implement using await self.components.state.get_sector_rotation_history()
         return None
 
-    def _load_game_plan_context(self) -> str | None:
-        """Load today's game plan and format as context string.
+    async def _load_game_plan_context(self) -> str | None:
+        """Load today's game plan from DB and format as context string.
 
         Returns:
             Formatted game plan context or None
         """
-        plan_dir = Path(self.components.config.game_plan.plan_dir).expanduser()
-        today = datetime.now(self.components.scheduler.timezone).date()
-        plan_file = plan_dir / f"{today}.json"
-
-        if not plan_file.exists():
-            return None
-
         try:
-            with plan_file.open() as f:
-                data = json.load(f)
-                plan = GamePlan.model_validate(data)
-
-            key_levels_str = ", ".join(f"{sym}: ${lvl:.2f}" for sym, lvl in plan.key_levels.items())
+            today = datetime.now(self.components.scheduler.timezone).date()
+            records = await self.components.state.get_game_plan_history(limit=1)
+            if not records:
+                return None
+            record = records[0]
+            if record.timestamp.date() != today:
+                return None
+            key_levels_str = ", ".join(f"{sym}: ${lvl:.2f}" for sym, lvl in record.key_levels.items())
             return (
-                f"Risk Stance: {plan.risk_stance}\n"
-                f"Priority Symbols: {', '.join(plan.priority_symbols)}\n"
-                f"Sector Focus: {', '.join(plan.sector_focus)}\n"
+                f"Risk Stance: {record.risk_stance}\n"
+                f"Priority Symbols: {', '.join(record.priority_symbols)}\n"
+                f"Sector Focus: {', '.join(record.sector_focus)}\n"
                 f"Key Levels: {key_levels_str}\n"
-                f"Reasoning: {plan.reasoning}"
+                f"Reasoning: {record.reasoning}"
             )
         except Exception as e:
             logger.opt(exception=True).warning(f"Failed to load game plan context: {e}")

--- a/src/daemon/tasks/analysis_tasks.py
+++ b/src/daemon/tasks/analysis_tasks.py
@@ -37,8 +37,6 @@ class GamePlanTask(TaskExecutor):
             timezone=self.components.scheduler.timezone,
         )
 
-        plan_path = agent.persist(plan, self.components.config.game_plan.plan_dir)
-
         from src.daemon.state.models import GamePlanRecord
 
         await self.components.state.record_game_plan(
@@ -59,7 +57,6 @@ class GamePlanTask(TaskExecutor):
         console.print(f"  Risk Stance: {plan.risk_stance}")
         console.print(f"  Priority: {', '.join(plan.priority_symbols)}")
         console.print(f"  Sectors: {', '.join(plan.sector_focus)}")
-        console.print(f"  Saved: {plan_path}")
 
     async def get_last_run(self) -> datetime | None:
         """Get last game plan timestamp."""

--- a/src/v1/tasks/implementations/game_plan.py
+++ b/src/v1/tasks/implementations/game_plan.py
@@ -74,8 +74,6 @@ class GamePlanTask(Task):
             timezone=self._scheduler.timezone,
         )
 
-        plan_path = self._agent.persist(plan, self._config.plan_dir)
-
         await self._state.record_game_plan(
             GamePlanRecord(
                 timestamp=plan.generated_at,
@@ -91,7 +89,7 @@ class GamePlanTask(Task):
         )
 
         duration = time.monotonic() - start
-        msg = f"{len(plan.priority_symbols)} priority symbols, stance={plan.risk_stance}, saved={plan_path}"
+        msg = f"{len(plan.priority_symbols)} priority symbols, stance={plan.risk_stance}"
         logger.info(f"Game plan complete: {msg}")
 
         return TaskResult(

--- a/tests/test_agents/test_game_plan.py
+++ b/tests/test_agents/test_game_plan.py
@@ -69,15 +69,6 @@ async def test_game_plan_agent_structured_output_error_propagates(test_container
         await agent.generate(["AAPL", "TSLA"])
 
 
-def test_game_plan_persist(test_container, sample_game_plan, tmp_path):
-    """Test game plan persistence."""
-    agent = test_container.game_plan_agent()
-    plan_path = agent.persist(sample_game_plan, str(tmp_path))
-
-    assert plan_path.exists()
-    assert plan_path.name == f"{sample_game_plan.date}.json"
-
-
 async def test_empty_watchlist_uses_defaults(test_container, mock_market_fetcher):
     """Test empty watchlist uses defaults."""
     agent = test_container.game_plan_agent()

--- a/tests/test_daemon/test_api.py
+++ b/tests/test_daemon/test_api.py
@@ -781,12 +781,12 @@ class TestGamePlanEndpoint:
         assert response.status_code == 200
         assert response.json() is None
 
-    def test_get_game_plan_missing_file(self, client: TestClient, mock_runner: Mock, tmp_path) -> None:
-        """Test game plan endpoint when file missing."""
+    def test_get_game_plan_no_history(self, client: TestClient, mock_runner: Mock) -> None:
+        """Test game plan endpoint when no history available."""
         from src.daemon.config import GamePlanConfig
         from src.daemon.state import GamePlanRecord
 
-        mock_runner.config.game_plan = GamePlanConfig(enabled=True, plan_dir=str(tmp_path))
+        mock_runner.config.game_plan = GamePlanConfig(enabled=True)
         mock_runner.state.game_plan_history = [
             GamePlanRecord(
                 timestamp=datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC),
@@ -800,32 +800,21 @@ class TestGamePlanEndpoint:
         assert response.status_code == 200
         assert response.json() is None
 
-    def test_get_game_plan_valid(self, client: TestClient, mock_runner: Mock, tmp_path) -> None:
-        """Test game plan endpoint with valid file."""
-        import json
-
+    def test_get_game_plan_valid(self, client: TestClient, mock_runner: Mock) -> None:
+        """Test game plan endpoint with valid DB record."""
         from src.daemon.config import GamePlanConfig
         from src.daemon.state import GamePlanRecord
 
-        plan_file = tmp_path / "2024-01-15.json"
-        plan_data = {
-            "date": "2024-01-15",
-            "priority_symbols": ["AAPL", "TSLA"],
-            "risk_stance": "BALANCED",
-            "sector_focus": ["tech"],
-            "reasoning": "Test reasoning",
-            "confidence": 0.85,
-            "generated_at": "2024-01-15T10:00:00+00:00",
-        }
-        plan_file.write_text(json.dumps(plan_data))
-
-        mock_runner.config.game_plan = GamePlanConfig(enabled=True, plan_dir=str(tmp_path))
+        mock_runner.config.game_plan = GamePlanConfig(enabled=True)
         mock_runner.state.game_plan_history = [
             GamePlanRecord(
                 timestamp=datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC),
                 priority_symbols=["AAPL", "TSLA"],
                 risk_stance="BALANCED",
                 sector_focus=["tech"],
+                reasoning="Test reasoning",
+                confidence=0.85,
+                generated_at=datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC),
             )
         ]
 


### PR DESCRIPTION
## Motivation

Game plans were being saved to JSON files on disk (`~/.ai-casino/game-plans/`) despite already being persisted to the database via `record_game_plan`. The file-based path was redundant and produced confusing `saved=` log entries.

## Implementation information

- Removed `GamePlanAgent.persist()` method and `json`/`Path` imports
- Removed `persist()` calls from `v1/tasks/implementations/game_plan.py` and `daemon/tasks/analysis_tasks.py`
- Changed `context_builder._load_game_plan_context()` to async, reading today's plan from DB via `state.get_game_plan_history(limit=1)`
- Made `build_analysis_contexts()` async, updated `analysis_orchestrator._build_extra_context()` to `await` it
- Removed `plan_dir` from `GamePlanConfig`, `docs/daemon.yaml.example`, and tests

> Changelog: refactor(game-plan): remove file-based persistence