### PR TITLE
feat(watchers): add watchlist pre-check in triage

### DIFF
--- a/src/v1/watchers/pipeline.py
+++ b/src/v1/watchers/pipeline.py
@@ -49,19 +49,22 @@ class EventTriagePipeline:
             events: Events to triage and route
         """
         triage_results = await self._triage_events(events)
+        active_symbols = await self._fetch_active_symbols()
         for event, triage in zip(events, triage_results, strict=True):
             if isinstance(triage, BaseException):
                 logger.error(f"Triage failed: {triage}")
                 continue
             if triage.urgency == Urgency.IMMEDIATE:
-                on_watchlist = await self._get_watchlist_symbols(triage.symbols)
+                on_watchlist = {s for s in triage.symbols if s in active_symbols}
                 if on_watchlist:
+                    sorted_watchlist = ", ".join(sorted(on_watchlist))
                     logger.info(
-                        f"Urgency escalation {on_watchlist}: WATCHLIST→IMMEDIATE for event {event.event_id}"
+                        f"Urgency escalation [{sorted_watchlist}]: "
+                        f"WATCHLIST→IMMEDIATE for event {event.event_id}"
                     )
                 await self._enqueue(event, triage)
             elif triage.urgency == Urgency.WATCHLIST:
-                on_watchlist = await self._get_watchlist_symbols(triage.symbols)
+                on_watchlist = {s for s in triage.symbols if s in active_symbols}
                 new_symbols = [s for s in triage.symbols if s not in on_watchlist]
                 if not new_symbols:
                     logger.debug(
@@ -121,15 +124,14 @@ class EventTriagePipeline:
             tasks = [tg.create_task(safe_triage(e)) for e in events]
         return [t.result() for t in tasks]
 
-    async def _get_watchlist_symbols(self, symbols: list[str]) -> set[str]:
-        """Return subset of symbols already in active discovery candidates."""
-        if not self._state or not symbols:
+    async def _fetch_active_symbols(self) -> set[str]:
+        """Fetch all active discovery symbols once per process cycle."""
+        if not self._state:
             return set()
         try:
-            active = await self._state.discovery.get_active_discovery_symbols()
-            return {s for s in symbols if s in active}
+            return set(await self._state.discovery.get_active_discovery_symbols())
         except Exception as e:
-            logger.opt(exception=True).warning(f"Failed to check watchlist symbols: {e}")
+            logger.opt(exception=True).warning(f"Failed to fetch active symbols: {e}")
             return set()
 
     async def _add_watchlist_candidates(self, event: BaseEvent, triage: TriageResult) -> None:


### PR DESCRIPTION
## Motivation

Every WATCHLIST-urgency event was added to discovery candidates regardless of whether the ticker was already being monitored, causing redundant DB writes and noise.

## Implementation information

Before processing a WATCHLIST event, `_get_watchlist_symbols()` checks active discovery candidates and filters out already-monitored symbols. If all symbols are already on the watchlist the event is skipped entirely. Partial overlap: only new symbols are written as candidates and enqueued.

IMMEDIATE events always pass through (urgency escalation). Added logging when an IMMEDIATE event's symbols were previously on the watchlist (`WATCHLIST→IMMEDIATE` escalation path).

> Changelog: feat(watchers): add watchlist pre-check in triage