### PR TITLE
fix(db): defer migrations to main event loop

### DIFF
--- a/src/di/providers/database.py
+++ b/src/di/providers/database.py
@@ -59,30 +59,11 @@ def create_database_engine(daemon_config: DaemonConfig) -> DatabaseEngine:
         f"recycle={pool_config.pool_recycle}s"
     )
 
-    # Run migrations on startup
-    import asyncio
+    # Migrations are deferred to lifecycle.startup() via ensure_migrated()
+    # to avoid running asyncio.run() here which would bind asyncpg pool
+    # connections to a temporary event loop, causing "Future attached to
+    # a different loop" errors in the main daemon event loop.
 
-    try:
-        asyncio.get_running_loop()
-        # If already in event loop, schedule migration
-
-        def _log_migration_result(t: asyncio.Task) -> None:
-            # Avoid calling t.exception() on cancelled tasks (raises CancelledError)
-            if t.cancelled():
-                logger.warning("DB migration task was cancelled before completion")
-                return
-            exc = t.exception()
-            if exc:
-                # Log full traceback for easier debugging
-                logger.opt(exception=exc).error("DB migration failed")
-
-        task = asyncio.create_task(engine.ensure_migrated())
-        task.add_done_callback(_log_migration_result)
-    except RuntimeError:
-        # No event loop yet, run in new loop
-        asyncio.run(engine.ensure_migrated())
-
-    logger.info("DatabaseEngine initialized and migrations applied")
     return engine
 
 


### PR DESCRIPTION
## Motivation

`create_database_engine()` called `asyncio.run(engine.ensure_migrated())` as a fallback when no event loop was running. This created a temporary event loop, bound asyncpg pool connections to it, then closed it. When the main daemon event loop started, the pool had stale connections causing:

```
RuntimeError: Event loop is closed
Session error: Task got Future attached to a different loop
```

Root cause chain: watcher creation → `container.market_event_queue()` → `container.database_engine()` → `create_database_engine()` → `asyncio.run(ensure_migrated())` before `asyncio.run(runner.run())`.

## Implementation information

Remove migration logic from `create_database_engine()` entirely. `lifecycle._initialize_database()` already calls `await database_engine.ensure_migrated()` in the main event loop after `asyncio.run()` starts — this is the correct place for migrations.

> Changelog: fix(db): defer migrations to main event loop